### PR TITLE
add task_id and some messages to view task queues

### DIFF
--- a/rmf_fleet_msgs/msg/DestinationRequest.msg
+++ b/rmf_fleet_msgs/msg/DestinationRequest.msg
@@ -1,3 +1,6 @@
 string fleet_name
 string robot_name
 Location destination
+
+# task_id must be copied into future RobotState messages
+string task_id

--- a/rmf_fleet_msgs/msg/ModeRequest.msg
+++ b/rmf_fleet_msgs/msg/ModeRequest.msg
@@ -1,3 +1,6 @@
 string fleet_name
 string robot_name
 RobotMode mode
+
+# task_id must be copied into future RobotState messages
+string task_id

--- a/rmf_fleet_msgs/msg/PathRequest.msg
+++ b/rmf_fleet_msgs/msg/PathRequest.msg
@@ -1,3 +1,6 @@
 string fleet_name
 string robot_name
 Location[] path
+
+# task_id must be copied into future RobotState messages
+string task_id

--- a/rmf_fleet_msgs/msg/RobotState.msg
+++ b/rmf_fleet_msgs/msg/RobotState.msg
@@ -1,5 +1,10 @@
 string name
 string model
+
+# task_id is copied in from the most recent Request message,
+# such as ModeRequest, DestinationRequest, or PathRequest
+string task_id
+
 RobotMode mode
 float32 battery_percent
 Location location

--- a/rmf_task_msgs/CMakeLists.txt
+++ b/rmf_task_msgs/CMakeLists.txt
@@ -21,6 +21,8 @@ set(msg_files
   "msg/Behavior.msg"
   "msg/BehaviorParameter.msg"
   "msg/Station.msg"
+  "msg/TaskSummary.msg"
+  "msg/Tasks.msg"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/rmf_task_msgs/msg/Delivery.msg
+++ b/rmf_task_msgs/msg/Delivery.msg
@@ -1,3 +1,8 @@
+# task_id is intended to be a pseudo-random string generated
+# by the caller which can be used to identify this task as it
+# moves between the queues to completion (or failure).
+string task_id
+
 string object_name
 string pickup_place_name
 Behavior pickup_behavior

--- a/rmf_task_msgs/msg/Station.msg
+++ b/rmf_task_msgs/msg/Station.msg
@@ -1,2 +1,11 @@
+# task_id is intended to be a pseudo-random string generated
+# by the caller which can be used to identify this task as it
+# moves between the queues to completion (or failure).
+string task_id
+
+# robot_type can be used to specify a particular robot fleet
+# for this request
 string robot_type
+
+# the place name where the robot is requested to station (park)
 string place_name

--- a/rmf_task_msgs/msg/TaskSummary.msg
+++ b/rmf_task_msgs/msg/TaskSummary.msg
@@ -1,0 +1,8 @@
+string task_id
+
+# a brief summary of the current status of the task
+string status
+
+builtin_interfaces/Time submission_time
+builtin_interfaces/Time start_time
+builtin_interfaces/Time end_time

--- a/rmf_task_msgs/msg/TaskSummary.msg
+++ b/rmf_task_msgs/msg/TaskSummary.msg
@@ -3,6 +3,12 @@ string task_id
 # a brief summary of the current status of the task
 string status
 
+# submission_time is when the task was submitted to rmf_core
 builtin_interfaces/Time submission_time
+
 builtin_interfaces/Time start_time
+
+# When this message is a summary of an in-process task, the end_time field is
+# an estimate. When this message is a summary of a completed or failed task,
+# end_time is the actual time.
 builtin_interfaces/Time end_time

--- a/rmf_task_msgs/msg/Tasks.msg
+++ b/rmf_task_msgs/msg/Tasks.msg
@@ -1,0 +1,4 @@
+TaskSummary[] queued_tasks
+TaskSummary[] active_tasks
+TaskSummary[] completed_tasks
+TaskSummary[] failed_tasks


### PR DESCRIPTION
Strawman implementation for discussion of #33 to add `task_id` to inbound task requests, and an outbound message called `Tasks` to periodically publish the states of queued, active, recently-completed, and recently-failed tasks.