### PR TITLE
Change target_guid to dispenser_name

### DIFF
--- a/rmf_dispenser_msgs/msg/DispenserRequest.msg
+++ b/rmf_dispenser_msgs/msg/DispenserRequest.msg
@@ -1,6 +1,6 @@
 builtin_interfaces/Time time
 string request_guid
-string target_guid
+string dispenser_name
 
 # below are custom workcell message fields
 string transporter_type


### PR DESCRIPTION
I'm not sure what `target_guid` was intended to mean, so I've changed the field name to `dispenser_name`, since that's my best guess at what it was intended to mean.