### PR TITLE
Make sure mirrors are woken up for all schedule modifications

### DIFF
--- a/rmf_traffic_msgs/srv/ReplaceTrajectories.srv
+++ b/rmf_traffic_msgs/srv/ReplaceTrajectories.srv
@@ -8,4 +8,10 @@ uint64 current_version
 
 uint64 original_version
 
+# All the IDs greater than original_version and less than or equal to this
+# latest_trajectory_version will represent active trajectory IDs. Everything
+# greater than latest_trajectory_version and less than or equal to
+# current_version will represent erasure IDs.
+uint64 latest_trajectory_version
+
 string error


### PR DESCRIPTION
I forgot to have all the different kinds of schedule changes trigger a mirror wakeup, which was causing mirrors to be out of sync for any changes besides brand new trajectory submissions.

I'm also sneaking in a slight change to the trajectory replacement API.