### PR TITLE
New planning start features

### DIFF
--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -539,6 +539,28 @@ rmf_utils::optional<Plan> Plan::replan(
 }
 
 //==============================================================================
+rmf_utils::optional<Plan> Plan::replan(const StartSet& new_starts) const
+{
+  return Plan::Implementation::generate(
+        _pimpl->cache_mgr,
+        new_starts,
+        _pimpl->result.goal,
+        _pimpl->result.options);
+}
+
+//==============================================================================
+rmf_utils::optional<Plan> Plan::replan(
+    const StartSet& new_starts,
+    Options new_options) const
+{
+  return Plan::Implementation::generate(
+        _pimpl->cache_mgr,
+        new_starts,
+        _pimpl->result.goal,
+        std::move(new_options));
+}
+
+//==============================================================================
 const Planner::Start& Plan::get_start() const
 {
   return _pimpl->result.start;

--- a/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
@@ -32,7 +32,7 @@ public:
 
   rmf_traffic::Time time;
 
-  std::size_t graph_index;
+  rmf_utils::optional<std::size_t> graph_index;
 
   Graph::Lane::EventPtr event;
 

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
@@ -208,12 +208,15 @@ std::vector<agv::Plan::Waypoint> reconstruct_waypoints(
   for (auto it = node_sequence.rbegin(); it != node_sequence.rend(); ++it)
   {
     const auto& n = *it;
-    const Eigen::Vector2d p = graph.waypoints[*n->waypoint].get_location();
+    const Eigen::Vector2d p = n->waypoint?
+          graph.waypoints[*n->waypoint].get_location() :
+          n->trajectory_from_parent.back().get_finish_position()
+            .template block<2,1>(0,0);
     const Time time{*n->trajectory_from_parent.finish_time()};
     waypoints.emplace_back(
           agv::Plan::Waypoint::Implementation::make(
             Eigen::Vector3d{p[0], p[1], n->orientation}, time,
-            *n->waypoint, n->event));
+            n->waypoint, n->event));
   }
 
   return waypoints;

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
@@ -33,7 +33,6 @@ using CachePtr = std::shared_ptr<Cache>;
 //==============================================================================
 struct Result
 {
-  bool solved = false;
   std::vector<Trajectory> trajectories;
   std::vector<agv::Plan::Waypoint> waypoints;
 
@@ -62,8 +61,8 @@ public:
 
   virtual void update(const Cache& other) = 0;
 
-  virtual Result plan(
-      agv::Planner::Start start,
+  virtual rmf_utils::optional<Result> plan(
+      const std::vector<agv::Planner::Start>& starts,
       agv::Planner::Goal goal,
       agv::Planner::Options options) = 0;
 
@@ -85,8 +84,8 @@ public:
   // Moving it is okay
   CacheHandle(CacheHandle&&) = default;
 
-  Result plan(
-      agv::Planner::Start start,
+  rmf_utils::optional<Result> plan(
+      const std::vector<agv::Planner::Start>& starts,
       agv::Planner::Goal goal,
       agv::Planner::Options options);
 

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1859,6 +1859,31 @@ SCENARIO("Test planner with various start conditions")
         == Approx(0.0).margin(1e-6));
     CHECK((t.front().get_finish_position()[2] - 0.0) == Approx(0.0));
 
+    WHEN("Obstace 4->0 overlaps")
+    {
+      std::vector<rmf_traffic::Trajectory> obstacles;
+      rmf_traffic::Trajectory obstacle(test_map_name);
+      obstacle.insert(
+        initial_time,
+        make_test_profile(UnitCircle),
+        Eigen::Vector3d{0, 0, 0},
+        Eigen::Vector3d{0, 0, 0});
+
+      obstacle.insert(
+        initial_time + 60s,
+        make_test_profile(UnitCircle),
+        Eigen::Vector3d{0, 0, 0},
+        Eigen::Vector3d{0, 0, 0});
+
+      REQUIRE(DetectConflict::between(obstacle, t).size() != 0);
+      obstacles.push_back(obstacle);
+
+      // TODO change to replan with startset
+      test_with_obstacle(
+          "Obstace 4->0 overlaps",
+          *plan, database, obstacles, 1, initial_time, true);
+    }
+
   }
   
 

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -345,6 +345,23 @@ SCENARIO("Test Start")
   CHECK(start.lane());
 }
 
+SCENARIO("Test Goal")
+{
+  using Planner = rmf_traffic::agv::Planner;
+  Planner::Goal goal{1};
+  CHECK(goal.orientation() == nullptr);
+  CHECK(goal.waypoint() == 1);
+  goal.waypoint(2);
+  CHECK(goal.waypoint() == 2);
+
+  goal.orientation(M_PI_2);
+  CHECK((*goal.orientation() - M_PI_2) == Approx(0.0));
+
+  goal = Planner::Goal{3, 0.0};
+  CHECK(goal.waypoint() ==3);
+  CHECK((*goal.orientation() - 0.0) == Approx(0.0));
+}
+
 SCENARIO("Test planning")
 {
   using namespace std::chrono_literals;

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -171,7 +171,7 @@ rmf_traffic::Trajectory test_with_obstacle(
     bool used_holding_point = false;
     for (const auto& wp : plan->get_waypoints())
     {
-      if (wp.graph_index() == hold_index)
+      if (*wp.graph_index() == hold_index)
       {
         used_holding_point = true;
         break;
@@ -1549,4 +1549,7 @@ SCENARIO("Graph with door", "[door]")
   CHECK(has_event(ExpectEvent::DoorOpen, *plan_with_door_open_close));
   CHECK(has_event(ExpectEvent::DoorClose, *plan_with_door_open_close));
 }
+
+
+// TODO(MXG): Make a test for the interrupt_flag in Planner::Options
 

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1843,6 +1843,11 @@ SCENARIO("Test planner with various start conditions")
     const auto plan = planner.plan(start, goal);
     CHECK_PLAN(plan, {-2.5, 0}, 0.0, {5.0, 0}, {1, 2, 3});
 
+    WHEN("Testign replan")
+    {
+      auto plan2 = plan->replan(start);
+    }
+
     WHEN("Obstace 4->0 overlaps")
     {
       std::vector<rmf_traffic::Trajectory> obstacles;

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1811,13 +1811,14 @@ SCENARIO("Test planner with various start conditions")
         == Approx(0.0).margin(1e-6));
     const auto& waypoints = plan->get_waypoints();
       REQUIRE(waypoints.size() == 3);
-
-    auto it = std::find(waypoints.begin(), waypoints.end(), 1);
-    CHECK(it != waypoints.end());
-    auto it = std::find(waypoints.begin(), waypoints.end(), 2);
-    CHECK(it != waypoints.end());
-    auto it = std::find(waypoints.begin(), waypoints.end(), 3);
-    CHECK(it != waypoints.end());
+    int wp_count = 0;
+    for (const auto& wp : waypoints)
+        if (
+            *wp.graph_index() == 1
+            || *wp.graph_index() == 2
+            || *wp.graph_index() == 3)
+          ++wp_count;
+    REQUIRE(wp_count == 3);
 
     WHEN("Obstace 4->0 overlaps")
     {
@@ -1850,12 +1851,14 @@ SCENARIO("Test planner with various start conditions")
           == Approx(0.0).margin(1e-6));
       const auto& waypoints = plan->get_waypoints();
       REQUIRE(waypoints.size() == 3);
-      auto it = std::find(waypoints.begin(), waypoints.end(), 1);
-      CHECK(it != waypoints.end());
-      auto it = std::find(waypoints.begin(), waypoints.end(), 2);
-      CHECK(it != waypoints.end());
-      auto it = std::find(waypoints.begin(), waypoints.end(), 3);
-      CHECK(it != waypoints.end());
+      wp_count = 0;
+      for (const auto& wp : waypoints)
+          if (
+              *wp.graph_index() == 1
+              || *wp.graph_index() == 2
+              || *wp.graph_index() == 3)
+            ++wp_count;
+      REQUIRE(wp_count == 3);
     }
   }
 
@@ -1888,12 +1891,14 @@ SCENARIO("Test planner with various start conditions")
         == Approx(0.0).margin(1e-6));
     const auto& waypoints = plan->get_waypoints();
     REQUIRE(waypoints.size() == 3);
-    auto it = std::find(waypoints.begin(), waypoints.end(), 1);
-    CHECK(it != waypoints.end());
-    auto it = std::find(waypoints.begin(), waypoints.end(), 2);
-    CHECK(it != waypoints.end());
-    auto it = std::find(waypoints.begin(), waypoints.end(), 3);
-    CHECK(it != waypoints.end());
+    int wp_count = 0;
+    for (const auto& wp : waypoints)
+        if (
+            *wp.graph_index() == 1
+            || *wp.graph_index() == 2
+            || *wp.graph_index() == 3)
+          ++wp_count;
+    REQUIRE(wp_count == 3);
   }
 
   WHEN("Planning with startset of waypoint index and orientations")
@@ -1920,9 +1925,19 @@ SCENARIO("Test planner with various start conditions")
 
     WHEN("Testing replan with startsets")
     {
-      plan = plan->replan(starts);
 
+      /*
+      CMAKE ERROR when invoking plan.replan(starts)
+  
+      MakeFiles/test_rmf_traffic.dir/test/unit/agv/test_Planner.cpp.o:
+      In function `____C_A_T_C_H____T_E_S_T____61()': test_Planner
+      undefined reference to `rmf_traffic::agv::Plan::replan(
+      std::vector<rmf_traffic::agv::Planner::Start, 
+      std::allocator<rmf_traffic::agv::Planner::Start> > const&) const'
+      collect2: error: ld returned 1 exit status
+      */ 
 
+      //auto plan2 = plan->replan(starts);
     }
     WHEN("Obstace 4->0 overlaps")
     {
@@ -1946,17 +1961,6 @@ SCENARIO("Test planner with various start conditions")
       for(auto& obstacle : obstacles)
         database.insert(obstacle);
 
-      /*
-      CMAKE ERROR when invoking plan.replan(starts)
-  
-      MakeFiles/test_rmf_traffic.dir/test/unit/agv/test_Planner.cpp.o:
-      In function `____C_A_T_C_H____T_E_S_T____61()': test_Planner
-      undefined reference to `rmf_traffic::agv::Plan::replan(
-      std::vector<rmf_traffic::agv::Planner::Start, 
-      std::allocator<rmf_traffic::agv::Planner::Start> > const&) const'
-      collect2: error: ld returned 1 exit status
-      */ 
-
       plan = planner.plan(starts, goal);
       REQUIRE(plan);
       REQUIRE(plan->get_trajectories().size() > 0);
@@ -1973,5 +1977,3 @@ SCENARIO("Test planner with various start conditions")
     }
   }
 }
-
-// TODO(MXG): Make a test for the interrupt_flag in Planner::Options

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -234,7 +234,7 @@ SCENARIO("Test Configuration", "[config]")
               == Approx(0).margin(1e-6));
   }
 
-  WHEN("Set the graph in config")
+  WHEN("Set the graph")
   {
     Graph& graph_ = config.graph();
     graph_.add_waypoint(test_map_name, {5, 5});
@@ -244,13 +244,13 @@ SCENARIO("Test Configuration", "[config]")
         - Eigen::Vector2d{5, 5}).norm() == Approx(0).margin(1e-6));
   }
 
-  WHEN("Get the vechile_traits in config")
+  WHEN("Get the vechile_traits")
   {
     VehicleTraits& traits_ = config.vehicle_traits();
     CHECK_TRAITS(traits_, traits);
   }
 
-  WHEN("Set the vechile_traits in config")
+  WHEN("Set the vechile_traits")
   {
     VehicleTraits& traits_ = config.vehicle_traits();
     VehicleTraits traits_new(
@@ -259,13 +259,13 @@ SCENARIO("Test Configuration", "[config]")
     CHECK_TRAITS(config.vehicle_traits(), traits_);
   }
 
-  WHEN("Get the interpolation in config")
+  WHEN("Get the interpolation")
   {
     Interpolate::Options& options_ = config.interpolation();
     CHECK_INTERPOLATION(options_, options);
   }
 
-  WHEN("Set the interpolation in config")
+  WHEN("Set the interpolation")
   {
     Interpolate::Options& options_ = config.interpolation();
     options_ = Interpolate::Options(
@@ -273,6 +273,49 @@ SCENARIO("Test Configuration", "[config]")
     CHECK_INTERPOLATION(config.interpolation(), options_);
   }
 }
+
+SCENARIO("Test Options", "[options]")
+{
+  using namespace std::chrono_literals;
+  using Planner = rmf_traffic::agv::Planner;
+  using Duration = std::chrono::nanoseconds;
+  using Database = rmf_traffic::schedule::Database;
+
+  Database database; 
+  bool interrupt_flag = false;
+  Duration hold_time = std::chrono::seconds(6);
+
+  Planner::Options default_options(database, hold_time, &interrupt_flag);
+  WHEN("Get the minimum_holding_time")
+  {
+    CHECK(rmf_traffic::time::to_seconds(
+        default_options.minimum_holding_time()- hold_time)
+            == Approx(0).margin(1e-6));
+  }
+
+  WHEN("Set the minimum_holding_time")
+  {
+    Duration hold_time_ = std::chrono::seconds(5);  
+    default_options.minimum_holding_time(hold_time_);
+    CHECK(rmf_traffic::time::to_seconds(
+        default_options.minimum_holding_time()- hold_time_)
+            == Approx(0).margin(1e-6));   
+  }
+
+  WHEN("Get the interrupt_flag")
+  {
+    CHECK_FALSE(*default_options.interrupt_flag());
+  }
+
+  WHEN("Set the interrupt_flag")
+  {
+    interrupt_flag = true;
+    CHECK(*default_options.interrupt_flag());
+  }
+
+}
+
+
 
 /*
 graph.add_waypoint(test_map_name, {-5, 0}); // 1

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -165,6 +165,31 @@ rmf_traffic::Trajectory test_with_obstacle(
   return t_obs;
 }
 
+SCENARIO("Test config, options and planner", "[setup]")
+{
+  using namespace std::chrono_literals;
+  using Graph = rmf_traffic::agv::Graph;
+  using Planner = rmf_traffic::agv::Planner;
+
+  const std::string test_map_name = "test_map";
+  Graph graph;
+  graph.add_waypoint(test_map_name, {0, -5}); // 0
+  graph.add_waypoint(test_map_name, {-5, 0}); // 1
+  graph.add_waypoint(test_map_name, {0, 0}); // 2
+  graph.add_waypoint(test_map_name, {5, 0}); // 3
+  graph.add_waypoint(test_map_name, {0, 5}); // 4
+  REQUIRE(graph.num_waypoints()==5);
+
+  const rmf_traffic::agv::VehicleTraits traits(
+      {0.7, 0.3}, {1.0, 0.45}, make_test_profile(UnitCircle));
+  
+  Planner::Configuration config(graph, traits);
+  
+
+  Planner planner(config, options);
+
+}
+
 SCENARIO("Test planning")
 {
   using namespace std::chrono_literals;

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -933,9 +933,6 @@ SCENARIO("Test planning")
   }
 }
 
-
-
-
 SCENARIO("DP1 Graph")
 {
   using namespace std::chrono_literals;
@@ -1803,25 +1800,31 @@ SCENARIO("Test planner with various start conditions")
 
     // throws bad optional access error
     const auto plan = planner.plan(start, goal);
-    CHECK(plan);
+    REQUIRE(plan);
     REQUIRE(plan->get_trajectories().size() == 1);
     auto t = plan->get_trajectories().front();
+
+    CHECK((t.front().get_finish_position().block<2,1>(0,0)
+        - Eigen::Vector2d{-2.5, 0}).norm() == Approx(0.0).margin(1e-6));
+    CHECK((graph.get_waypoint(3).get_location()
+        - t.back().get_finish_position().block<2,1>(0, 0)).norm()
+        == Approx(0.0).margin(1e-6));
 
     WHEN("Obstace 4->0 overlaps")
     {
       std::vector<rmf_traffic::Trajectory> obstacles;
       rmf_traffic::Trajectory obstacle(test_map_name);
       obstacle.insert(
-        initial_time,
-        make_test_profile(UnitCircle),
-        Eigen::Vector3d{0, 0, 0},
-        Eigen::Vector3d{0, 0, 0});
+          initial_time,
+          make_test_profile(UnitCircle),
+          Eigen::Vector3d{0, 0, 0},
+          Eigen::Vector3d{0, 0, 0});
 
       obstacle.insert(
-        initial_time + 60s,
-        make_test_profile(UnitCircle),
-        Eigen::Vector3d{0, 0, 0},
-        Eigen::Vector3d{0, 0, 0});
+          initial_time + 60s,
+          make_test_profile(UnitCircle),
+          Eigen::Vector3d{0, 0, 0},
+          Eigen::Vector3d{0, 0, 0});
 
       REQUIRE(DetectConflict::between(obstacle, t).size() != 0);
       obstacles.push_back(obstacle);
@@ -1830,6 +1833,12 @@ SCENARIO("Test planner with various start conditions")
           "Obstace 4->0 overlaps",
           *plan, database, obstacles, 1, initial_time, true);
 
+      t = plan->get_trajectories().front();    
+      CHECK((t.front().get_finish_position().block<2,1>(0,0)
+          - Eigen::Vector2d{-2.5, 0}).norm() == Approx(0.0).margin(1e-6));
+      CHECK((graph.get_waypoint(3).get_location()
+          - t.back().get_finish_position().block<2,1>(0, 0)).norm()
+          == Approx(0.0).margin(1e-6));
     }
   }
 
@@ -1852,12 +1861,11 @@ SCENARIO("Test planner with various start conditions")
 
     // throws bad optional access error
     const auto plan = planner.plan(start, goal);
-    CHECK(plan);
+    REQUIRE(plan);
   }
 
   WHEN("Planning with startset of waypoint index and orientations")
   {
-
     std::vector<Planner::Start> starts;
     Planner::Start start1{initial_time, 1, 0.0};
     Planner::Start start2{initial_time, 1, M_PI_2};
@@ -1867,7 +1875,7 @@ SCENARIO("Test planner with various start conditions")
     Planner::Goal goal{3, 0.0};
 
     auto plan = planner.plan(starts, goal);
-    CHECK(plan);
+    REQUIRE(plan);
     REQUIRE(plan->get_trajectories().size() > 0);
     const auto t = plan->get_trajectories().front();
 
@@ -1882,16 +1890,16 @@ SCENARIO("Test planner with various start conditions")
       std::vector<rmf_traffic::Trajectory> obstacles;
       rmf_traffic::Trajectory obstacle(test_map_name);
       obstacle.insert(
-        initial_time,
-        make_test_profile(UnitCircle),
-        Eigen::Vector3d{0, 0, 0},
-        Eigen::Vector3d{0, 0, 0});
+          initial_time,
+          make_test_profile(UnitCircle),
+          Eigen::Vector3d{0, 0, 0},
+          Eigen::Vector3d{0, 0, 0});
 
       obstacle.insert(
-        initial_time + 60s,
-        make_test_profile(UnitCircle),
-        Eigen::Vector3d{0, 0, 0},
-        Eigen::Vector3d{0, 0, 0});
+          initial_time + 60s,
+          make_test_profile(UnitCircle),
+          Eigen::Vector3d{0, 0, 0},
+          Eigen::Vector3d{0, 0, 0});
 
       REQUIRE(DetectConflict::between(obstacle, t).size() != 0);
       obstacles.push_back(obstacle);
@@ -1901,12 +1909,7 @@ SCENARIO("Test planner with various start conditions")
           "Obstace 4->0 overlaps",
           *plan, database, obstacles, 1, initial_time, true);
     }
-
   }
-  
-
- 
 }
 
 // TODO(MXG): Make a test for the interrupt_flag in Planner::Options
-

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1529,7 +1529,7 @@ SCENARIO("DP1 Graph")
 
           test_with_obstacle(
                 "Obstacle 28->2 , 29->4, 23->26",
-                *plan, database, obstacles, 27, time, true, true, true);
+                *plan, database, obstacles, 27, time);
         }
       }
     }
@@ -1695,7 +1695,7 @@ SCENARIO("Graph with door", "[door]")
   CHECK(has_event(ExpectEvent::DoorClose, *plan_with_door_open_close));
 }
 
-SCENARIO("Test planner with start")
+SCENARIO("Test planner with various start conditions")
 {
   using namespace std::chrono_literals;
   using rmf_traffic::agv::Graph;
@@ -1754,6 +1754,7 @@ SCENARIO("Test planner with start")
         1,
         0.0,
         initial_location};
+
     CHECK(start.location());
     CHECK_FALSE(start.lane());
 
@@ -1776,28 +1777,36 @@ SCENARIO("Test planner with start")
       REQUIRE(DetectConflict::between(obstacle, t).size() != 0);
       obstacles.push_back(obstacle);
 
+      test_with_obstacle(
+          "Obstace 4->0 overlaps",
+          *plan, database, obstacles, 1, initial_time, true);
+
     }
   }
 
   WHEN("Start contains initial_location and initial_lane")
   { 
     rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-2.5, 0};
-    rmf_utils::optional<std::size_t> initial_lane = std::size_t(3);
+    rmf_utils::optional<std::size_t> initial_lane = std::size_t{3};
   
-    Planner::Start start(
+    Planner::Start start{
         initial_time,
         1,
         0.0,
         initial_location,
-        initial_lane);
+        initial_lane};
 
-    REQUIRE(start.location());
-    REQUIRE(start.lane());
+    CHECK(start.location());
+    CHECK(start.lane());
 
-    Planner::Goal goal(3);
+    Planner::Goal goal{3};
 
-    //const auto plan = planner.plan(start, goal);
-    //CHECK(plan);
+    const auto plan = planner.plan(start, goal);
+    CHECK(plan);
+  }
+
+  WHEN("Planning with startset of waypoint index and orientations")
+  {
 
   }
   

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -46,56 +46,64 @@ void print_timing(const std::chrono::steady_clock::time_point& start_time)
 
 void display_path(rmf_traffic::Trajectory t, rmf_traffic::agv::Graph graph)
 {
-  //this is a very bad algorithm but will be improved
+  // this is a very bad algorithm but will be improved
   const auto start_time = std::chrono::steady_clock::now();
-
   std::vector<Eigen::Vector2d> graph_locations;
   std::vector<int> path;
-  for(std::size_t i=0;i<graph.num_waypoints();i++)
+
+  for (std::size_t i=0; i<graph.num_waypoints(); i++)
     graph_locations.push_back(graph.get_waypoint(i).get_location());
 
-  for(auto it=t.begin();it!=t.end();it++)
+  for (auto it = t.begin(); it != t.end(); it++)
   {
-   auto it2 = std::find(graph_locations.begin(), graph_locations.end(),it->get_finish_position().block<2,1>(0,0));
-   if(it2!=graph_locations.end())
-     {
-       int waypoint_index=std::distance(graph_locations.begin(),it2);
-       if(path.empty())
-        path.push_back(waypoint_index);
-       else if(path.back()!=waypoint_index)
+    auto it2 = std::find(
+        graph_locations.begin(),
+        graph_locations.end(),
+        it->get_finish_position().block<2,1>(0,0));
+    if (it2! = graph_locations.end())
+      {
+        int waypoint_index=std::distance(graph_locations.begin(), it2);
+        if (path.empty())
           path.push_back(waypoint_index);
-
-     }
-
+        else if (path.back() != waypoint_index)
+          path.push_back(waypoint_index);
+      }
   }
-
-    
   const auto end_time = std::chrono::steady_clock::now();
-  std::cout<<"Display Path computed in: "<<std::setprecision(4)<<rmf_traffic::time::to_seconds(end_time-start_time)<<"s\n";
-
-  for(auto it=path.begin();it!=path.end();it++)
+  std::cout<<"Display Path computed in: "
+      <<std::setprecision(4)
+      <<rmf_traffic::time::to_seconds(end_time - start_time)
+      <<"s\n";
+  for (auto it = path.begin(); it != path.end(); it++)
   {
     std::cout<<*it;
     if(it!=--path.end())
       std::cout<<"->";
   }
   std::cout<<std::endl;
-
 }
 
-void print_trajectory_info(const rmf_traffic::Trajectory t,rmf_traffic::Time time,rmf_traffic::agv::Graph graph)
+void print_trajectory_info(
+    const rmf_traffic::Trajectory t,
+    rmf_traffic::Time time,
+    rmf_traffic::agv::Graph graph)
 {
-  int count =1;
-  std::cout<<"Trajectory in: "<<t.get_map_name()<<" with "<<t.size()<<" segments\n";
-  display_path(t,graph);
-  for(auto it=t.begin();it!=t.end();it++)
+  int count = 1;
+  std::cout<<"Trajectory in: "
+      <<t.get_map_name()
+      <<" with "<<t.size()
+      <<" segments\n";
+  display_path(t, graph);
+  for (auto it = t.begin(); it != t.end(); it++)
     {
       auto position=it->get_finish_position();
-      std::cout<<"Segment "<<count<<": {"<<position[0]<<","<<position[1]<<","<<position[2]<<"} "<<rmf_traffic::time::to_seconds(it->get_finish_time()-time)<<"s"<<std::endl;
+      std::cout<<"Segment "<<count<<": {"<<position[0]<<","<<position[1]
+          <<","<<position[2]<<"} "
+          <<rmf_traffic::time::to_seconds(it->get_finish_time() - time)<<"s"
+          <<std::endl;
       count++;
     }
   std::cout<<"__________________\n";
-
 }
 
 rmf_traffic::Trajectory test_with_obstacle(
@@ -111,19 +119,19 @@ rmf_traffic::Trajectory test_with_obstacle(
 {
   rmf_traffic::Trajectory t_obs{""};
 
-  for(const auto& obstacle : obstacles)
+  for (const auto& obstacle : obstacles)
     database.insert(obstacle);
 
   rmf_utils::optional<rmf_traffic::agv::Plan> plan;
   const auto start_time = std::chrono::steady_clock::now();
-  for(std::size_t i=0; i < N; ++i)
+  for (std::size_t i = 0; i < N; ++i)
   {
     plan = original_plan.replan(original_plan.get_start());
     REQUIRE(plan);
   }
 
   const auto end_time = std::chrono::steady_clock::now();
-  if(test_performance)
+  if (test_performance)
   {
     const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
     std::cout << "\n" << parent << " w/ obstacle" << std::endl;
@@ -188,9 +196,6 @@ rmf_traffic::Trajectory test_with_obstacle(
   }
   return t_obs;
 }
-
-
-
 
 SCENARIO("Test planning")
 {

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -29,8 +29,8 @@
 #include <iomanip>
 
 // TODO(MXG): Move performance testing content into a performance test folder
-//const bool test_performance = false;
-const bool test_performance = true;
+const bool test_performance = false;
+// const bool test_performance = true;
 const std::size_t N = test_performance? 10 : 1;
 
 void print_timing(const std::chrono::steady_clock::time_point& start_time)
@@ -60,7 +60,7 @@ void display_path(rmf_traffic::Trajectory t, rmf_traffic::agv::Graph graph)
         graph_locations.begin(),
         graph_locations.end(),
         it->get_finish_position().block<2,1>(0,0));
-    if (it2! = graph_locations.end())
+    if (it2 != graph_locations.end())
       {
         int waypoint_index=std::distance(graph_locations.begin(), it2);
         if (path.empty())
@@ -248,21 +248,13 @@ SCENARIO("Test planning")
 
   //TODO abort planning that is impossible as lane does not exit in the graph
 
-  /*WHEN("goal waypoint does not have a lane in the graph")
-  {
-
-    const rmf_traffic::Time time = std::chrono::steady_clock::now();
-    const rmf_traffic::agv::VehicleTraits traits(
-        {0.7, 0.3}, {1.0, 0.45}, make_test_profile(UnitCircle));
-    rmf_traffic::schedule::Database database;
-    rmf_traffic::agv::Planner::Options options(traits, graph, database);
-    std::vector<rmf_traffic::Trajectory> solution;
-    
-    bool solved=rmf_traffic::agv::Planner::solve(time,3,0.0,9,nullptr,options,solution);
-    CHECK_FALSE(solved);
-    CHECK(solution.size()==0);
-
-  } */
+  // WHEN("goal waypoint does not have a lane in the graph")
+  // {
+  //   const rmf_traffic::Time start_time = std::chrono::steady_clock::now();
+  //   auto plan = planner.plan(
+  //       rmf_traffic::agv::Planner::Start(start_time, 3, 0.0),
+  //       rmf_traffic::agv::Planner::Goal(9));
+  // } 
 
   WHEN("initial conditions satisfy the goals")
   {

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1851,8 +1851,8 @@ SCENARIO("Test planner with various start conditions")
         initial_time,
         1,
         0.0,
-        initial_location,
-        initial_lane};
+        std::move(initial_location),
+        std::move(initial_lane)};
 
     CHECK(start.location());
     CHECK(start.lane());

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1754,19 +1754,19 @@ SCENARIO("Test planner with various start conditions")
 
   graph.add_lane(0 ,2); // 0
   graph.add_lane(2, 0); // 1
-  graph.add_lane(1, 2); // 2
-  graph.add_lane(2, 1); // 3
-  graph.add_lane(3, 2); // 4
-  graph.add_lane(2, 3); // 5
-  graph.add_lane(4, 2); // 6
-  graph.add_lane(2, 4); // 7
+  // added within tests for testing with orientation constraints
+  // graph.add_lane(1, 2); 
+  // graph.add_lane(2, 1); 
+  graph.add_lane(3, 2); // 2
+  graph.add_lane(2, 3); // 3
+  graph.add_lane(4, 2); // 4
+  graph.add_lane(2, 4); // 5
 
   const VehicleTraits traits{
       {1.0, 0.4},
       {1.0, 0.5},
       make_test_profile(UnitCircle)
   };
-
 
   rmf_traffic::schedule::Database database;
   bool interrupt_flag = false;
@@ -1785,6 +1785,9 @@ SCENARIO("Test planner with various start conditions")
 
   WHEN("Start contains initial_location")
   { 
+    graph.add_lane(1, 2); // 6
+    graph.add_lane(2, 1); // 7
+
     rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-2.5, 0};
 
     Planner::Start start = Planner::Start{
@@ -1862,10 +1865,13 @@ SCENARIO("Test planner with various start conditions")
     }
   }
 
-  WHEN("Start contains initial_location and initial_lane")
+  WHEN("Start contains initial_location and initial_lane without constraints")
   { 
+    graph.add_lane(1, 2); // 6
+    graph.add_lane(2, 1); // 7
+
     rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-2.5, 0};
-    rmf_utils::optional<std::size_t> initial_lane = std::size_t{3};
+    rmf_utils::optional<std::size_t> initial_lane = std::size_t{7};
   
     Planner::Start start{
         initial_time,
@@ -1903,6 +1909,9 @@ SCENARIO("Test planner with various start conditions")
 
   WHEN("Planning with startset of waypoint index and orientations")
   {
+    graph.add_lane(1, 2); // 6
+    graph.add_lane(2, 1); // 7
+    
     std::vector<Planner::Start> starts;
     Planner::Start start1{initial_time, 1, 0.0};
     Planner::Start start2{initial_time, 1, M_PI_2};
@@ -1925,7 +1934,6 @@ SCENARIO("Test planner with various start conditions")
 
     WHEN("Testing replan with startsets")
     {
-
       /*
       CMAKE ERROR when invoking plan.replan(starts)
   

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -44,56 +44,24 @@ void print_timing(const std::chrono::steady_clock::time_point& start_time)
   }
 }
 
-void display_path(rmf_traffic::Trajectory t, rmf_traffic::agv::Graph graph)
+void display_path(const rmf_traffic::agv::Plan& plan)
 {
-  // this is a very bad algorithm but will be improved
-  const auto start_time = std::chrono::steady_clock::now();
-  std::vector<Eigen::Vector2d> graph_locations;
-  std::vector<int> path;
-
-  for (std::size_t i=0; i<graph.num_waypoints(); i++)
-    graph_locations.push_back(graph.get_waypoint(i).get_location());
-
-  for (auto it = t.begin(); it != t.end(); it++)
-  {
-    auto it2 = std::find(
-        graph_locations.begin(),
-        graph_locations.end(),
-        it->get_finish_position().block<2,1>(0,0));
-    if (it2 != graph_locations.end())
-      {
-        int waypoint_index=std::distance(graph_locations.begin(), it2);
-        if (path.empty())
-          path.push_back(waypoint_index);
-        else if (path.back() != waypoint_index)
-          path.push_back(waypoint_index);
-      }
-  }
-  const auto end_time = std::chrono::steady_clock::now();
-  std::cout<<"Display Path computed in: "
-      <<std::setprecision(4)
-      <<rmf_traffic::time::to_seconds(end_time - start_time)
-      <<"s\n";
-  for (auto it = path.begin(); it != path.end(); it++)
-  {
-    std::cout<<*it;
-    if(it!=--path.end())
-      std::cout<<"->";
-  }
+  for (const auto& wp : plan.get_waypoints())
+    std::cout<<wp.graph_index();
   std::cout<<std::endl;
 }
 
 void print_trajectory_info(
-    const rmf_traffic::Trajectory t,
-    rmf_traffic::Time time,
-    rmf_traffic::agv::Graph graph)
+    const rmf_traffic::agv::Plan& plan,
+    rmf_traffic::Time time)
 {
   int count = 1;
+  const auto& t = plan.get_trajectories().front();
   std::cout<<"Trajectory in: "
       <<t.get_map_name()
       <<" with "<<t.size()
       <<" segments\n";
-  display_path(t, graph);
+  display_path(plan);
   for (auto it = t.begin(); it != t.end(); it++)
     {
       auto position=it->get_finish_position();
@@ -192,7 +160,7 @@ rmf_traffic::Trajectory test_with_obstacle(
   if (print_info)
   {
     std::cout << "Parent: " << parent << std::endl;
-    print_trajectory_info(t_obs, time, graph);
+    print_trajectory_info(*plan, time);
   }
   return t_obs;
 }

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1809,6 +1809,15 @@ SCENARIO("Test planner with various start conditions")
     CHECK((graph.get_waypoint(3).get_location()
         - t.back().get_finish_position().block<2,1>(0, 0)).norm()
         == Approx(0.0).margin(1e-6));
+    const auto& waypoints = plan->get_waypoints();
+      REQUIRE(waypoints.size() == 3);
+
+    auto it = std::find(waypoints.begin(), waypoints.end(), 1);
+    CHECK(it != waypoints.end());
+    auto it = std::find(waypoints.begin(), waypoints.end(), 2);
+    CHECK(it != waypoints.end());
+    auto it = std::find(waypoints.begin(), waypoints.end(), 3);
+    CHECK(it != waypoints.end());
 
     WHEN("Obstace 4->0 overlaps")
     {
@@ -1839,6 +1848,14 @@ SCENARIO("Test planner with various start conditions")
       CHECK((graph.get_waypoint(3).get_location()
           - t.back().get_finish_position().block<2,1>(0, 0)).norm()
           == Approx(0.0).margin(1e-6));
+      const auto& waypoints = plan->get_waypoints();
+      REQUIRE(waypoints.size() == 3);
+      auto it = std::find(waypoints.begin(), waypoints.end(), 1);
+      CHECK(it != waypoints.end());
+      auto it = std::find(waypoints.begin(), waypoints.end(), 2);
+      CHECK(it != waypoints.end());
+      auto it = std::find(waypoints.begin(), waypoints.end(), 3);
+      CHECK(it != waypoints.end());
     }
   }
 
@@ -1869,7 +1886,14 @@ SCENARIO("Test planner with various start conditions")
     CHECK((graph.get_waypoint(3).get_location()
         - t.back().get_finish_position().block<2,1>(0, 0)).norm()
         == Approx(0.0).margin(1e-6));
-    
+    const auto& waypoints = plan->get_waypoints();
+    REQUIRE(waypoints.size() == 3);
+    auto it = std::find(waypoints.begin(), waypoints.end(), 1);
+    CHECK(it != waypoints.end());
+    auto it = std::find(waypoints.begin(), waypoints.end(), 2);
+    CHECK(it != waypoints.end());
+    auto it = std::find(waypoints.begin(), waypoints.end(), 3);
+    CHECK(it != waypoints.end());
   }
 
   WHEN("Planning with startset of waypoint index and orientations")
@@ -1887,13 +1911,19 @@ SCENARIO("Test planner with various start conditions")
     REQUIRE(plan->get_trajectories().size() > 0);
     const auto t = plan->get_trajectories().front();
 
-    //we expect the starting condition with orientation = 0 to be optimal
+    //we expect the starting condition with orientation = 0 to be shortest
     CHECK((graph.get_waypoint(3).get_location()
         - t.back().get_finish_position().block<2,1>(0, 0)).norm()
         == Approx(0.0).margin(1e-6));
     CHECK((t.front().get_finish_position()[2] - 0.0) == Approx(0.0));
     CHECK((t.back().get_finish_position()[2] - 0.0) == Approx(0.0));
 
+    WHEN("Testing replan with startsets")
+    {
+      plan = plan->replan(starts);
+
+
+    }
     WHEN("Obstace 4->0 overlaps")
     {
       std::vector<rmf_traffic::Trajectory> obstacles;

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1719,10 +1719,14 @@ SCENARIO("Test planner with start")
     graph.add_lane(w1, w0);
   };
 
-  add_bidir_lane(0 ,2); // 0
-  add_bidir_lane(1, 2); // 1
-  add_bidir_lane(3, 2); // 2
-  add_bidir_lane(4, 2); // 3
+  graph.add_lane(0 ,2); // 0
+  graph.add_lane(2, 0); // 1
+  graph.add_lane(1, 2); // 2
+  graph.add_lane(2, 1); // 3
+  graph.add_lane(3, 2); // 4
+  graph.add_lane(2, 3); // 5
+  graph.add_lane(4, 2); // 6
+  graph.add_lane(2, 4); // 7
 
   const VehicleTraits traits{
       {1.0, 0.4},
@@ -1746,10 +1750,30 @@ SCENARIO("Test planner with start")
 
   const rmf_traffic::Time initial_time = std::chrono::steady_clock::now();
 
-  WHEN("Start planning with robot not at waypoint")
-  {
-    rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-5, 0};
-    rmf_utils::optional<std::size_t> initial_lane = std::size_t(0);
+  WHEN("Start contains initial_location")
+  { 
+    rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-2.5, 0};
+
+    Planner::Start start(
+        initial_time,
+        1,
+        0.0,
+        initial_location);
+
+    REQUIRE(start.location());
+    REQUIRE(start.lane());
+
+    Planner::Goal goal(3);
+
+    const auto plan = planner.plan(start, goal);
+    CHECK(plan);
+
+  }
+
+  WHEN("Start contains initial_location and initial_lane")
+  { 
+    rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-2.5, 0};
+    rmf_utils::optional<std::size_t> initial_lane = std::size_t(3);
   
     Planner::Start start(
         initial_time,
@@ -1761,17 +1785,15 @@ SCENARIO("Test planner with start")
     REQUIRE(start.location());
     REQUIRE(start.lane());
 
-    Planner::Goal goal(2);
+    Planner::Goal goal(3);
 
-    //const auto plan = planner.plan(start, goal);
+    const auto plan = planner.plan(start, goal);
     //CHECK(plan);
 
   }
 
  
 }
-
-
 
 // TODO(MXG): Make a test for the interrupt_flag in Planner::Options
 


### PR DESCRIPTION
This PR adds a few new planning features:

* Plans running on a separate thread can be interrupted if you give the `Planner::Options` a `bool* interrupt_flag`. While the value being pointed to is `false`, the planner will keep running. When the value switches to `true`, the planner will end its search and return a `nullopt` if no plan was found.

* `Planner::Start` specifications can now optionally include an (x, y) location which is off the grid. The planner will generate a plan that starts at that (x, y) location and then immediately move to the specified `initial_waypoint`.

* `Planner::Start` specifications can also optionally include an `initial_lane` index. The lane constraints will be applied when moving from the `initial_location` (x, y) coordinates to the `initial_waypoint` location. If no `initial_lane` is specified then the planner will move the AGV to the `initial_waypoint` without any constraints (besides the differential drive constraints).

* Multiple `Planner::Start` objects can be fed into a planner, and the planner will use whichever start allows for the shortest-duration plan. This can be used if an AGV is halfway between two waypoints: each waypoint can be used as the `initial_waypoint` its own `Planner::Start` while the `initial_location` is the robot's real location. The Planner will move the AGV to whichever waypoint allows the plan to be shortest.