### PR TITLE
reverting dispenser request item message to be used for fiducial tag …

### DIFF
--- a/rmf_dispenser_msgs/msg/DispenserRequestItem.msg
+++ b/rmf_dispenser_msgs/msg/DispenserRequestItem.msg
@@ -1,2 +1,3 @@
 string item_type
 int32 quantity
+string compartment_name


### PR DESCRIPTION
…name in CSSD workcell

* `compartment_name` field is needed for CSSD workcell target slot's fiducial tag