### PR TITLE
Create a node to supervise the door requests

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -97,6 +97,49 @@ target_include_directories(full_control
 
 # -----------------------------------------------------------------------------
 
+add_executable(lift_supervisor
+  src/lift_supervisor/main.cpp
+  src/lift_supervisor/Node.cpp
+)
+
+target_link_libraries(lift_supervisor
+  PRIVATE
+    rmf_fleet_adapter
+    ${rclcpp_LIBARRIES}
+    ${rmf_lift_msgs_LIBRARIES}
+    ${std_msgs_LIBRARIES}
+)
+
+target_include_directories(lift_supervisor
+  PRIVATE
+    ${rclcpp_INCLUDE_DIRS}
+    ${rmf_lift_msgs_INCLUDE_DIRS}
+    ${std_msgs_INCLUDE_DIRS}
+)
+
+
+# -----------------------------------------------------------------------------
+
+add_executable(door_supervisor
+  src/door_supervisor/main.cpp
+  src/door_supervisor/Node.cpp
+)
+
+target_link_libraries(door_supervisor
+  PRIVATE
+    rmf_fleet_adapter
+    ${rclcpp_LIBRARIES}
+    ${rmf_door_msgs_LIBRARIES}
+)
+
+target_include_directories(door_supervisor
+  PRIVATE
+    ${rclcpp_INCLUDE_DIRS}
+    ${rmf_door_msgs_INCLUDE_DIRS}
+)
+
+# -----------------------------------------------------------------------------
+
 add_executable(fake_fleet
   test/FakeFleet.cpp
 )

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -27,10 +27,12 @@ const std::string DestinationRequestTopicName = "destination_requests";
 const std::string ModeRequestTopicName = "mode_requests";
 const std::string PathRequestTopicName = "path_requests";
 
-const std::string DoorRequestTopicName = "adapter_door_requests";
+const std::string FinalDoorRequestTopicName = "door_requests";
+const std::string AdapterDoorRequestTopicName = "adapter_door_requests";
 const std::string DoorStateTopicName = "door_states";
 
-const std::string LiftRequestTopicName = "adapter_lift_requests";
+const std::string FinalLiftRequestTopicName = "lift_requests";
+const std::string AdapterLiftRequestTopicName = "adapter_lift_requests";
 const std::string LiftStateTopicName = "lift_states";
 
 const std::string DispenserRequestTopicName = "dispenser_requests";

--- a/rmf_fleet_adapter/src/door_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/door_supervisor/Node.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Node.hpp"
+
+#include <rmf_fleet_adapter/StandardNames.hpp>
+
+namespace rmf_fleet_adapter {
+namespace door_supervisor {
+
+const std::string DoorSupervisorRequesterID = "door_supervisor";
+
+//==============================================================================
+Node::Node()
+: rclcpp::Node("door_supervisor")
+{
+  const auto default_qos = rclcpp::SystemDefaultsQoS();
+
+  _door_request_pub = create_publisher<DoorRequest>(
+        FinalDoorRequestTopicName, default_qos);
+
+  _adapter_door_request_sub = create_subscription<DoorRequest>(
+        AdapterDoorRequestTopicName, default_qos,
+        [&](DoorRequest::UniquePtr msg)
+  {
+    _adapter_door_request_update(std::move(msg));
+  });
+
+  _door_state_sub = create_subscription<DoorState>(
+        DoorStateTopicName, default_qos,
+        [&](DoorState::UniquePtr msg)
+  {
+    _door_state_update(std::move(msg));
+  });
+}
+
+//==============================================================================
+void Node::_adapter_door_request_update(DoorRequest::UniquePtr msg)
+{
+  if (DoorMode::MODE_OPEN == msg->requested_mode.value)
+    _process_open_request(msg->door_name, msg->requester_id, msg->request_time);
+
+  if (DoorMode::MODE_CLOSED == msg->requested_mode.value)
+    _process_close_request(msg->door_name, msg->requester_id, msg->request_time);
+}
+
+//==============================================================================
+void Node::_process_open_request(
+    const std::string& door_name,
+    const std::string& requester_id,
+    const builtin_interfaces::msg::Time& time)
+{
+  auto& open_requests = _log[door_name];
+  auto insertion = open_requests.insert(std::make_pair(requester_id, time));
+  if (!insertion.second)
+  {
+    // Use the latest time in the log
+    auto& logged_request_time = insertion.first->second;
+    logged_request_time = std::max(logged_request_time, rclcpp::Time(time));
+  }
+
+  _send_open_request(door_name);
+}
+
+//==============================================================================
+void Node::_send_open_request(const std::string& door_name)
+{
+  DoorRequest request;
+  request.door_name = door_name;
+  request.request_time = get_clock()->now();
+  request.requester_id = DoorSupervisorRequesterID;
+  request.requested_mode.value = DoorMode::MODE_OPEN;
+  _door_request_pub->publish(request);
+}
+
+//==============================================================================
+void Node::_process_close_request(
+    const std::string& door_name,
+    const std::string& requester_id,
+    const builtin_interfaces::msg::Time& time)
+{
+  auto door_it = _log.find(door_name);
+  if (door_it == _log.end())
+    return;
+
+  auto& door_log = door_it->second;
+  auto request_it = door_log.find(requester_id);
+  if (request_it == door_log.end())
+    return;
+
+  auto& logged_request_time = request_it->second;
+  const auto new_request_time = rclcpp::Time(time);
+  if (new_request_time < logged_request_time)
+    return;
+
+  // We can remove this requester from the log of open requests
+  door_log.erase(request_it);
+
+  if (!door_log.empty())
+    return;
+
+  // If all the open requests have been erased for this door, then we can
+  // safely close it.
+  // TODO(MXG): Consider whether the door_it should be erased from _log
+  _send_close_request(door_name);
+}
+
+//==============================================================================
+void Node::_send_close_request(const std::string& door_name)
+{
+  DoorRequest request;
+  request.door_name = door_name;
+  request.request_time = get_clock()->now();
+  request.requester_id = DoorSupervisorRequesterID;
+  request.requested_mode.value = DoorMode::MODE_CLOSED;
+  _door_request_pub->publish(request);
+}
+
+//==============================================================================
+void Node::_door_state_update(DoorState::UniquePtr msg)
+{
+  const std::string& door_name = msg->door_name;
+  const auto& door_it = _log.find(door_name);
+
+  // TODO(MXG): Instead of MOVE_MOVING, we may want to consider having a
+  // MODE_OPENING and MODE_CLOSING to be more precise about what the door is
+  // doing.
+  if (door_it == _log.end() || door_it->second.empty())
+  {
+    if (DoorMode::MODE_OPEN == msg->current_mode.value
+        || DoorMode::MODE_MOVING == msg->current_mode.value)
+    {
+      // If the door is not closed but it's supposed to be, then send a reminder
+      _send_close_request(door_name);
+    }
+  }
+  else
+  {
+    if (DoorMode::MODE_CLOSED == msg->current_mode.value
+        || DoorMode::MODE_MOVING == msg->current_mode.value)
+    {
+      // If the door is not open but it's supposed to be, then send a reminder
+      _send_open_request(door_name);
+    }
+  }
+}
+
+} // namespace door_supervisor
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/door_supervisor/Node.hpp
+++ b/rmf_fleet_adapter/src/door_supervisor/Node.hpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/time.hpp>
+
+#include <rmf_door_msgs/msg/door_state.hpp>
+#include <rmf_door_msgs/msg/door_request.hpp>
+
+#include <string>
+#include <unordered_map>
+
+namespace rmf_fleet_adapter {
+namespace door_supervisor {
+
+//==============================================================================
+class Node : public rclcpp::Node
+{
+public:
+
+  Node();
+
+private:
+
+  using DoorMode = rmf_door_msgs::msg::DoorMode;
+
+  using DoorRequest = rmf_door_msgs::msg::DoorRequest;
+  using DoorRequestPub = rclcpp::Publisher<DoorRequest>;
+  DoorRequestPub::SharedPtr _door_request_pub;
+
+  using DoorRequestSub = rclcpp::Subscription<DoorRequest>;
+  DoorRequestSub::SharedPtr _adapter_door_request_sub;
+  void _adapter_door_request_update(DoorRequest::UniquePtr msg);
+
+  void _process_open_request(
+      const std::string& door_name,
+      const std::string& requester_id,
+      const builtin_interfaces::msg::Time& time);
+
+  void _send_open_request(const std::string& door_name);
+
+  void _process_close_request(
+      const std::string& door_name,
+      const std::string& requester_id,
+      const builtin_interfaces::msg::Time& time);
+
+  void _send_close_request(const std::string& door_name);
+
+  using DoorState = rmf_door_msgs::msg::DoorState;
+  using DoorStateSub = rclcpp::Subscription<DoorState>;
+  DoorStateSub::SharedPtr _door_state_sub;
+  void _door_state_update(DoorState::UniquePtr msg);
+
+  using OpenRequestLog =
+      std::unordered_map<
+        std::string,
+        std::unordered_map<std::string, rclcpp::Time>>;
+  OpenRequestLog _log;
+};
+
+} // namespace door_supervisor
+} // namesapce rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/door_supervisor/main.cpp
+++ b/rmf_fleet_adapter/src/door_supervisor/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Node.hpp"
+
+#include <rclcpp/executors.hpp>
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<rmf_fleet_adapter::door_supervisor::Node>());
+  rclcpp::shutdown();
+}

--- a/rmf_fleet_adapter/src/full_control/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/full_control/FleetAdapterNode.cpp
@@ -110,8 +110,11 @@ std::shared_ptr<FleetAdapterNode> FleetAdapterNode::make(
 }
 
 //==============================================================================
-FleetAdapterNode::RobotContext::RobotContext(Location location_)
-  : location(std::move(location_))
+FleetAdapterNode::RobotContext::RobotContext(
+    std::string name,
+    Location location_)
+: location(std::move(location_)),
+  _name(std::move(name))
 {
   // Do nothing
 }
@@ -186,6 +189,12 @@ std::size_t FleetAdapterNode::RobotContext::num_tasks() const
 {
   const std::size_t n_queue = _task_queue.size();
   return _task? n_queue + 1 : n_queue;
+}
+
+//==============================================================================
+const std::string& FleetAdapterNode::RobotContext::robot_name() const
+{
+  return _name;
 }
 
 //==============================================================================
@@ -426,10 +435,10 @@ void FleetAdapterNode::start(Fields fields)
         PathRequestTopicName, default_qos);
 
   door_request_publisher = create_publisher<DoorRequest>(
-        DoorRequestTopicName, default_qos);
+        AdapterDoorRequestTopicName, default_qos);
 
   lift_request_publisher = create_publisher<LiftRequest>(
-        LiftRequestTopicName, default_qos);
+        AdapterLiftRequestTopicName, default_qos);
 
   dispenser_request_publisher = create_publisher<DispenserRequest>(
         DispenserRequestTopicName, default_qos);
@@ -537,7 +546,8 @@ void FleetAdapterNode::fleet_state_update(FleetState::UniquePtr msg)
 
     if (inserted)
     {
-      it->second = std::make_unique<RobotContext>(RobotContext{robot.location});
+      it->second = std::make_unique<RobotContext>(
+            RobotContext{robot.name, robot.location});
     }
     else
     {

--- a/rmf_fleet_adapter/src/full_control/FleetAdapterNode.hpp
+++ b/rmf_fleet_adapter/src/full_control/FleetAdapterNode.hpp
@@ -101,7 +101,7 @@ public:
 
   struct RobotContext
   {
-    RobotContext(Location location);
+    RobotContext(std::string name, Location location);
 
     Location location;
     RobotStateListeners state_listeners;
@@ -118,9 +118,12 @@ public:
 
     std::size_t num_tasks() const;
 
+    const std::string& robot_name() const;
+
   private:
     std::unique_ptr<Task> _task;
     std::vector<std::unique_ptr<Task>> _task_queue;
+    const std::string _name;
   };
 
   const std::string& get_fleet_name() const;

--- a/rmf_fleet_adapter/src/full_control/MoveAction.cpp
+++ b/rmf_fleet_adapter/src/full_control/MoveAction.cpp
@@ -538,7 +538,8 @@ public:
       request.door_name = door_name;
       request.request_time = _command_time;
       request.requested_mode.value = mode;
-      request.requester_id = _parent->_node->get_fleet_name();
+      request.requester_id = _parent->_node->get_fleet_name()
+          + "/" + _parent->_context->robot_name();
 
       _parent->_node->door_request_publisher->publish(request);
     }
@@ -623,7 +624,8 @@ public:
 
       LiftRequest request;
       request.lift_name = lift_name;
-      request.session_id = _parent->_node->get_fleet_name();
+      request.session_id = _parent->_node->get_fleet_name()
+          + "/" + _parent->_context->robot_name();
       request.request_type = lift_mode;
       request.destination_floor = floor_name;
       request.door_state = door_state;

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Node.hpp"
+
+#include <rmf_fleet_adapter/StandardNames.hpp>
+#include <rmf_traffic_ros2/StandardNames.hpp>
+
+namespace rmf_fleet_adapter {
+namespace lift_supervisor {
+
+//==============================================================================
+Node::Node()
+: rclcpp::Node("rmf_lift_supervisor")
+{
+  const auto default_qos = rclcpp::SystemDefaultsQoS();
+
+  _lift_request_pub = create_publisher<LiftRequest>(
+        FinalLiftRequestTopicName, default_qos);
+
+  _adapter_lift_request_sub = create_subscription<LiftRequest>(
+        AdapterLiftRequestTopicName, default_qos,
+        [&](LiftRequest::UniquePtr msg)
+  {
+    _adapter_lift_request_update(std::move(msg));
+  });
+
+  _lift_state_sub = create_subscription<LiftState>(
+        LiftStateTopicName, default_qos,
+        [&](LiftState::UniquePtr msg)
+  {
+    _lift_state_update(std::move(msg));
+  });
+
+  _emergency_notice_pub = create_publisher<EmergencyNotice>(
+        rmf_traffic_ros2::EmergencyTopicName, default_qos);
+}
+
+//==============================================================================
+void Node::_adapter_lift_request_update(LiftRequest::UniquePtr /*msg*/)
+{
+  // TODO(MXG): At some point, come up with an intelligent way to plan out
+  // lift usage based on incoming requests.
+  //
+  // For right now, the only job of this node is to sniff out the emergency
+  // message from the lift messages, and broadcast that over the emergency
+  // topic.
+}
+
+//==============================================================================
+void Node::_lift_state_update(LiftState::UniquePtr msg)
+{
+  std_msgs::msg::Bool emergency_msg;
+  emergency_msg.data = false;
+
+  if (LiftState::MODE_FIRE == msg->current_mode
+      || LiftState::MODE_EMERGENCY == msg->current_mode)
+  {
+    emergency_msg.data = true;
+  }
+
+  _emergency_notice_pub->publish(emergency_msg);
+}
+
+} // namespace lift_supervisor
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.hpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.hpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__LIFT_SUPERVISOR__NODE_HPP
+#define SRC__LIFT_SUPERVISOR__NODE_HPP
+
+#include <rmf_lift_msgs/msg/lift_request.hpp>
+#include <rmf_lift_msgs/msg/lift_state.hpp>
+
+#include <std_msgs/msg/bool.hpp>
+
+#include <rclcpp/node.hpp>
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace rmf_fleet_adapter {
+namespace lift_supervisor {
+
+//==============================================================================
+class Node : public rclcpp::Node
+{
+public:
+
+  Node();
+
+private:
+
+  using LiftRequest = rmf_lift_msgs::msg::LiftRequest;
+  using LiftRequestPub = rclcpp::Publisher<LiftRequest>;
+  LiftRequestPub::SharedPtr _lift_request_pub;
+
+  using LiftRequestSub = rclcpp::Subscription<LiftRequest>;
+  LiftRequestSub::SharedPtr _adapter_lift_request_sub;
+  void _adapter_lift_request_update(LiftRequest::UniquePtr msg);
+
+  using LiftState = rmf_lift_msgs::msg::LiftState;
+  using LiftStateSub = rclcpp::Subscription<LiftState>;
+  LiftStateSub::SharedPtr _lift_state_sub;
+  void _lift_state_update(LiftState::UniquePtr msg);
+
+  using EmergencyNotice = std_msgs::msg::Bool;
+  using EmergencyNoticePub = rclcpp::Publisher<EmergencyNotice>;
+  EmergencyNoticePub::SharedPtr _emergency_notice_pub;
+
+};
+
+} // namespace lift_supervisor
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__LIFT_SUPERVISOR__NODE_HPP

--- a/rmf_fleet_adapter/src/lift_supervisor/main.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/main.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2019 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "Node.hpp"
+
+#include <rclcpp/executors.hpp>
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<rmf_fleet_adapter::lift_supervisor::Node>());
+  rclcpp::shutdown();
+}


### PR DESCRIPTION
Since every fleet adapter is issuing lift and door requests for each of their own robots without consideration for the needs of other fleets, we need to have nodes whose responsibility is to multiplex these requests into a single open or close command.

The strategy used for the door is to gather all the requests that are being emitted by the fleet adapters and keep track of what the latest command was from each adapter for each robot with respect to each door. If the latest request for any combination of `(fleet, robot name)` on a given door is to have the door open, then the door supervisor node will maintain a door open request. When all of the latest requests for a given door were to have it closed, then the door supervisor will issue door close requests.

This makes sure that the open state is favored whenever a robot needs to pass through a door. Otherwise there may be a risk that a fleet adapter may command the door to close on the robot of another fleet's robot that the adapter does not know anything about.