### PR TITLE
include the state of the task within TaskSummary

### DIFF
--- a/rmf_task_msgs/msg/TaskSummary.msg
+++ b/rmf_task_msgs/msg/TaskSummary.msg
@@ -1,11 +1,18 @@
 string task_id
 
-# a brief summary of the current status of the task
+uint32 state
+uint32 STATE_QUEUED=0
+uint32 STATE_ACTIVE=1
+uint32 STATE_COMPLETED=2  # hooray
+uint32 STATE_FAILED=3     # oh no
+
+# a brief summary of the current status of the task, for UI's
 string status
 
 # submission_time is when the task was submitted to rmf_core
 builtin_interfaces/Time submission_time
 
+# when rmf_core actually began processing the task
 builtin_interfaces/Time start_time
 
 # When this message is a summary of an in-process task, the end_time field is

--- a/rmf_task_msgs/msg/Tasks.msg
+++ b/rmf_task_msgs/msg/Tasks.msg
@@ -1,4 +1,1 @@
-TaskSummary[] queued_tasks
-TaskSummary[] active_tasks
-TaskSummary[] completed_tasks
-TaskSummary[] failed_tasks
+TaskSummary[] tasks


### PR DESCRIPTION
instead of having multiple lists within `Tasks.msg`, now that container message is just a single list of `TaskSummary.msg`, each of which has their own state field.

The intent is that when a task is completed it is included with `STATE_COMPLETED` set only for one publication, and then it ceases to be included in this message stream. Similarly for `STATE_FAILED`.