### PR TITLE
Updated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ to `rmf_core`. These messages express the current mode of the door as `CLOSED`, 
  * `rmf_door_msgs/DoorRequest` messages are sent from `rmf_core` to doors when
 they need to open or close for robot operations.
 
+## Installation
+```
+mkdir ws_rmf/src -p
+cd ws_rmf/src/
+git clone https://github.com/osrf/rmf_core.git
+cd ../
+source /opt/ros/eloquent/setup.bash
+rosdep update
+rosdep install --from-paths src --ignore-src -y -r
+colcon build
+```
+
 ## Demonstrations
 
 [This repository](https://github.com/osrf/rmf_demos) holds a number of demonstrations and examples of working with `rmf_core` and the other packages in the RMF ecosystem.

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -15,7 +15,6 @@
   <depend>rmf_door_msgs</depend>
   <depend>rmf_dispenser_msgs</depend>
   <depend>rmf_fleet_msgs</depend>
-  <depend>rmf_fleet_utils</depend>
   <depend>rmf_lift_msgs</depend>
   <depend>rmf_task_msgs</depend>
   <depend>rmf_traffic</depend>

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -13,6 +13,9 @@
   <build_depend>rmf_utils</build_depend>
   <build_export_depend>rmf_utils</build_export_depend>
 
+  <build_depend>libccd-dev</build_depend>
+  <build_depend>libfcl-dev</build_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -13,6 +13,8 @@
   <depend>rmf_traffic_msgs</depend>
   <depend>rmf_fleet_msgs</depend>
 
+  <build_depend>yaml-cpp</build_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
This PR is a fix for Issue #70.

Test procedure in docker:
```
Step 1: Create environment
sudo docker run -it ros:eloquent-ros-base-bionic /bin/bash

Step 2: Test build
sudo apt update
cd /home
mkdir ws_rmf/src -p
cd ws_rmf/src/
git clone https://github.com/osrf/rmf_core.git
cd rmf_core/
git checkout bug/fix_build_dependencies
cd /home/ws_rmf
source /opt/ros/eloquent/setup.bash
rosdep update
rosdep install --from-paths src --ignore-src -y -r
colcon build
```