### PR TITLE
Test/multi negotiation

### DIFF
--- a/rmf_traffic/include/rmf_traffic/schedule/Negotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Negotiator.hpp
@@ -101,6 +101,17 @@ public:
       schedule::ParticipantId for_participant,
       std::vector<schedule::ParticipantId> to_accommodate);
 
+  /// Constructor
+  ///
+  /// \param[in] negotiation
+  ///   The Negotiation that this SimpleResponder is tied to
+  ///
+  /// \param[in] table_sequence
+  ///   The sequence that identifies what table this responder should submit to
+  SimpleResponder(
+      std::shared_ptr<schedule::Negotiation> negotiation,
+      std::vector<schedule::ParticipantId> table_sequence);
+
   // Documentation inherited
   // NOTE: approval_callback does not get used
   void submit(

--- a/rmf_traffic/test/regression/regress_Negotiation.cpp
+++ b/rmf_traffic/test/regression/regress_Negotiation.cpp
@@ -21,8 +21,6 @@
 
 #include <rmf_utils/catch.hpp>
 
-#include <iostream>
-
 namespace {
 //==============================================================================
 struct MockNegotiator : public rmf_traffic::schedule::Negotiator

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -25,24 +25,31 @@
 
 #include <rmf_utils/catch.hpp>
 
+#include <unordered_map>
+
 #include <iostream>
 
+//==============================================================================
 void print_proposal(
     const rmf_traffic::schedule::Negotiation::Proposal& proposals)
 {
   for (const auto& proposal : proposals)
   {
-    std::cout << "participant " << proposal.participant << ":\n";
+    std::cout << "\nparticipant " << proposal.participant << ":\n";
+    const auto start_time =
+        *proposal.itinerary.front()->trajectory().start_time();
     for (const auto& r : proposal.itinerary)
     {
       for (const auto& t : r->trajectory())
       {
-        std::cout << t.position().transpose() << std::endl;
+        std::cout << "[" << rmf_traffic::time::to_seconds(t.time() - start_time)
+                  << "]" << t.position().transpose() << std::endl;
       }
     }
   }
 }
 
+//==============================================================================
 SCENARIO("Test Plan Negotiation Between Two Participants")
 {
   using namespace std::chrono_literals;
@@ -328,4 +335,207 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
 
 //    print_proposal(*proposals);
   }
+}
+
+//==============================================================================
+class NegotiationRoom
+{
+public:
+
+  using ParticipantId = rmf_traffic::schedule::ParticipantId;
+  using Negotiator = rmf_traffic::agv::SimpleNegotiator;
+  using Negotiation = rmf_traffic::schedule::Negotiation;
+  using Responder = rmf_traffic::schedule::SimpleResponder;
+
+  struct Intention
+  {
+    rmf_traffic::agv::Planner::Start start;
+    rmf_traffic::agv::Planner::Goal goal;
+    rmf_traffic::agv::Planner::Configuration configuration;
+  };
+
+  using Intentions = std::unordered_map<ParticipantId, Intention>;
+
+  NegotiationRoom(
+      const rmf_traffic::schedule::Viewer& viewer,
+      Intentions intentions,
+      const bool print_failures_ = false)
+    : negotiators(make_negotiations(intentions)),
+      negotiation(std::make_shared<Negotiation>(
+                    viewer, get_participants(intentions))),
+      print_failures(print_failures_)
+  {
+    // Do nothing
+  }
+
+  rmf_utils::optional<Negotiation::Proposal> solve()
+  {
+    std::vector<Negotiation::TablePtr> queue;
+    for (const auto& p : negotiation->participants())
+    {
+      const auto table = negotiation->table(p, {});
+      negotiators.at(p).respond(table, Responder(negotiation, p, {}));
+      queue.push_back(table);
+    }
+
+    while (!queue.empty())
+    {
+      const auto top = queue.back();
+      queue.pop_back();
+
+      for (auto& n : negotiators)
+      {
+        const auto participant = n.first;
+        auto& negotiator = n.second;
+        const auto respond_to = top->respond(participant);
+        if (respond_to)
+        {
+          negotiator.respond(
+                respond_to,
+                Responder(negotiation, respond_to->sequence()));
+          if (print_failures && !respond_to->submission())
+          {
+            std::cout << "Failed to make a submission for [";
+            for (const auto p : respond_to->sequence())
+              std::cout << " " << p;
+            std::cout << " ]" << std::endl;
+          }
+          queue.push_back(respond_to);
+        }
+      }
+    }
+
+    CHECK(negotiation->complete());
+    if (!negotiation->ready())
+      return rmf_utils::nullopt;
+
+    return negotiation->evaluate(
+          rmf_traffic::schedule::QuickestFinishEvaluator())->proposal();
+  }
+
+  static std::unordered_map<ParticipantId, Negotiator> make_negotiations(
+      const std::unordered_map<ParticipantId, Intention>& intentions)
+  {
+    std::unordered_map<ParticipantId, Negotiator> negotiators;
+    for (const auto& entry : intentions)
+    {
+      const auto participant = entry.first;
+      const auto& intention = entry.second;
+      negotiators.insert(
+            std::make_pair(
+              participant,
+              rmf_traffic::agv::SimpleNegotiator(
+                intention.start, intention.goal, intention.configuration)));
+    }
+
+    return negotiators;
+  }
+
+  static std::vector<ParticipantId> get_participants(
+      const std::unordered_map<ParticipantId, Intention>& intentions)
+  {
+    std::vector<ParticipantId> participants;
+    participants.reserve(intentions.size());
+    for (const auto& entry : intentions)
+      participants.push_back(entry.first);
+
+    return participants;
+  }
+
+  std::unordered_map<ParticipantId, Negotiator> negotiators;
+  std::shared_ptr<rmf_traffic::schedule::Negotiation> negotiation;
+  bool print_failures = false;
+};
+
+//==============================================================================
+SCENARIO("Multi-participant negotiation")
+{
+  using namespace std::chrono_literals;
+
+  rmf_traffic::schedule::Database database;
+
+  rmf_traffic::Profile profile{
+    rmf_traffic::geometry::make_final_convex<
+        rmf_traffic::geometry::Circle>(1.0)
+  };
+
+  auto p1 = rmf_traffic::schedule::make_participant(
+        rmf_traffic::schedule::ParticipantDescription{
+          "participant 1",
+          "test_Negotiator",
+          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+          profile
+        },
+        database);
+
+  auto p2 = rmf_traffic::schedule::make_participant(
+        rmf_traffic::schedule::ParticipantDescription{
+          "participant 2",
+          "test_Negotiator",
+          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+          profile
+        },
+        database);
+
+  auto p3 = rmf_traffic::schedule::make_participant(
+        rmf_traffic::schedule::ParticipantDescription{
+          "participant 3",
+          "test_Negotiator",
+          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+          profile
+        },
+        database);
+
+  const std::string test_map_name = "test_map";
+  rmf_traffic::agv::Graph graph;
+  graph.add_waypoint(test_map_name, { 0.0, -5.0}, true); // 0
+  graph.add_waypoint(test_map_name, {-5.0,  0.0}, true); // 1
+  graph.add_waypoint(test_map_name, { 0.0,  0.0}, true); // 2
+//  graph.add_waypoint(test_map_name, { 5.0,  0.0}, true); // 3 // TODO(MXG): This edge case needs to be dealt with
+  graph.add_waypoint(test_map_name, { 14.0,  0.0}, true); // 3
+  graph.add_waypoint(test_map_name, { 0.0,  5.0}, true); // 4
+
+  /*
+   *         4
+   *         |
+   *         |
+   *   1-----2-------3
+   *         |
+   *         |
+   *         0
+   */
+
+  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
+  {
+    graph.add_lane(w0, w1);
+    graph.add_lane(w1, w0);
+  };
+
+  add_bidir_lane(0, 2);
+  add_bidir_lane(1, 2);
+  add_bidir_lane(3, 2);
+  add_bidir_lane(4, 2);
+
+  const rmf_traffic::agv::VehicleTraits traits{
+    {0.7, 0.3},
+    {1.0, 0.45},
+    profile
+  };
+
+  const auto time = std::chrono::steady_clock::now();
+
+  rmf_traffic::agv::Planner::Configuration configuration{graph, traits};
+
+  NegotiationRoom::Intentions intentions;
+  intentions.insert({0, NegotiationRoom::Intention{
+                       {time, 1, 0.0}, 3, configuration}});
+  intentions.insert({1, NegotiationRoom::Intention{
+                       {time, 4, M_PI/2.0}, 0, configuration}});
+  intentions.insert({2, NegotiationRoom::Intention{
+                       {time, 3, 0.0}, 1, configuration}});
+
+  auto proposal = NegotiationRoom(database, intentions).solve();
+  REQUIRE(proposal);
+
+  print_proposal(*proposal);
 }

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -703,7 +703,7 @@ SCENARIO("A Single Lane")
   {
     auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
 
-    WHEN("Negotiate moving A->D")
+    WHEN("Empty Schedule, p0(A->D)")
     {
       const auto time = std::chrono::steady_clock::now();
       rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a0_config.traits};
@@ -728,7 +728,7 @@ SCENARIO("A Single Lane")
       }
     }
 
-    WHEN("Negotiate moving A->D, D->B")
+    WHEN("Empty Schedule, p(A->D, D->B)")
     {
       const auto time = std::chrono::steady_clock::now();
       rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
@@ -767,7 +767,7 @@ SCENARIO("A Single Lane")
     }
 
     // TODO(BH): This test will not be valid until 'A->D, D->B is resolved.'
-    WHEN("Negotiate moving from A->D, C->B")
+    WHEN("Empty Schedule, p(A->D, C->B)")
     {
       const auto time = std::chrono::steady_clock::now();
       rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
@@ -805,6 +805,11 @@ SCENARIO("A Single Lane")
     // Identical entities
     auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
     auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
+  }
+
+  WHEN("Negotiate p0(A->B), p1(D->C)")
+  {
+
   }
 }
 

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -704,7 +704,7 @@ SCENARIO("A Single Lane")
   {
     auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
 
-    WHEN("Empty Schedule, p0(A->D)")
+    WHEN("Schedule:[], Negotiation:[p0(A->D)]")
     {
       const auto time = std::chrono::steady_clock::now();
       rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
@@ -729,7 +729,7 @@ SCENARIO("A Single Lane")
       }
     }
 
-    WHEN("Empty Schedule, p(A->D, D->B)")
+    WHEN("Schedule:[], Negotiation:[p(A->D, D->B)]")
     {
       const auto time = std::chrono::steady_clock::now();
       rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
@@ -768,7 +768,7 @@ SCENARIO("A Single Lane")
     }
 
     // TODO(BH): This test will not be valid until 'A->D, D->B is resolved.'
-    WHEN("Empty Schedule, p(A->D, C->B)")
+    WHEN("Schedule:[], Negotiation:[p(A->D, C->B)]")
     {
       const auto time = std::chrono::steady_clock::now();
       rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
@@ -807,7 +807,7 @@ SCENARIO("A Single Lane")
     auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
 
     // No conflicts expected
-    WHEN("Empty Schedule, p0(A->B), p1(D->C)")
+    WHEN("Schedule:[], Negotiation:[p0(A->B), p1(D->C)]")
     {
         const auto time = std::chrono::steady_clock::now();
         rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
@@ -845,7 +845,7 @@ SCENARIO("A Single Lane")
     }
 
     // Identical Start Points, expected failure
-    WHEN("Empty Schedule, p0(A->B), p1(A->C)")
+    WHEN("Schedule:[], Negotiation:[p0(A->B), p1(A->C)]")
     {
         const auto time = std::chrono::steady_clock::now();
         rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -2527,15 +2527,15 @@ SCENARIO("Fully connected graph of 10 vertices")
   EdgeMap edges;
 
   vertices.insert({"A", {{0.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"B", {{1.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"C", {{2.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"D", {{3.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"E", {{4.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"F", {{5.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"G", {{6.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"H", {{7.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"I", {{8.0, 0.0}, IsHoldingSpot(true)}});
-  vertices.insert({"J", {{9.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"B", {{3.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"C", {{6.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"D", {{9.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"E", {{12.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"F", {{15.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"G", {{18.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"H", {{21.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"I", {{24.0, 0.0}, IsHoldingSpot(true)}});
+  vertices.insert({"J", {{27.0, 0.0}, IsHoldingSpot(true)}});
 
   std::string vtxs = "ABCDEFGHIJ";
   for(char&v_source : vtxs)
@@ -2584,7 +2584,7 @@ SCENARIO("Fully connected graph of 10 vertices")
     }
   }
 
-  // TODO(BH): Valid proposal not found.
+  // Proposal not found.
   GIVEN("2 Participants")
   {
     auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
@@ -2594,6 +2594,7 @@ SCENARIO("Fully connected graph of 10 vertices")
     {
       const auto time = std::chrono::steady_clock::now();
       rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
 
       NegotiationRoom::Intentions intentions;
       intentions.insert({
@@ -2610,7 +2611,7 @@ SCENARIO("Fully connected graph of 10 vertices")
           NegotiationRoom::Intention{
             {time, vertex_id_to_idx["J"], 0.0},  // Time, Start Vertex, Initial Orientation
             vertex_id_to_idx["A"], // Goal Vertex
-            p0_planner_config // Planner Configuration ( Preset )
+            p1_planner_config // Planner Configuration ( Preset )
           }
       });
 

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -625,7 +625,7 @@ rmf_utils::optional<rmf_traffic::schedule::Itinerary> get_participant_itinerary(
 // Preset Robot Configurations
 // Agent a(i) generates participant p(i), instantiated in tests
 //==============================================================================
-// a1
+// a0
 const rmf_traffic::Profile a0_profile{
   rmf_traffic::geometry::make_final_convex<
     rmf_traffic::geometry::Circle>(1.0)
@@ -638,7 +638,7 @@ const rmf_traffic::agv::VehicleTraits a0_traits{
 };
 
 const rmf_traffic::schedule::ParticipantDescription a0_description = {
-  "p1",
+  "p0",
   "test_Negotiator",
   rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
   a0_profile
@@ -646,6 +646,29 @@ const rmf_traffic::schedule::ParticipantDescription a0_description = {
 
 const ParticipantConfig a0_config = {
  a0_profile, a0_traits, a0_description
+};
+
+// a1
+const rmf_traffic::Profile a1_profile{
+  rmf_traffic::geometry::make_final_convex<
+    rmf_traffic::geometry::Circle>(1.0)
+};
+
+const rmf_traffic::agv::VehicleTraits a1_traits{
+  {0.7, 0.3},
+  {1.0, 0.45},
+  a1_profile
+};
+
+const rmf_traffic::schedule::ParticipantDescription a1_description = {
+  "p1",
+  "test_Negotiator",
+  rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+  a1_profile
+};
+
+const ParticipantConfig a1_config = {
+ a1_profile, a1_traits, a1_description
 };
 
 // Tests
@@ -678,7 +701,7 @@ SCENARIO("A Single Lane")
 
   GIVEN("1 Participant")
   {
-    auto p1 = rmf_traffic::schedule::make_participant(a0_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
 
     WHEN("Negotiate moving A->D")
     {
@@ -687,7 +710,7 @@ SCENARIO("A Single Lane")
 
       NegotiationRoom::Intentions intentions;
       intentions.insert({
-          p1.id(),
+          p0.id(),
           NegotiationRoom::Intention{
             {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
             vertex_id_to_idx["D"], // Goal Vertex
@@ -700,34 +723,34 @@ SCENARIO("A Single Lane")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
+        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
       }
     }
 
     WHEN("Negotiate moving A->D, D->B")
     {
       const auto time = std::chrono::steady_clock::now();
-      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
 
       NegotiationRoom::Intentions intentions;
       // A -> D
       intentions.insert({
-          p1.id(),
+          p0.id(),
           NegotiationRoom::Intention{
             {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
             vertex_id_to_idx["D"], // Goal Vertex
-            p1_planner_config // Planner Configuration ( Preset )
+            p0_planner_config // Planner Configuration ( Preset )
           }
           });
 
       // D -> C
       intentions.insert({
-          p1.id(),
+          p0.id(),
           NegotiationRoom::Intention{
             {time + 10s, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
             vertex_id_to_idx["B"], // Goal Vertex
-            p1_planner_config // Planner Configuration ( Preset )
+            p0_planner_config // Planner Configuration ( Preset )
           }
           });
 
@@ -737,8 +760,8 @@ SCENARIO("A Single Lane")
         REQUIRE(proposal);
 
         // TODO(BH): Consecutive intentions don't seem to result in an 'extended' proposal
-        //auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        //REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["B"].first);
+        //auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
+        //REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["B"].first);
       }
 
     }
@@ -747,24 +770,24 @@ SCENARIO("A Single Lane")
     WHEN("Negotiate moving from A->D, C->B")
     {
       const auto time = std::chrono::steady_clock::now();
-      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
 
       NegotiationRoom::Intentions intentions;
       intentions.insert({
-          p1.id(),
+          p0.id(),
           NegotiationRoom::Intention{
             {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
             vertex_id_to_idx["D"], // Goal Vertex
-            p1_planner_config // Planner Configuration ( Preset )
+            p0_planner_config // Planner Configuration ( Preset )
           }
           });
 
       intentions.insert({
-          p1.id(),
+          p0.id(),
           NegotiationRoom::Intention{
             {time + 10s, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
             vertex_id_to_idx["B"], // Goal Vertex
-            p1_planner_config // Planner Configuration ( Preset )
+            p0_planner_config // Planner Configuration ( Preset )
           }
         });
 
@@ -775,6 +798,13 @@ SCENARIO("A Single Lane")
         //REQUIRE(proposal);
       //}
     }
+  }
+
+  GIVEN("2 Participants")
+  {
+    // Identical entities
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
   }
 }
 

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -607,7 +607,6 @@ generate_test_graph_data(std::string map_name, VertexMap vertices, EdgeMap edges
   return std::pair<rmf_traffic::agv::Graph, VertexIdtoIdxMap>(graph, vertex_id_to_idx);
 }
 
-// TODO(BH): Might consider changing Proposal to include a getter function?
 rmf_utils::optional<rmf_traffic::schedule::Itinerary> get_participant_itinerary(
     rmf_traffic::schedule::Negotiation::Proposal proposal, 
     rmf_traffic::schedule::ParticipantId participant_id)
@@ -681,7 +680,7 @@ SCENARIO("A Single Lane")
   VertexMap vertices;
   EdgeMap edges;
 
-  /*    single_lane_map
+  /*           single_lane_map
    *
    *          2        2        2
    *    A(p) <-> B(p) <-> C(p) <-> D(p)
@@ -703,6 +702,32 @@ SCENARIO("A Single Lane")
   GIVEN("1 Participant")
   {
     auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
+
+    WHEN("Schedule:[], Negotiation:[p0(A->A)]")
+    {
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
+      });
+
+      // TODO(BH): Segfault happens here
+      //THEN("Valid Proposal is found")
+      //{
+        //auto proposal = NegotiationRoom(database, intentions).solve();
+        //REQUIRE(proposal);
+
+        //auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
+        //REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["A"].first);
+      //}
+    }
 
     WHEN("Schedule:[], Negotiation:[p0(A->D)]")
     {
@@ -792,11 +817,11 @@ SCENARIO("A Single Lane")
           }
         });
 
-      // TODO(BH): What should we expect in such a situation? I expect this to be invalid.
+      // TODO(BH): What should we expect in such a situation where D->B is unintended?
       //THEN("Valid Proposal is found")
       //{
         //auto proposal = NegotiationRoom(database, intentions).solve();
-        //REQUIRE(proposal);
+        //REQUIRE_FALSE(proposal);
       //}
     }
   }
@@ -844,7 +869,7 @@ SCENARIO("A Single Lane")
       }
     }
 
-    // Identical Start Points, expected failure
+    // Identical Start Points, expect failure
     WHEN("Schedule:[], Negotiation:[p0(A->B), p1(A->C)]")
     {
         const auto time = std::chrono::steady_clock::now();
@@ -874,6 +899,167 @@ SCENARIO("A Single Lane")
       {
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE_FALSE(proposal);
+      }
+    }
+
+    // TODO(BH): This test is invalid until p0(A->A) is resolved.
+    WHEN("Schedule:[p0(A->C)], Negotiation:[p1(D->D)]")
+    {
+        const auto time = std::chrono::steady_clock::now();
+        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+
+        rmf_traffic::agv::Planner a0_planner{
+          p0_planner_config, 
+          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+        };
+
+        const auto a0_plan_0 = a0_planner.plan(
+            {time, vertex_id_to_idx["A"], 0.0},
+            {vertex_id_to_idx["C"]}
+            );
+
+        p0.set(a0_plan_0->get_itinerary());
+
+        NegotiationRoom::Intentions intentions;
+        
+        intentions.insert({
+            p1.id(),
+            NegotiationRoom::Intention{
+              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+              vertex_id_to_idx["D"], // Goal Vertex
+              p1_planner_config // Planner Configuration ( Preset )
+            }
+        });
+
+      //THEN("Valid Proposal is found.")
+      //{
+        //auto proposal = NegotiationRoom(database, intentions).solve();
+        //REQUIRE(proposal);
+        //print_proposal(*proposal);
+      //}
+    }
+
+    WHEN("Schedule:[p0(A->B)], Negotiation:[p1(D->C)]")
+    {
+        const auto time = std::chrono::steady_clock::now();
+        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+
+        rmf_traffic::agv::Planner a0_planner{
+          p0_planner_config, 
+          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+        };
+
+        const auto a0_plan_0 = a0_planner.plan(
+            {time, vertex_id_to_idx["A"], 0.0},
+            {vertex_id_to_idx["B"]}
+            );
+
+        p0.set(a0_plan_0->get_itinerary());
+
+        NegotiationRoom::Intentions intentions;
+        
+        intentions.insert({
+            p1.id(),
+            NegotiationRoom::Intention{
+              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+              vertex_id_to_idx["C"], // Goal Vertex
+              p1_planner_config // Planner Configuration ( Preset )
+            }
+        });
+
+      THEN("Valid Proposal is found.")
+      {
+        auto proposal = NegotiationRoom(database, intentions).solve();
+        REQUIRE(proposal);
+
+        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+      }
+    }
+    
+    WHEN("Schedule:[p0(A->C)], Negotiation:[p1(D->B)]")
+    {
+        const auto time = std::chrono::steady_clock::now();
+        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+
+        rmf_traffic::agv::Planner a0_planner{
+          p0_planner_config, 
+          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+        };
+
+        const auto a0_plan_0 = a0_planner.plan(
+            {time, vertex_id_to_idx["A"], 0.0},
+            {vertex_id_to_idx["C"]}
+            );
+
+        p0.set(a0_plan_0->get_itinerary());
+
+        NegotiationRoom::Intentions intentions;
+        
+        intentions.insert({
+            p1.id(),
+            NegotiationRoom::Intention{
+              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+              vertex_id_to_idx["B"], // Goal Vertex
+              p1_planner_config // Planner Configuration ( Preset )
+            }
+        });
+
+      THEN("No Proposal is found.")
+      {
+        auto proposal = NegotiationRoom(database, intentions).solve();
+        REQUIRE_FALSE(proposal);
+      }
+    }
+
+    WHEN("Schedule:[p0(A->C->A)], Negotiation:[p1(D->C)]")
+    {
+        const auto time = std::chrono::steady_clock::now();
+        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+
+        rmf_traffic::agv::Planner a0_planner{
+          p0_planner_config, 
+          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+        };
+
+        const auto a0_plan_0 = a0_planner.plan(
+            {time, vertex_id_to_idx["A"], 0.0},
+            {vertex_id_to_idx["C"]}
+            );
+
+        p0.set(a0_plan_0->get_itinerary());
+
+        const auto a0_plan_1 = a0_planner.plan(
+            {time + 8s, vertex_id_to_idx["C"], 0.0},
+            {vertex_id_to_idx["A"]}
+            );
+
+        p0.extend(a0_plan_1->get_itinerary());
+
+        NegotiationRoom::Intentions intentions;
+        
+        intentions.insert({
+            p1.id(),
+            NegotiationRoom::Intention{
+              // Setting the increment to 8s force collision will cause negotation to fail
+              {time + 9s, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+              vertex_id_to_idx["C"], // Goal Vertex
+              p1_planner_config // Planner Configuration ( Preset )
+            }
+        });
+
+      THEN("Valid Proposal is found.")
+      {
+        auto proposal = NegotiationRoom(database, intentions).solve();
+        REQUIRE(proposal);
+        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+
+        print_proposal(*proposal);
       }
     }
   }


### PR DESCRIPTION
This PR proposes some initial tests written to test the Negotiation API of rmf_core in common traffic scenarios. :traffic_light:  I'm not sure which branch might be the best to propose merging for now, so i'm targeting the `develop` branch for cleaner diffs.

Do note the following:
1) Proposed tests are appended [from this line onwards](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L549).

2) Helper functions are defined [here](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L575). They are aimed to make the graph definitions in each test more readable. If preferred, I can move them to a separate header file. 

3) Participant characteristics are defined [here](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L624). Each "mobile robot" is labelled a0,a1,... and the corresponding participant manifest is p0, p1, ...

4) In each scenario i define a Graph for testing. For [example](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L706). Each vertex is labelled by a capital letter, and each edge is labelled [source vertex][sink vertex].

5) Each test instance sets up a Negotiation scenario described as a string, for example ["Schedule:[], Negotiation:[p0(A->D)]"](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L729). This reads: 'the schedule is empty, and we are negotiating participant p0 moving from vertex A to D'.

6) Each test outcome is verified by whether the proposal solver outcome is expected, and whether the participants are indeed found at the destinations where their negotiations prescribe them to be. The second verification step might not be necessary, and can be removed, if it is redundant.

The following are links to tests of interest. Note that many of them are repeated as they might be stemming from the same issue. I'm happy to explain what i'm trying to do in each test, as it might not be clear from the code.

[1](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L943) I am trying to do an impossible task of getting two participants to drive past each other on a single lane. This should fail. However, a proposal is found as one of the plans is directly placed in the schedule, thus after that participant completes its plan it "disappears". I'm wondering if this should be the case.

[2](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L1061) I am trying to encourage p0 to move to B, which is a holding spot, to wait for p1 to move out of the (one lane) way. This represents congestion on one-lane traffic, where some areas should not be blocked. However, it seems p0 remains in A, but spins 360 degrees in order to not be "holding" in that position. I wonder if this is "cheating"?

[3, similar to 2](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L1102) 

[4](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L1411) I am trying to get p0 to hide away at E to let p1 pass before resuming. This tests one way of getting robots out of the way of higher priority traffic. Interestingly, testing each of these "diversionary actions" (going to E, resuming from E) by p0 pass, but requiring the NegotiationRoom to string both together fails.

[5, similar to 4](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L1609)

[6](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L1731) Here I try to test another way of getting robots out of the way, replacing an alcove with a single lane road. Interestingly, when p1 moves from C, a proposal is found. But starting p1 further away, from D, fails the test.

[7, similar to 6](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L1850)

[8](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L2054) Here I test a scenario with 3 participants in a box loop, where each vertex has its own alcove. This aims to emulate high traffic. A solution is found but takes quite long. This raises the question of what sort of timeout should be implemented, if any.

[9](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L2469) This map aims to represent parking spots where multiple robots often funnel into a bottleneck as robots are deployed out / return. With three participants, 2 deploying and 1 returning, the solver doesn't terminate on my laptop.  (waited about 3 minutes)

[10](https://github.com/osrf/rmf_core/blob/test/multi_negotiation/rmf_traffic/test/unit/agv/test_Negotiator.cpp#L2587) I am trying to get the two participants to "swap positions" in this graph. This possibly unrealistic graph is fully connected. Due to the fully connected nature of the graph, a proposal like p0(A->J), p1(J->B, B->A) could work, but the solver fails.

There is a lot of copied code in these tests, so do bear with me if there are any mistakes in the code. If the tests are not clear / incorrectly used / flat wrong, do let me know. :bowing_man: 