### PR TITLE
Improve fleet adapter

### DIFF
--- a/rmf_fleet_adapter/src/full_control/DispenseAction.cpp
+++ b/rmf_fleet_adapter/src/full_control/DispenseAction.cpp
@@ -127,7 +127,7 @@ public:
     }
 
     _last_reported_wait_time = now + _duration_estimate;
-    _context->schedule.push_routes({calculate_itinerary()}, [](){});
+    _context->schedule.push_routes({calculate_itinerary()});
   }
 
   void finish()
@@ -175,7 +175,7 @@ public:
       }
     }
 
-    responder.submit({route}, [](){});
+    responder.submit({route});
   }
 
   Status get_status() const final

--- a/rmf_fleet_adapter/src/full_control/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/full_control/FleetAdapterNode.cpp
@@ -148,13 +148,14 @@ void FleetAdapterNode::RobotContext::next_task()
   // TODO(MXG): Report the current task complete before clearing it
   if (!_task_queue.empty())
   {
-    std::cout << "Starting the next task" << std::endl;
+    std::cout << "Starting the next task for [" << _name << "]" << std::endl;
     _task = std::move(_task_queue.front());
     _task_queue.erase(_task_queue.begin());
     _task->next();
     return;
   }
 
+  std::cout << " ======== Task complete for [" << _name << "]" << std::endl;
   _task = nullptr;
 
   // TODO(MXG): If the task queue is empty, have the robot move back to its
@@ -227,7 +228,7 @@ void FleetAdapterNode::RobotContext::respond(
     std::cerr << "[FleetAdatperNode::RobotContext::respond] "
               << "Responding to a negotiation while not performing a task"
               << std::endl;
-    responder.submit({}, [](){});
+    responder.submit({});
   }
 }
 

--- a/rmf_fleet_adapter/src/full_control/MoveAction.cpp
+++ b/rmf_fleet_adapter/src/full_control/MoveAction.cpp
@@ -290,8 +290,8 @@ public:
     {
       RCLCPP_WARN(
             _node->get_logger(),
-            "Robot [" + _context->robot_name() + "] is stuck! We will try to "
-            "find a path again soon.");
+            "Robot [" + _context->robot_name() + "] is stuck! We will submit a "
+            "conflict to open a negotiation.");
 
       return plans;
     }

--- a/rmf_fleet_adapter/src/full_control/Tasks.cpp
+++ b/rmf_fleet_adapter/src/full_control/Tasks.cpp
@@ -114,7 +114,7 @@ public:
             _node->get_logger(),
             "No action for this task [" + id() + "] to respond with. This "
             "might indicate a bug!");
-      responder.submit({}, [](){});
+      responder.submit({});
       return;
     }
 

--- a/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
@@ -137,7 +137,7 @@ void FleetAdapterNode::push_route(
 
   it->second->cumulative_delay = std::chrono::seconds(0);
   it->second->route = make_route(state, _traits, it->second->sitting);
-  it->second->schedule->push_routes({*it->second->route}, [](){});
+  it->second->schedule->push_routes({*it->second->route});
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.cpp
@@ -39,9 +39,7 @@ ScheduleManager::ScheduleManager(rclcpp::Node& node,
 }
 
 //==============================================================================
-void ScheduleManager::push_routes(
-    const std::vector<rmf_traffic::Route>& routes,
-    std::function<void()> approval_callback)
+void ScheduleManager::push_routes(const std::vector<rmf_traffic::Route>& routes)
 {
   // TODO(MXG): Be smarter here. If there are no trajectories then erase the
   // current schedule? Or have the robot stand in place?
@@ -61,12 +59,10 @@ void ScheduleManager::push_routes(
   if (valid_routes.empty())
   {
     _participant.clear();
-    approval_callback();
     return;
   }
 
   _participant.set(std::move(valid_routes));
-  approval_callback();
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.hpp
@@ -44,9 +44,7 @@ public:
 
   using TrajectorySet = std::vector<rmf_traffic::Trajectory>;
 
-  void push_routes(
-      const std::vector<rmf_traffic::Route>& routes,
-      std::function<void()> approval_callback);
+  void push_routes(const std::vector<rmf_traffic::Route>& routes);
 
   void push_delay(
       const rmf_traffic::Duration duration,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/make_trajectory.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/make_trajectory.cpp
@@ -65,6 +65,20 @@ rmf_traffic::Trajectory make_trajectory(
 }
 
 //==============================================================================
+rmf_traffic::Trajectory make_trajectory(
+    const rmf_traffic::Time start_time,
+    const std::vector<rmf_fleet_msgs::msg::Location>& path,
+    const rmf_traffic::agv::VehicleTraits& traits)
+{
+  std::vector<Eigen::Vector3d> positions;
+  for (const auto& location : path)
+    positions.push_back({location.x, location.y, location.yaw});
+
+  return rmf_traffic::agv::Interpolate::positions(
+        traits, start_time, positions);
+}
+
+//==============================================================================
 rmf_traffic::Route make_route(
     const rmf_fleet_msgs::msg::RobotState& state,
     const rmf_traffic::agv::VehicleTraits& traits,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/make_trajectory.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/make_trajectory.hpp
@@ -31,6 +31,12 @@ rmf_traffic::Trajectory make_trajectory(
     bool& is_sitting);
 
 //==============================================================================
+rmf_traffic::Trajectory make_trajectory(
+    const rmf_traffic::Time start_time,
+    const std::vector<rmf_fleet_msgs::msg::Location>& path,
+    const rmf_traffic::agv::VehicleTraits& traits);
+
+//==============================================================================
 rmf_traffic::Route make_route(
     const rmf_fleet_msgs::msg::RobotState& state,
     const rmf_traffic::agv::VehicleTraits& traits,

--- a/rmf_fleet_msgs/msg/RobotMode.msg
+++ b/rmf_fleet_msgs/msg/RobotMode.msg
@@ -7,3 +7,7 @@ uint32 MODE_WAITING=4
 uint32 MODE_EMERGENCY=5
 uint32 MODE_GOING_HOME=6
 uint32 MODE_DOCKING=7
+
+# Use this when a command received from the fleet adapter
+# has a problem and needs to be recomputed.
+uint32 MODE_ADAPTER_ERROR=8

--- a/rmf_traffic/include/rmf_traffic/agv/Negotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Negotiator.hpp
@@ -77,8 +77,7 @@ public:
       const Options& options = Options());
 
   // Documentation inherited
-  void respond(
-      std::shared_ptr<const schedule::Negotiation::Table> table,
+  void respond(std::shared_ptr<const schedule::Negotiation::Table> table,
       const Responder& responder,
       const bool* interrupt_flag = nullptr) final;
 

--- a/rmf_traffic/include/rmf_traffic/schedule/Database.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Database.hpp
@@ -186,6 +186,11 @@ public:
   /// call this function for any other purpose.
   void set_current_time(Time time);
 
+  /// Get the curret itinerary version for the specified participant.
+  //
+  // TODO(MXG): This function needs unit testing
+  ItineraryVersion itinerary_version(ParticipantId participant) const;
+
   class Implementation;
   class Debug;
 private:

--- a/rmf_traffic/include/rmf_traffic/schedule/Negotiation.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Negotiation.hpp
@@ -139,11 +139,16 @@ public:
     /// Reject the proposals that underlie this Negotiation::Table. This
     /// indicates that the underlying proposals are infeasible for the
     /// Participant of this Table to accommodate.
-    //
-    // TODO(MXG): Versioning should be added to rejections as well as
-    // submissions. In fact, version numbers should be added to table sequence
-    // codes as well for maximum consistency.
-    void reject();
+    ///
+    /// \param[in] version
+    ///   A version number assigned to the submission. If this is equal to or
+    ///   greater than the last version number given, then this table will be
+    ///   put into a rejected state until a higher proposal version is
+    ///   submitted.
+    void reject(Version version);
+
+    /// Returns true if a proposal put on this table has been rejected.
+    bool rejected() const;
 
     /// If by_participant can respond to this table, then this will return a
     /// TablePtr that by_participant can submit a proposal to.

--- a/rmf_traffic/include/rmf_traffic/schedule/Negotiation.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Negotiation.hpp
@@ -161,6 +161,12 @@ public:
     // const-qualified parent()
     ConstTablePtr parent() const;
 
+    /// Get the children of this Table if any children exist.
+    std::vector<TablePtr> children();
+
+    // const-qualified children()
+    std::vector<ConstTablePtr> children() const;
+
     /// Return true if the negotiation is ongoing (i.e. the Negotiation instance
     /// that created this table is still alive). When the Negotiation instance
     /// that this Table belongs to has destructed, this will begin to return

--- a/rmf_traffic/include/rmf_traffic/schedule/Negotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Negotiator.hpp
@@ -37,6 +37,9 @@ public:
   {
   public:
 
+    using ItineraryVersion = rmf_traffic::schedule::ItineraryVersion;
+    using UpdateVersion = rmf_utils::optional<ItineraryVersion>;
+
     /// The negotiator will call this function when it has an itinerary to
     /// submit in response to a negotiation.
     ///
@@ -45,10 +48,13 @@ public:
     ///
     /// \param[in] approval_callback
     ///   This callback will get triggered if this submission gets approved.
-    ///   Pass in a nullptr if a callback is not necessary.
+    ///   The return value of the callback should be the itinerary version of
+    ///   the participant update that will follow the resolution of this
+    ///   negotiation (or a nullopt if no update will be performed). Pass in a
+    ///   nullptr if an approval callback is not necessary.
     virtual void submit(
         std::vector<Route> itinerary,
-        std::function<void()> approval_callback = nullptr) const = 0;
+        std::function<UpdateVersion()> approval_callback = nullptr) const = 0;
 
     /// The negotiator will call this function if it has decided to reject an
     /// attempt to negotiate.
@@ -105,7 +111,7 @@ public:
   // NOTE: approval_callback does not get used
   void submit(
       std::vector<Route> itinerary,
-      std::function<void()> approval_callback = nullptr) const final;
+      std::function<UpdateVersion()> approval_callback=nullptr) const final;
 
   // Documentation inherited
   void reject() const final;

--- a/rmf_traffic/include/rmf_traffic/schedule/Participant.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Participant.hpp
@@ -81,12 +81,17 @@ public:
   /// Get the current itinerary of the participant.
   //
   // TODO(MXG): The implementation of this class could be simpler and more
-  // efficient if we did not provide this function. But it would might also hurt
+  // efficient if we did not provide this function. But not having it might hurt
   // usability if end users want some verification or reflection of the changes
   // that they are making to the schedule. Perhaps we can create a second class
   // that extends the functionality of this one, where it will both make the
   // changes to the schedule and reflect the changes locally.
   const Writer::Input& itinerary() const;
+
+  /// Get the current itinerary version for this participant.
+  //
+  // TODO(MXG): This function needs to be unit tested.
+  ItineraryVersion version() const;
 
   /// Get the description of this participant.
   const ParticipantDescription& description() const;

--- a/rmf_traffic/src/rmf_traffic/schedule/InconsistencyTracker.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/InconsistencyTracker.cpp
@@ -17,7 +17,8 @@
 
 #include "InconsistencyTracker.hpp"
 #include "InconsistenciesInternal.hpp"
-#include "Modular.hpp"
+
+#include <rmf_utils/Modular.hpp>
 
 namespace rmf_traffic {
 namespace schedule {
@@ -75,7 +76,7 @@ auto InconsistencyTracker::check(
   using Range = Inconsistencies::Ranges::Range;
 
   // Check if this is the lastest itinerary version for this trajectory
-  if (modular(_last_known_version).less_than(version))
+  if (rmf_utils::modular(_last_known_version).less_than(version))
     _last_known_version = version;
 
   if (_ranges.empty())
@@ -98,7 +99,7 @@ auto InconsistencyTracker::check(
 
     // This should have been checked earlier by the caller, but we will assert
     // it here just to make sure.
-    assert(!modular(version).less_than(_expected_version));
+    assert(!rmf_utils::modular(version).less_than(_expected_version));
 
     // This is the only inconsistency, so it should be easy to fill in the set:
     _ranges.insert(Range{_expected_version, version-1});
@@ -197,7 +198,7 @@ auto InconsistencyTracker::check(
         const ItineraryVersion lower = (++_changes.rbegin())->first + 1;
         const ItineraryVersion upper = version - 1;
 
-        if (modular(lower).less_than_or_equal(upper))
+        if (rmf_utils::modular(lower).less_than_or_equal(upper))
         {
           // Less than:
           // x x o x x x o _ _ _
@@ -300,7 +301,7 @@ auto InconsistencyTracker::check(
           // The lower end of a range must be less than or equal to the upper
           // end of the range. We already confirmed that it is not equal, so it
           // must be less.
-          assert(modular(lower).less_than(version));
+          assert(rmf_utils::modular(lower).less_than(version));
 
           _ranges.insert(range_it, Range{lower, version-1});
           _ranges.erase(range_it);
@@ -310,7 +311,7 @@ auto InconsistencyTracker::check(
       }
       else
       {
-        assert(modular(version).less_than(upper));
+        assert(rmf_utils::modular(version).less_than(upper));
         if (lower == version)
         {
           // x x o x x x o
@@ -328,7 +329,7 @@ auto InconsistencyTracker::check(
           // be a change that was already received (so we should have exited
           // this function already) or the call to ranges.lower_bound(version)
           // should have returned a different iterator.
-          assert(modular(lower).less_than(version));
+          assert(rmf_utils::modular(lower).less_than(version));
 
           // x x o x x x o
           //         ^

--- a/rmf_traffic/src/rmf_traffic/schedule/InconsistencyTracker.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/InconsistencyTracker.hpp
@@ -18,13 +18,12 @@
 #ifndef SRC__RMF_TRAFFIC__SCHEDULE__INCONSISTENCYTRACKER_HPP
 #define SRC__RMF_TRAFFIC__SCHEDULE__INCONSISTENCYTRACKER_HPP
 
-#include "Modular.hpp"
-
 #include <rmf_traffic/schedule/Inconsistencies.hpp>
 #include <rmf_traffic/schedule/Itinerary.hpp>
 #include <rmf_traffic/schedule/Participant.hpp>
 
 #include <rmf_utils/optional.hpp>
+#include <rmf_utils/Modular.hpp>
 
 #include <set>
 #include <map>
@@ -40,7 +39,7 @@ struct RangeLess
 
   bool operator()(const Range& lhs, const Range& rhs)
   {
-    return modular(lhs.upper).less_than(rhs.upper);
+    return rmf_utils::modular(lhs.upper).less_than(rhs.upper);
   }
 };
 
@@ -119,6 +118,11 @@ public:
   ItineraryVersion expected_version() const
   {
     return _expected_version;
+  }
+
+  ItineraryVersion last_known_version() const
+  {
+    return _last_known_version;
   }
 
 private:

--- a/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
@@ -17,9 +17,10 @@
 
 #include <rmf_traffic/schedule/Negotiation.hpp>
 
-#include "Modular.hpp"
 #include "Timeline.hpp"
 #include "ViewerInternal.hpp"
+
+#include <rmf_utils/Modular.hpp>
 
 namespace rmf_traffic {
 namespace schedule {
@@ -124,7 +125,7 @@ public:
   const ParticipantId participant;
   const std::size_t depth;
   rmf_utils::optional<Itinerary> itinerary;
-  Version version = std::numeric_limits<Version>::max();
+  rmf_utils::optional<Version> version = rmf_utils::nullopt;
   bool rejected = false;
   TableMap descendants;
 
@@ -186,13 +187,17 @@ public:
     const auto it = std::remove_if(unsubmitted.begin(), unsubmitted.end(),
                    [&](const ParticipantId p) { return p == participant; });
     assert(it != unsubmitted.end());
-    unsubmitted.erase(it);
+    unsubmitted.erase(it, unsubmitted.end());
+
+    assert(std::find(unsubmitted.begin(), unsubmitted.end(), participant) == unsubmitted.end());
   }
 
   Viewer::View query(const Query::Spacetime& spacetime) const;
 
   void add_participant(const ParticipantId new_participant)
   {
+    assert(std::find(unsubmitted.begin(), unsubmitted.end(), new_participant) == unsubmitted.end());
+    assert(std::find(sequence.begin(), sequence.end(), new_participant) == sequence.end());
     unsubmitted.push_back(new_participant);
 
     if (itinerary)
@@ -207,6 +212,8 @@ public:
   {
     assert(itinerary);
     assert(proposal.size() == depth);
+
+    assert(std::find(unsubmitted.begin(), unsubmitted.end(), participant) == unsubmitted.end());
 
     std::unordered_map<ParticipantId, Table> descendants;
     for (const auto u : unsubmitted)
@@ -252,8 +259,10 @@ public:
       std::vector<Route> new_itinerary,
       const Version new_version)
   {
-    if (!modular(version).less_than(new_version))
+    if (version && rmf_utils::modular(new_version).less_than_or_equal(*version))
       return false;
+
+    version = new_version;
 
     bool formerly_successful = false;
     const auto negotiation_data = weak_negotiation_data.lock();
@@ -272,7 +281,6 @@ public:
 
     const bool had_itinerary = itinerary.has_value();
 
-    version = new_version;
     itinerary = convert_itinerary(new_itinerary);
     rejected = false;
 
@@ -300,8 +308,13 @@ public:
     return true;
   }
 
-  void reject()
+  void reject(const Version rejected_version)
   {
+    if (version && rmf_utils::modular(rejected_version).less_than(*version))
+      return;
+
+    version = rejected_version;
+
     if (rejected)
       return;
 
@@ -315,8 +328,13 @@ public:
       negotiation_data->num_terminated_tables -= 1;
     }
 
+    if (itinerary)
+    {
+      itinerary = rmf_utils::nullopt;
+      proposal.pop_back();
+    }
+
     rejected = true;
-    itinerary = rmf_utils::nullopt;
     clear_descendants();
 
     if (negotiation_data)
@@ -511,6 +529,7 @@ public:
       data->num_terminated_tables += termination_factor(rejected->depth, N);
 
     std::vector<TableMap*> queue;
+    std::vector<Table::Implementation*> current_tables;
     queue.push_back(&tables);
     while (!queue.empty())
     {
@@ -520,11 +539,23 @@ public:
       for (auto& element : *next)
       {
         const auto& entry = element.second;
-        Table::Implementation::get(*entry).add_participant(new_participant);
-
+        current_tables.push_back(&Table::Implementation::get(*entry));
         queue.push_back(&Table::Implementation::get(*entry).descendants);
       }
     }
+
+    // We collect all the current tables before adding the new participant to
+    // any of them, because if we try to traverse the tables and add the
+    // participant at the same time, we might accidentally traverse over tables
+    // that are being freshly created for the new participant.
+    for (auto* t : current_tables)
+      t->add_participant(new_participant);
+
+    tables[new_participant] = Table::Implementation::make_root(
+          *viewer, data, new_participant,
+          std::vector<ParticipantId>(
+            data->participants.begin(),
+            data->participants.end()));
   }
 };
 
@@ -634,8 +665,8 @@ const Itinerary* Negotiation::Table::submission() const
 //==============================================================================
 const Version* Negotiation::Table::version() const
 {
-  if (_pimpl->itinerary)
-    return &_pimpl->version;
+  if (_pimpl->version)
+    return &(*_pimpl->version);
 
   return nullptr;
 }
@@ -667,9 +698,15 @@ bool Negotiation::Table::submit(
 }
 
 //==============================================================================
-void Negotiation::Table::reject()
+void Negotiation::Table::reject(const Version version)
 {
-  _pimpl->reject();
+  _pimpl->reject(version);
+}
+
+//==============================================================================
+bool Negotiation::Table::rejected() const
+{
+  return _pimpl->rejected;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
@@ -702,6 +702,24 @@ auto Negotiation::Table::parent() const -> ConstTablePtr
 }
 
 //==============================================================================
+auto Negotiation::Table::children() -> std::vector<TablePtr>
+{
+  std::vector<TablePtr> children_;
+  for (const auto& c : _pimpl->descendants)
+    children_.push_back(c.second);
+  return children_;
+}
+
+//==============================================================================
+auto Negotiation::Table::children() const -> std::vector<ConstTablePtr>
+{
+  std::vector<ConstTablePtr> children_;
+  for (const auto& c : _pimpl->descendants)
+    children_.push_back(c.second);
+  return children_;
+}
+
+//==============================================================================
 bool Negotiation::Table::ongoing() const
 {
   return static_cast<bool>(_pimpl->weak_negotiation_data.lock());

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -57,7 +57,7 @@ void Participant::Implementation::retransmit(
 {
   for (const auto& range : ranges)
   {
-    assert(modular(range.lower).less_than_or_equal(range.upper));
+    assert(rmf_utils::modular(range.lower).less_than_or_equal(range.upper));
 
     // We use lower_bound because it is possible that some of this range has
     // been truncated because of a nullifying change. Therefore we should accept
@@ -302,6 +302,12 @@ RouteId Participant::last_route_id() const
 const Writer::Input& Participant::itinerary() const
 {
   return _pimpl->_current_itinerary;
+}
+
+//==============================================================================
+ItineraryVersion Participant::version() const
+{
+  return _pimpl->_version;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/ParticipantInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/ParticipantInternal.hpp
@@ -18,9 +18,9 @@
 #ifndef SRC__RMF_TRAFFIC__SCHEDULE__PARTICIPANTINTERNAL_HPP
 #define SRC__RMF_TRAFFIC__SCHEDULE__PARTICIPANTINTERNAL_HPP
 
-#include "Modular.hpp"
-
 #include <rmf_traffic/schedule/Participant.hpp>
+
+#include <rmf_utils/Modular.hpp>
 
 #include <map>
 
@@ -64,7 +64,7 @@ private:
   std::unique_ptr<RectificationRequester> _rectification;
 
   using ChangeHistory =
-      std::map<RouteId, std::function<void()>, ModularLess<RouteId>>;
+      std::map<RouteId, std::function<void()>, rmf_utils::ModularLess<RouteId>>;
 
   Writer::Input _current_itinerary;
 

--- a/rmf_traffic/test/regression/regress_Negotiation.cpp
+++ b/rmf_traffic/test/regression/regress_Negotiation.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_traffic/schedule/Database.hpp>
+#include <rmf_traffic/schedule/Negotiation.hpp>
+#include <rmf_traffic/schedule/Negotiator.hpp>
+
+#include <rmf_utils/catch.hpp>
+
+#include <iostream>
+
+namespace {
+//==============================================================================
+struct MockNegotiator : public rmf_traffic::schedule::Negotiator
+{
+  virtual void respond(
+      std::shared_ptr<const rmf_traffic::schedule::Negotiation::Table>,
+      const Responder& responder,
+      const bool* = nullptr) final
+  {
+    if (_submit)
+      responder.submit({});
+    else
+      responder.reject();
+  }
+
+  MockNegotiator& submit()
+  {
+    _submit = true;
+    return *this;
+  }
+
+  MockNegotiator& reject()
+  {
+    _submit = false;
+    return *this;
+  }
+
+  bool _submit = true;
+};
+
+//==============================================================================
+struct Table
+{
+  std::vector<rmf_traffic::schedule::ParticipantId> to_accommodate;
+  rmf_traffic::schedule::ParticipantId for_participant;
+};
+
+//==============================================================================
+void apply_submissions(
+    const std::shared_ptr<rmf_traffic::schedule::Negotiation>& negotiation,
+    const std::vector<Table>& submitted)
+{
+  using Responder = rmf_traffic::schedule::SimpleResponder;
+  for (const auto& table : submitted)
+  {
+    MockNegotiator().submit().respond(
+          negotiation->table(table.for_participant, table.to_accommodate),
+          Responder(negotiation, table.for_participant, table.to_accommodate));
+  }
+}
+
+//==============================================================================
+void apply_rejection(
+    const std::shared_ptr<rmf_traffic::schedule::Negotiation>& negotiation,
+    const std::vector<Table>& rejected)
+{
+  using Responder = rmf_traffic::schedule::SimpleResponder;
+  for (const auto& table : rejected)
+  {
+    MockNegotiator().reject().respond(
+          negotiation->table(table.for_participant, table.to_accommodate),
+          Responder(negotiation, table.for_participant, table.to_accommodate));
+  }
+}
+
+} // anonymous namespace
+
+//==============================================================================
+SCENARIO("Identify a failed negotiation")
+{
+  // This situation emerged during testing and revealed some bugs that can occur
+  // while adding participants.
+  rmf_traffic::schedule::Database database;
+  auto negotiation =
+      std::make_shared<rmf_traffic::schedule::Negotiation>(
+        database, std::vector<rmf_traffic::schedule::ParticipantId>{0, 2});
+
+  std::vector<Table> submitted =
+  {
+    {{}, 2}, {{}, 0}, {{0}, 2}, {{2}, 0}
+  };
+
+  apply_submissions(negotiation, submitted);
+
+  CHECK(negotiation->complete());
+  CHECK(negotiation->ready());
+
+  negotiation->add_participant(1);
+
+  CHECK_FALSE(negotiation->complete());
+  CHECK_FALSE(negotiation->ready());
+
+  submitted =
+  {
+    {{}, 1}, {{2}, 1}
+  };
+
+  apply_submissions(negotiation, submitted);
+
+  CHECK_FALSE(negotiation->table(1, {2})->respond(1));
+
+  std::vector<Table> rejected =
+  {
+    {{2}, 1}, {{2}, 0}, {{}, 1}, {{2}, 1}, {{0, 2}, 1}, {{0}, 1}
+  };
+
+  apply_rejection(negotiation, rejected);
+
+  CHECK(negotiation->complete());
+}
+
+//==============================================================================
+SCENARIO("Submit after a rejection")
+{
+  class MockResponder : public rmf_traffic::schedule::Negotiator::Responder
+  {
+  public:
+
+    rmf_traffic::schedule::Negotiation::TablePtr table;
+    bool* accepted;
+    rmf_utils::optional<rmf_traffic::schedule::Version>* version;
+
+    MockResponder(
+          rmf_traffic::schedule::Negotiation::TablePtr table_,
+          bool* accepted_,
+          rmf_utils::optional<rmf_traffic::schedule::Version>* version_)
+      : table(table_),
+        accepted(accepted_),
+        version(version_)
+    {
+      // Do nothing
+    }
+
+    void submit(
+          std::vector<rmf_traffic::Route> itinerary,
+          std::function<UpdateVersion()>) const final
+    {
+      *version = table->version()? *table->version() + 1 : 0;
+      *accepted = table->submit(std::move(itinerary), **version);
+    }
+
+    void reject() const
+    {
+      const auto parent = table->parent();
+      if (parent)
+        parent->reject(*parent->version());
+      else
+        table->reject(table->version()? *table->version() : 0);
+    }
+
+  };
+
+  rmf_traffic::schedule::Database database;
+  auto negotiation =
+      std::make_shared<rmf_traffic::schedule::Negotiation>(
+        database, std::vector<rmf_traffic::schedule::ParticipantId>{0, 1});
+
+  bool accepted = false;
+  rmf_utils::optional<rmf_traffic::schedule::Version> version;
+
+  MockResponder responder(negotiation->table(0, {}), &accepted, &version);
+  MockNegotiator().submit().respond(responder.table, responder);
+
+  CHECK(accepted);
+  REQUIRE(version);
+  CHECK(*version == 0);
+  const auto last_version = *version;
+
+  accepted = false;
+  version = rmf_utils::nullopt;
+  MockResponder child_responder(negotiation->table(1, {0}), &accepted, &version);
+  MockNegotiator().reject().respond(child_responder.table, child_responder);
+
+  CHECK_FALSE(version);
+  CHECK_FALSE(accepted);
+
+  accepted = false;
+  version = rmf_utils::nullopt;
+  MockResponder reresponder(responder.table, &accepted, &version);
+  MockNegotiator().submit().respond(reresponder.table, reresponder);
+
+  CHECK(accepted);
+  REQUIRE(version);
+  CHECK(last_version < *version);
+  CHECK(*version == 1);
+}

--- a/rmf_traffic/test/unit/schedule/test_Modular.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Modular.cpp
@@ -15,42 +15,44 @@
  *
 */
 
-#include "src/rmf_traffic/schedule/Modular.hpp"
+#include <rmf_utils/Modular.hpp>
 
 #include <rmf_utils/catch.hpp>
 
 TEMPLATE_TEST_CASE("Test Modular", "[modular]", uint8_t, uint16_t, uint64_t)
 {
+  // TODO(MXG): This test should be moved to rmf_utils
+
   const auto max_value = std::numeric_limits<TestType>::max();
   const auto min_value = std::numeric_limits<TestType>::min();
 
   // Here we check less_than() returns false when lhs = rhs
-  CHECK_FALSE(rmf_traffic::schedule::modular(max_value).less_than(max_value));
-  CHECK_FALSE(rmf_traffic::schedule::modular(min_value).less_than(min_value));
+  CHECK_FALSE(rmf_utils::modular(max_value).less_than(max_value));
+  CHECK_FALSE(rmf_utils::modular(min_value).less_than(min_value));
 
   // Here we check less_than_or_equal() returns true when lhs = rhs
-  CHECK(rmf_traffic::schedule::modular(max_value).less_than_or_equal(max_value));
-  CHECK(rmf_traffic::schedule::modular(min_value).less_than_or_equal(min_value));
+  CHECK(rmf_utils::modular(max_value).less_than_or_equal(max_value));
+  CHECK(rmf_utils::modular(min_value).less_than_or_equal(min_value));
 
   // Here we check max_value-1 < max_value < min_value < min_value+1
-  CHECK(rmf_traffic::schedule::modular(max_value-1).less_than(max_value));
-  CHECK(rmf_traffic::schedule::modular(max_value).less_than(min_value));
-  CHECK(rmf_traffic::schedule::modular(min_value).less_than(min_value+1));
+  CHECK(rmf_utils::modular(max_value-1).less_than(max_value));
+  CHECK(rmf_utils::modular(max_value).less_than(min_value));
+  CHECK(rmf_utils::modular(min_value).less_than(min_value+1));
 
   // Check the noncommutativity
-  CHECK_FALSE(rmf_traffic::schedule::modular(max_value).less_than(max_value-1));
-  CHECK_FALSE(rmf_traffic::schedule::modular(min_value).less_than(max_value));
-  CHECK_FALSE(rmf_traffic::schedule::modular(min_value+1).less_than(min_value));
+  CHECK_FALSE(rmf_utils::modular(max_value).less_than(max_value-1));
+  CHECK_FALSE(rmf_utils::modular(min_value).less_than(max_value));
+  CHECK_FALSE(rmf_utils::modular(min_value+1).less_than(min_value));
 
   // Here we check lhs < rhs when basis < lhs
-  CHECK(rmf_traffic::schedule::modular(max_value-2).less_than(max_value-1, max_value));
-  CHECK(rmf_traffic::schedule::modular(max_value).less_than(min_value, min_value+1));
+  CHECK(rmf_utils::modular(max_value-2).less_than(max_value-1, max_value));
+  CHECK(rmf_utils::modular(max_value).less_than(min_value, min_value+1));
 
   // Check the noncommutativity
-  CHECK_FALSE(rmf_traffic::schedule::modular(max_value-2).less_than(max_value, max_value-1));
-  CHECK_FALSE(rmf_traffic::schedule::modular(max_value).less_than(min_value+1, min_value));
+  CHECK_FALSE(rmf_utils::modular(max_value-2).less_than(max_value, max_value-1));
+  CHECK_FALSE(rmf_utils::modular(max_value).less_than(min_value+1, min_value));
 
   // Here we check lhs = rhs when basis < lhs
-  CHECK(rmf_traffic::schedule::modular(max_value-1).less_than_or_equal(max_value, max_value));
-  CHECK(rmf_traffic::schedule::modular(max_value).less_than_or_equal(min_value, min_value));
+  CHECK(rmf_utils::modular(max_value-1).less_than_or_equal(max_value, max_value));
+  CHECK(rmf_utils::modular(max_value).less_than_or_equal(min_value, min_value));
 }

--- a/rmf_traffic_msgs/CMakeLists.txt
+++ b/rmf_traffic_msgs/CMakeLists.txt
@@ -38,6 +38,7 @@ set(msg_files
   "msg/ScheduleConflictAck.msg"
   "msg/ScheduleConflictConclusion.msg"
   "msg/ScheduleConflictNotice.msg"
+  "msg/ScheduleConflictParticipantAck.msg"
   "msg/ScheduleConflictProposal.msg"
   "msg/ScheduleConflictRejection.msg"
   "msg/ScheduleConflictRepeat.msg"

--- a/rmf_traffic_msgs/msg/ScheduleConflictAck.msg
+++ b/rmf_traffic_msgs/msg/ScheduleConflictAck.msg
@@ -4,4 +4,4 @@ uint64 conflict_version
 
 # The participants who are acknowledging the conclusion of the conflict
 # negotiation
-uint64[] participants
+ScheduleConflictParticipantAck[] acknowledgments

--- a/rmf_traffic_msgs/msg/ScheduleConflictParticipantAck.msg
+++ b/rmf_traffic_msgs/msg/ScheduleConflictParticipantAck.msg
@@ -1,0 +1,10 @@
+
+# The participant that is acknowledging
+uint64 participant
+
+# Whether this participant will be updating
+bool updating false
+
+# The itinerary version that will provide the update to
+# conform to the negotiation result
+uint64 itinerary_version

--- a/rmf_traffic_msgs/msg/ScheduleConflictRejection.msg
+++ b/rmf_traffic_msgs/msg/ScheduleConflictRejection.msg
@@ -2,5 +2,8 @@
 # The conflict ID that this proposal is targeted at
 uint64 conflict_version
 
+# The version number for the proposal that is being rejected
+uint64 proposal_version
+
 # Reject this negotiation table
 uint64[] table

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/ConvexShape.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/ConvexShape.cpp
@@ -37,9 +37,19 @@ public:
   {
     if(!initialized)
     {
-      add<rmf_traffic::geometry::Box>(rmf_traffic_msgs::msg::ConvexShape::BOX);
-      add<rmf_traffic::geometry::Circle>(rmf_traffic_msgs::msg::ConvexShape::CIRCLE);
+      // TODO(MXG): Reconsider this design. Static initialization of singletons
+      // seems too error prone with too little benefit. A template-based
+      // implementation may be preferable.
+      std::lock_guard<std::mutex> lock(initialization_mutex);
+      if(!initialized)
+      {
+        add<rmf_traffic::geometry::Box>(rmf_traffic_msgs::msg::ConvexShape::BOX);
+        add<rmf_traffic::geometry::Circle>(rmf_traffic_msgs::msg::ConvexShape::CIRCLE);
+        initialized = true;
+      }
     }
+
+    shapes.resize(num_shape_types);
   }
 
   static const Implementation& get(const ConvexShapeContext& parent)

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/Shape.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/Shape.cpp
@@ -37,9 +37,19 @@ public:
   {
     if(!initialized)
     {
-      add<rmf_traffic::geometry::Box>(rmf_traffic_msgs::msg::Shape::BOX);
-      add<rmf_traffic::geometry::Circle>(rmf_traffic_msgs::msg::Shape::CIRCLE);
+      // TODO(MXG): Reconsider this design. Static initialization of singletons
+      // seems too error prone with too little benefit. A template-based
+      // implementation may be preferable.
+      std::lock_guard<std::mutex> lock(initialization_mutex);
+      if(!initialized)
+      {
+        add<rmf_traffic::geometry::Box>(rmf_traffic_msgs::msg::Shape::BOX);
+        add<rmf_traffic::geometry::Circle>(rmf_traffic_msgs::msg::Shape::CIRCLE);
+        initialized = true;
+      }
     }
+
+    shapes.resize(num_shape_types);
   }
 
   static const Implementation& get(const ShapeContext& parent)

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/ShapeInternal.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/ShapeInternal.hpp
@@ -21,6 +21,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -49,20 +50,16 @@ public:
   EntryMap entry_map;
 
   using Caster = std::function<std::size_t(const ShapeTypePtr&)>;
+  static std::mutex initialization_mutex;
   static bool initialized;
   static std::vector<Caster> casters;
   static std::size_t num_shape_types;
 
-  ShapeContextImpl()
-  {
-    shapes.resize(num_shape_types);
-  }
+  ShapeContextImpl() { }
 
   template<typename DerivedShape>
   void add(const std::size_t type_index)
   {
-    initialized = true;
-
     casters.push_back(
           [=](const ShapeTypePtr& shape) -> std::size_t
     {
@@ -136,6 +133,10 @@ public:
   }
 
 };
+
+//==============================================================================
+template<class T, class M, class C>
+std::mutex ShapeContextImpl<T, M, C>::initialization_mutex;
 
 //==============================================================================
 template<class T, class M, class C>

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/NegotiationRoom.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/NegotiationRoom.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "NegotiationRoom.hpp"
+
+#include <rmf_traffic_ros2/Route.hpp>
+
+#include <iostream>
+
+namespace rmf_traffic_ros2 {
+namespace schedule {
+
+//==============================================================================
+NegotiationRoom::NegotiationRoom(rmf_traffic::schedule::Negotiation negotiation_)
+  : negotiation(std::move(negotiation_))
+{
+  // Do nothing
+}
+
+//==============================================================================
+std::vector<rmf_traffic::schedule::Negotiation::TablePtr> NegotiationRoom::check_cache()
+{
+  std::vector<rmf_traffic::schedule::Negotiation::TablePtr> new_tables;
+
+  bool recheck = false;
+  do
+  {
+    recheck = false;
+
+    for (auto it = cached_proposals.begin(); it != cached_proposals.end();)
+    {
+      const auto& proposal = *it;
+      const auto table = negotiation.table(
+            proposal.for_participant, proposal.to_accommodate);
+      if (table)
+      {
+        const bool updated = table->submit(
+              rmf_traffic_ros2::convert(
+                proposal.itinerary), proposal.proposal_version);
+        if (updated)
+          new_tables.push_back(table);
+
+        recheck = true;
+        cached_proposals.erase(it++);
+      }
+      else
+        ++it;
+    }
+
+    for (auto it = cached_rejections.begin(); it != cached_rejections.end();)
+    {
+      // TODO(MXG): This needs to account for what version of the proposal
+      // is being rejected.
+      const auto& rejection = *it;
+      const auto table = negotiation.table(rejection.table);
+      if (table)
+      {
+        table->reject(rejection.proposal_version);
+        recheck = true;
+        cached_rejections.erase(it++);
+      }
+      else
+        ++it;
+    }
+
+  } while (recheck);
+
+  auto remove_it = std::remove_if(new_tables.begin(), new_tables.end(),
+                 [](const rmf_traffic::schedule::Negotiation::TablePtr& table)
+  {
+    return table->rejected();
+  });
+  new_tables.erase(remove_it, new_tables.end());
+
+  return new_tables;
+}
+
+void print_negotiation_status(
+    rmf_traffic::schedule::Version conflict_version,
+    const rmf_traffic::schedule::Negotiation& negotiation)
+{
+  using Negotiation = rmf_traffic::schedule::Negotiation;
+
+  std::cout << "\n[" << conflict_version << "] Active negotiation:";
+  for (const auto p : negotiation.participants())
+    std::cout << " " << p;
+  std::cout << std::endl;
+
+  std::vector<Negotiation::ConstTablePtr> terminal;
+  std::vector<Negotiation::ConstTablePtr> queue;
+  for (const auto p : negotiation.participants())
+  {
+    const auto p_table = negotiation.table(p, {});
+    assert(p_table);
+    queue.push_back(p_table);
+  }
+
+  while (!queue.empty())
+  {
+    Negotiation::ConstTablePtr top = queue.back();
+    queue.pop_back();
+
+    std::vector<Negotiation::ConstTablePtr> children = top->children();
+    if (children.empty())
+    {
+      terminal.push_back(top);
+    }
+    else
+    {
+      for (const auto& child : children)
+      {
+        assert(child);
+        queue.push_back(child);
+      }
+    }
+  }
+
+  std::cout << "    Current negotiation state";
+  for (const auto& t : terminal)
+  {
+    std::cout << "\n --";
+    const bool finished = static_cast<bool>(t->submission());
+    const bool rejected = t->rejected();
+    const auto sequence = t->sequence();
+    for (std::size_t i=0; i < sequence.size(); ++i)
+    {
+      if (i == t->sequence().size()-1 && rejected)
+        std::cout << " <" << sequence[i] << ">";
+      else if (i == t->sequence().size()-1 && !finished)
+        std::cout << " [" << sequence[i] << "]";
+      else
+        std::cout << " " << sequence[i];
+    }
+  }
+  std::cout << "\n" << std::endl;
+}
+
+} // namespace schedule
+} // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/NegotiationRoom.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/NegotiationRoom.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_TRAFFIC_ROS2__SCHEDULE__NEGOTIATIONROOM_HPP
+#define SRC__RMF_TRAFFIC_ROS2__SCHEDULE__NEGOTIATIONROOM_HPP
+
+#include <rmf_traffic/schedule/Negotiation.hpp>
+#include <rmf_traffic_msgs/msg/schedule_conflict_proposal.hpp>
+#include <rmf_traffic_msgs/msg/schedule_conflict_rejection.hpp>
+
+#include <list>
+
+namespace rmf_traffic_ros2 {
+namespace schedule {
+
+//==============================================================================
+// TODO(MXG): Refactor this class into something more broadly usable.
+struct NegotiationRoom
+{
+  NegotiationRoom(rmf_traffic::schedule::Negotiation negotiation_);
+
+  rmf_traffic::schedule::Negotiation negotiation;
+  std::list<rmf_traffic_msgs::msg::ScheduleConflictProposal> cached_proposals;
+  std::list<rmf_traffic_msgs::msg::ScheduleConflictRejection> cached_rejections;
+
+  std::vector<rmf_traffic::schedule::Negotiation::TablePtr> check_cache();
+};
+
+//==============================================================================
+// TODO(MXG): Refactor this by putting it somewhere more meaningful.
+void print_negotiation_status(
+    rmf_traffic::schedule::Version conflict_version,
+    const rmf_traffic::schedule::Negotiation& negotiation);
+
+} // namespace schedule
+} // namespace rmf_traffic_ros2
+
+#endif // SRC__RMF_TRAFFIC_ROS2__SCHEDULE__NEGOTIATIONROOM_HPP

--- a/rmf_traffic_ros2/src/rmf_traffic_schedule/ScheduleNode.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_schedule/ScheduleNode.cpp
@@ -623,7 +623,43 @@ void ScheduleNode::receive_proposal(const ConflictProposal& msg)
 
   table->submit(rmf_traffic_ros2::convert(msg.itinerary), msg.proposal_version);
 
-  print the proposals so far
+  std::vector<Negotiation::ConstTablePtr> terminal;
+  std::vector<Negotiation::ConstTablePtr> queue;
+  for (const auto p : negotiation->participants())
+    queue.push_back(negotiation->table(p, {}));
+
+  while (!queue.empty())
+  {
+    Negotiation::ConstTablePtr top = queue.back();
+    queue.pop_back();
+
+    std::vector<Negotiation::ConstTablePtr> children = top->children();
+    if (children.empty())
+    {
+      terminal.push_back(top);
+    }
+    else
+    {
+      for (const auto& child : children)
+        queue.push_back(child);
+    }
+  }
+
+  std::cout << "\nCurrent negotiation state:";
+  for (const auto& t : terminal)
+  {
+    std::cout << "\n --";
+    const bool finished = static_cast<bool>(t->submission());
+    const auto sequence = t->sequence();
+    for (std::size_t i=0; i < sequence.size(); ++i)
+    {
+      if (i == t->sequence().size()-1 && !finished)
+        std::cout << " [" << sequence[i] << "]";
+      else
+        std::cout << " " << sequence[i];
+    }
+  }
+  std::cout << "\n" << std::endl;
 
   if (negotiation->ready())
   {

--- a/rmf_traffic_ros2/src/rmf_traffic_schedule/ScheduleNode.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_schedule/ScheduleNode.hpp
@@ -182,13 +182,15 @@ public:
   {
   public:
 
+    using Entry = std::pair<Version, const Negotiation*>;
+
     ConflictRecord(const rmf_traffic::schedule::Viewer& viewer)
       : _viewer(viewer)
     {
       // Do nothing
     }
 
-    const Negotiation* insert(const ConflictSet& conflicts)
+    rmf_utils::optional<Entry> insert(const ConflictSet& conflicts)
     {
       ConflictSet add_to_negotiation;
       const Version* existing_negotiation = nullptr;
@@ -210,7 +212,7 @@ public:
       }
 
       if (add_to_negotiation.empty())
-        return nullptr;
+        return rmf_utils::nullopt;
 
       const Version negotiation_version = existing_negotiation ?
             *existing_negotiation : _next_negotiation_version++;
@@ -231,7 +233,8 @@ public:
           update_negotiation->add_participant(p);
       }
 
-      return &(*update_negotiation);
+      return Entry(std::make_pair<const Version, const Negotiation*>(
+            negotiation_version, &(*update_negotiation)));
     }
 
     rmf_traffic::schedule::Negotiation* negotiation(const Version version)

--- a/rmf_utils/include/rmf_utils/Modular.hpp
+++ b/rmf_utils/include/rmf_utils/Modular.hpp
@@ -15,15 +15,14 @@
  *
 */
 
-#ifndef SRC__RMF_TRAFFIC__SCHEDULE__MODULAR_HPP
-#define SRC__RMF_TRAFFIC__SCHEDULE__MODULAR_HPP
+#ifndef RMF_UTILS__MODULAR_HPP
+#define RMF_UTILS__MODULAR_HPP
 
 #include <stdexcept>
 #include <limits>
 #include <type_traits>
 
-namespace rmf_traffic {
-namespace schedule {
+namespace rmf_utils {
 
 //==============================================================================
 /// This class allows us to correctly handle version number overflow. Since the
@@ -139,7 +138,6 @@ struct ModularLess
   }
 };
 
-} // namespace schedule
-} // namespace rmf_traffic
+} // namespace rmf_utils
 
-#endif // SRC__RMF_TRAFFIC__SCHEDULE__MODULAR_HPP
+#endif // RMF_UTILS__MODULAR_HPP


### PR DESCRIPTION
This PR introduces many comprehensive changes to fleet adapter behavior. In particular, it uses the negotiation system to allow the traffic schedule participants to negotiate with each other in a more robust way. I've been testing it extensively on a particularly difficult version of DP2, and most of the kinks are out. There are a few very specific edge cases that need some more work, but I think overall these changes should prove to be a major improvement.