### PR TITLE
geometry_msgs is not needed, removing from cmake

### DIFF
--- a/rmf_lift_msgs/CMakeLists.txt
+++ b/rmf_lift_msgs/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(geometry_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files


### PR DESCRIPTION
Removing the find_package pointing to geometry_msgs as it is not needed and fails when creating the package due to a dependency not found.