### PR TITLE
RMF Linter

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -12,6 +12,17 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
+if(BUILD_TESTING)
+  find_package(rmf_cmake_uncrustify REQUIRED)
+  find_file(uncrustify_config_file NAMES "share/format/rmf_code_style.cfg")
+                
+  rmf_uncrustify(
+    ARGN include src test
+    CONFIG_FILE ${uncrustify_config_file}
+    MAX_LINE_LENGTH 80
+  )
+endif()
+
 set(dep_pkgs
   rclcpp
   rmf_utils

--- a/rmf_fleet_adapter/src/door_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/door_supervisor/Node.cpp
@@ -31,21 +31,21 @@ Node::Node()
   const auto default_qos = rclcpp::SystemDefaultsQoS();
 
   _door_request_pub = create_publisher<DoorRequest>(
-        FinalDoorRequestTopicName, default_qos);
+    FinalDoorRequestTopicName, default_qos);
 
   _adapter_door_request_sub = create_subscription<DoorRequest>(
-        AdapterDoorRequestTopicName, default_qos,
-        [&](DoorRequest::UniquePtr msg)
-  {
-    _adapter_door_request_update(std::move(msg));
-  });
+    AdapterDoorRequestTopicName, default_qos,
+    [&](DoorRequest::UniquePtr msg)
+    {
+      _adapter_door_request_update(std::move(msg));
+    });
 
   _door_state_sub = create_subscription<DoorState>(
-        DoorStateTopicName, default_qos,
-        [&](DoorState::UniquePtr msg)
-  {
-    _door_state_update(std::move(msg));
-  });
+    DoorStateTopicName, default_qos,
+    [&](DoorState::UniquePtr msg)
+    {
+      _door_state_update(std::move(msg));
+    });
 }
 
 //==============================================================================
@@ -55,14 +55,15 @@ void Node::_adapter_door_request_update(DoorRequest::UniquePtr msg)
     _process_open_request(msg->door_name, msg->requester_id, msg->request_time);
 
   if (DoorMode::MODE_CLOSED == msg->requested_mode.value)
-    _process_close_request(msg->door_name, msg->requester_id, msg->request_time);
+    _process_close_request(msg->door_name, msg->requester_id,
+      msg->request_time);
 }
 
 //==============================================================================
 void Node::_process_open_request(
-    const std::string& door_name,
-    const std::string& requester_id,
-    const builtin_interfaces::msg::Time& time)
+  const std::string& door_name,
+  const std::string& requester_id,
+  const builtin_interfaces::msg::Time& time)
 {
   auto& open_requests = _log[door_name];
   auto insertion = open_requests.insert(std::make_pair(requester_id, time));
@@ -89,9 +90,9 @@ void Node::_send_open_request(const std::string& door_name)
 
 //==============================================================================
 void Node::_process_close_request(
-    const std::string& door_name,
-    const std::string& requester_id,
-    const builtin_interfaces::msg::Time& time)
+  const std::string& door_name,
+  const std::string& requester_id,
+  const builtin_interfaces::msg::Time& time)
 {
   auto door_it = _log.find(door_name);
   if (door_it == _log.end())
@@ -142,7 +143,7 @@ void Node::_door_state_update(DoorState::UniquePtr msg)
   if (door_it == _log.end() || door_it->second.empty())
   {
     if (DoorMode::MODE_OPEN == msg->current_mode.value
-        || DoorMode::MODE_MOVING == msg->current_mode.value)
+      || DoorMode::MODE_MOVING == msg->current_mode.value)
     {
       // If the door is not closed but it's supposed to be, then send a reminder
       _send_close_request(door_name);
@@ -151,7 +152,7 @@ void Node::_door_state_update(DoorState::UniquePtr msg)
   else
   {
     if (DoorMode::MODE_CLOSED == msg->current_mode.value
-        || DoorMode::MODE_MOVING == msg->current_mode.value)
+      || DoorMode::MODE_MOVING == msg->current_mode.value)
     {
       // If the door is not open but it's supposed to be, then send a reminder
       _send_open_request(door_name);

--- a/rmf_fleet_adapter/src/door_supervisor/Node.hpp
+++ b/rmf_fleet_adapter/src/door_supervisor/Node.hpp
@@ -47,16 +47,16 @@ private:
   void _adapter_door_request_update(DoorRequest::UniquePtr msg);
 
   void _process_open_request(
-      const std::string& door_name,
-      const std::string& requester_id,
-      const builtin_interfaces::msg::Time& time);
+    const std::string& door_name,
+    const std::string& requester_id,
+    const builtin_interfaces::msg::Time& time);
 
   void _send_open_request(const std::string& door_name);
 
   void _process_close_request(
-      const std::string& door_name,
-      const std::string& requester_id,
-      const builtin_interfaces::msg::Time& time);
+    const std::string& door_name,
+    const std::string& requester_id,
+    const builtin_interfaces::msg::Time& time);
 
   void _send_close_request(const std::string& door_name);
 
@@ -66,9 +66,9 @@ private:
   void _door_state_update(DoorState::UniquePtr msg);
 
   using OpenRequestLog =
-      std::unordered_map<
-        std::string,
-        std::unordered_map<std::string, rclcpp::Time>>;
+    std::unordered_map<
+    std::string,
+    std::unordered_map<std::string, rclcpp::Time>>;
   OpenRequestLog _log;
 };
 

--- a/rmf_fleet_adapter/src/full_control/Actions.hpp
+++ b/rmf_fleet_adapter/src/full_control/Actions.hpp
@@ -24,19 +24,19 @@ namespace rmf_fleet_adapter {
 namespace full_control {
 
 std::unique_ptr<Action> make_move(
-    FleetAdapterNode* node,
-    FleetAdapterNode::RobotContext* state,
-    Task* parent,
-    const std::size_t goal_wp_index,
-    const std::size_t move_id);
+  FleetAdapterNode* node,
+  FleetAdapterNode::RobotContext* state,
+  Task* parent,
+  const std::size_t goal_wp_index,
+  const std::size_t move_id);
 
 std::unique_ptr<Action> make_dispense(
-    FleetAdapterNode* const node,
-    FleetAdapterNode::RobotContext* const context,
-    Task* const parent,
-    std::string dispenser_name,
-    std::vector<rmf_dispenser_msgs::msg::DispenserRequestItem> items,
-    const rmf_task_msgs::msg::Behavior& behavior);
+  FleetAdapterNode* const node,
+  FleetAdapterNode::RobotContext* const context,
+  Task* const parent,
+  std::string dispenser_name,
+  std::vector<rmf_dispenser_msgs::msg::DispenserRequestItem> items,
+  const rmf_task_msgs::msg::Behavior& behavior);
 
 std::unique_ptr<Action> make_failure(std::string error);
 

--- a/rmf_fleet_adapter/src/full_control/DispenseAction.cpp
+++ b/rmf_fleet_adapter/src/full_control/DispenseAction.cpp
@@ -34,11 +34,11 @@ class DispenseAction : public Action
 public:
 
   DispenseAction(
-      FleetAdapterNode* node,
-      FleetAdapterNode::RobotContext* context,
-      Task* task,
-      std::string dispenser_name,
-      std::vector<rmf_dispenser_msgs::msg::DispenserRequestItem> items)
+    FleetAdapterNode* node,
+    FleetAdapterNode::RobotContext* context,
+    Task* task,
+    std::string dispenser_name,
+    std::vector<rmf_dispenser_msgs::msg::DispenserRequestItem> items)
   : _node(node),
     _context(context),
     _task(task),
@@ -97,7 +97,7 @@ public:
     const auto finish = rmf_traffic_ros2::convert(*_last_reported_wait_time);
 
     const std::string map_name =
-        _node->get_graph().get_waypoint(0).get_map_name();
+      _node->get_graph().get_waypoint(0).get_map_name();
 
     rmf_traffic::Trajectory trajectory;
     trajectory.insert(start, position, zero);
@@ -120,8 +120,8 @@ public:
         _last_reported_wait_time = next_wait_time;
 
         _context->schedule.push_delay(
-              rmf_traffic_ros2::convert(delay),
-              rmf_traffic_ros2::convert(now));
+          rmf_traffic_ros2::convert(delay),
+          rmf_traffic_ros2::convert(now));
         return;
       }
     }
@@ -150,25 +150,25 @@ public:
   }
 
   void respond(
-      rmf_traffic::schedule::Negotiation::ConstTablePtr table,
-      const Responder& responder,
-      const bool* /*interrupt_flag*/) final
+    rmf_traffic::schedule::Negotiation::ConstTablePtr table,
+    const Responder& responder,
+    const bool* /*interrupt_flag*/) final
   {
     const rmf_traffic::Route route = calculate_itinerary();
     const auto& trajectory = route.trajectory();
     const auto view = table->query(rmf_traffic::schedule::make_query(
-                   {route.map()},
-                   trajectory.start_time(),
-                   trajectory.finish_time()).spacetime());
+          {route.map()},
+          trajectory.start_time(),
+          trajectory.finish_time()).spacetime());
     const auto& profile = _context->schedule.description().profile();
 
     for (const auto& v : view)
     {
       if (rmf_traffic::DetectConflict::between(
-            profile,
-            trajectory,
-            v.description.profile(),
-            v.route.trajectory()))
+          profile,
+          trajectory,
+          v.description.profile(),
+          v.route.trajectory()))
       {
         responder.reject();
         return;
@@ -241,11 +241,11 @@ public:
       if (!_parent->_request_received)
       {
         _parent->_request_received =
-            std::find(
-              msg.request_guid_queue.begin(),
-              msg.request_guid_queue.end(),
-              _parent->_request->request_guid)
-            != msg.request_guid_queue.end();
+          std::find(
+          msg.request_guid_queue.begin(),
+          msg.request_guid_queue.end(),
+          _parent->_request->request_guid)
+          != msg.request_guid_queue.end();
 
         if (_parent->_request_received)
         {
@@ -262,11 +262,11 @@ public:
         // The request has been received, so if it's no longer in the queue,
         // then we'll assume it's finished.
         _parent->_request_finished =
-            std::find(
-              msg.request_guid_queue.begin(),
-              msg.request_guid_queue.end(),
-              _parent->_request->request_guid)
-            == msg.request_guid_queue.end();
+          std::find(
+          msg.request_guid_queue.begin(),
+          msg.request_guid_queue.end(),
+          _parent->_request->request_guid)
+          == msg.request_guid_queue.end();
       }
 
       _parent->update();
@@ -356,17 +356,17 @@ private:
 
 //==============================================================================
 std::unique_ptr<Action> make_dispense(
-    FleetAdapterNode* const node,
-    FleetAdapterNode::RobotContext* const context,
-    Task* const parent,
-    std::string dispenser_name,
-    std::vector<rmf_dispenser_msgs::msg::DispenserRequestItem> items,
-    const rmf_task_msgs::msg::Behavior& /*behavior*/)
+  FleetAdapterNode* const node,
+  FleetAdapterNode::RobotContext* const context,
+  Task* const parent,
+  std::string dispenser_name,
+  std::vector<rmf_dispenser_msgs::msg::DispenserRequestItem> items,
+  const rmf_task_msgs::msg::Behavior& /*behavior*/)
 {
   return std::make_unique<DispenseAction>(
-        node, context, parent,
-        std::move(dispenser_name),
-        std::move(items));
+    node, context, parent,
+    std::move(dispenser_name),
+    std::move(items));
 }
 
 } // namespace full_control

--- a/rmf_fleet_adapter/src/full_control/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/full_control/FleetAdapterNode.cpp
@@ -42,43 +42,43 @@ std::shared_ptr<FleetAdapterNode> FleetAdapterNode::make()
   const auto node = std::shared_ptr<FleetAdapterNode>(new FleetAdapterNode);
 
   node->_perform_deliveries =
-      node->declare_parameter<bool>("perform_deliveries", false);
+    node->declare_parameter<bool>("perform_deliveries", false);
 
   const std::string nav_graph_param_name = "nav_graph_file";
   std::string graph_file =
-      node->declare_parameter(nav_graph_param_name, std::string());
+    node->declare_parameter(nav_graph_param_name, std::string());
 
   if (graph_file.empty())
   {
     RCLCPP_ERROR(
-          node->get_logger(),
-          "Missing [" + nav_graph_param_name + "] parameter!");
+      node->get_logger(),
+      "Missing [" + nav_graph_param_name + "] parameter!");
 
     return nullptr;
   }
 
-  const std::string fleet_name = node->get_fleet_name().empty()?
-        "all fleets" : "[" + node->get_fleet_name() + "]";
+  const std::string fleet_name = node->get_fleet_name().empty() ?
+    "all fleets" : "[" + node->get_fleet_name() + "]";
   RCLCPP_INFO(
-        node->get_logger(),
-        "Launching fleet adapter for " + fleet_name);
+    node->get_logger(),
+    "Launching fleet adapter for " + fleet_name);
 
   auto traits = get_traits_or_default(*node, 0.7, 0.3, 0.5, 1.5, 0.6);
 
   node->_delay_threshold =
-      get_parameter_or_default_time(*node, "delay_threshold", 5.0);
+    get_parameter_or_default_time(*node, "delay_threshold", 5.0);
 
   node->_retry_wait =
-      get_parameter_or_default_time(*node, "retry_wait", 5.0);
+    get_parameter_or_default_time(*node, "retry_wait", 5.0);
 
   node->_plan_time =
-      get_parameter_or_default_time(*node, "planning_timeout", 5.0);
+    get_parameter_or_default_time(*node, "planning_timeout", 5.0);
 
   auto mirror_future = rmf_traffic_ros2::schedule::make_mirror(
-        *node, rmf_traffic::schedule::query_all());
+    *node, rmf_traffic::schedule::query_all());
 
   rmf_utils::optional<GraphInfo> graph_info =
-      parse_graph(graph_file, traits, *node);
+    parse_graph(graph_file, traits, *node);
 
   if (!graph_info)
     return nullptr;
@@ -88,10 +88,10 @@ std::shared_ptr<FleetAdapterNode> FleetAdapterNode::make()
   auto writer = rmf_traffic_ros2::schedule::Writer::make(*node);
 
   const auto wait_time =
-      get_parameter_or_default_time(*node, "discovery_timeout", 10.0);
+    get_parameter_or_default_time(*node, "discovery_timeout", 10.0);
 
   const auto stop_time = std::chrono::steady_clock::now() + wait_time;
-  while(rclcpp::ok() && std::chrono::steady_clock::now() < stop_time)
+  while (rclcpp::ok() && std::chrono::steady_clock::now() < stop_time)
   {
     rclcpp::spin_some(node);
 
@@ -102,44 +102,44 @@ std::shared_ptr<FleetAdapterNode> FleetAdapterNode::make()
     if (ready)
     {
       node->start(
-            Fields{
-              *node,
-              std::move(*graph_info),
-              std::move(traits),
-              mirror_future.get(),
-              std::move(writer)
-            });
+        Fields{
+          *node,
+          std::move(*graph_info),
+          std::move(traits),
+          mirror_future.get(),
+          std::move(writer)
+        });
 
       return node;
     }
   }
 
   RCLCPP_ERROR(
-        node->get_logger(),
-        "Timeout after waiting ["
-        + std::to_string(rmf_traffic::time::to_seconds(wait_time))
-        + "] to connect to the schedule");
+    node->get_logger(),
+    "Timeout after waiting ["
+    + std::to_string(rmf_traffic::time::to_seconds(wait_time))
+    + "] to connect to the schedule");
 
   return nullptr;
 }
 
 //==============================================================================
 FleetAdapterNode::RobotContext::RobotContext(
-    std::string name,
-    Location location_,
-    ScheduleManager schedule_)
+  std::string name,
+  Location location_,
+  ScheduleManager schedule_)
 : location(std::move(location_)),
   schedule(std::move(schedule_)),
   _name(std::move(name))
 {
   schedule.set_negotiator(
-        [this](
-          rmf_traffic::schedule::Negotiation::ConstTablePtr table,
-          const rmf_traffic::schedule::Negotiator::Responder& responder,
-          const bool* interrupt_flag)
-  {
-    this->respond(std::move(table), responder, interrupt_flag);
-  });
+    [this](
+      rmf_traffic::schedule::Negotiation::ConstTablePtr table,
+      const rmf_traffic::schedule::Negotiator::Responder& responder,
+      const bool* interrupt_flag)
+    {
+      this->respond(std::move(table), responder, interrupt_flag);
+    });
 }
 
 //==============================================================================
@@ -191,10 +191,10 @@ void FleetAdapterNode::RobotContext::discard_task(Task* discarded_task)
   }
 
   const auto it = std::find_if(_task_queue.begin(), _task_queue.end(),
-               [&](const std::unique_ptr<Task>& task)
-  {
-    return task.get() == discarded_task;
-  });
+      [&](const std::unique_ptr<Task>& task)
+      {
+        return task.get() == discarded_task;
+      });
 
   if (it != _task_queue.end())
     _task_queue.erase(it);
@@ -216,9 +216,9 @@ void FleetAdapterNode::RobotContext::resume()
 
 //==============================================================================
 void FleetAdapterNode::RobotContext::respond(
-    rmf_traffic::schedule::Negotiation::ConstTablePtr table,
-    const rmf_traffic::schedule::Negotiator::Responder& responder,
-    const bool* interrupt_flag)
+  rmf_traffic::schedule::Negotiation::ConstTablePtr table,
+  const rmf_traffic::schedule::Negotiator::Responder& responder,
+  const bool* interrupt_flag)
 {
   if (_task)
     _task->respond(std::move(table), responder, interrupt_flag);
@@ -236,7 +236,7 @@ void FleetAdapterNode::RobotContext::respond(
 std::size_t FleetAdapterNode::RobotContext::num_tasks() const
 {
   const std::size_t n_queue = _task_queue.size();
-  return _task? n_queue + 1 : n_queue;
+  return _task ? n_queue + 1 : n_queue;
 }
 
 //==============================================================================
@@ -247,14 +247,14 @@ const std::string& FleetAdapterNode::RobotContext::robot_name() const
 
 //==============================================================================
 void FleetAdapterNode::RobotContext::insert_listener(
-    Listener<RobotState>* listener)
+  Listener<RobotState>* listener)
 {
   state_listeners.insert(listener);
 }
 
 //==============================================================================
 void FleetAdapterNode::RobotContext::remove_listener(
-    Listener<RobotState>* listener)
+  Listener<RobotState>* listener)
 {
   state_listeners.erase(listener);
 }
@@ -362,78 +362,78 @@ void FleetAdapterNode::start(Fields fields)
   const auto default_qos = rclcpp::SystemDefaultsQoS();
 
   _delivery_sub = create_subscription<Delivery>(
-        DeliveryTopicName, default_qos,
-        [&](Delivery::UniquePtr msg)
-  {
-    this->delivery_request(std::move(msg));
-  });
+    DeliveryTopicName, default_qos,
+    [&](Delivery::UniquePtr msg)
+    {
+      this->delivery_request(std::move(msg));
+    });
 
   _loop_request_sub = create_subscription<LoopRequest>(
-        LoopRequestTopicName, default_qos,
-        [&](LoopRequest::UniquePtr msg)
-  {
-    this->loop_request(std::move(msg));
-  });
+    LoopRequestTopicName, default_qos,
+    [&](LoopRequest::UniquePtr msg)
+    {
+      this->loop_request(std::move(msg));
+    });
 
   _dispenser_result_sub = create_subscription<DispenserResult>(
-        DispenserResultTopicName, default_qos,
-        [&](DispenserResult::UniquePtr msg)
-  {
-    this->dispenser_result_update(std::move(msg));
-  });
+    DispenserResultTopicName, default_qos,
+    [&](DispenserResult::UniquePtr msg)
+    {
+      this->dispenser_result_update(std::move(msg));
+    });
 
   _dispenser_state_sub = create_subscription<DispenserState>(
-        DispenserStateTopicName, default_qos,
-        [&](DispenserState::UniquePtr msg)
-  {
-    this->dispenser_state_update(std::move(msg));
-  });
+    DispenserStateTopicName, default_qos,
+    [&](DispenserState::UniquePtr msg)
+    {
+      this->dispenser_state_update(std::move(msg));
+    });
 
   _fleet_state_sub = create_subscription<FleetState>(
-        FleetStateTopicName, default_qos,
-        [&](FleetState::UniquePtr msg)
-  {
-    this->fleet_state_update(std::move(msg));
-  });
+    FleetStateTopicName, default_qos,
+    [&](FleetState::UniquePtr msg)
+    {
+      this->fleet_state_update(std::move(msg));
+    });
 
   _door_state_sub = create_subscription<DoorState>(
-        DoorStateTopicName, default_qos,
-        [&](DoorState::UniquePtr msg)
-  {
-    this->door_state_update(std::move(msg));
-  });
+    DoorStateTopicName, default_qos,
+    [&](DoorState::UniquePtr msg)
+    {
+      this->door_state_update(std::move(msg));
+    });
 
   _lift_state_sub = create_subscription<LiftState>(
-        LiftStateTopicName, default_qos,
-        [&](LiftState::UniquePtr msg)
-  {
-    this->lift_state_update(std::move(msg));
-  });
+    LiftStateTopicName, default_qos,
+    [&](LiftState::UniquePtr msg)
+    {
+      this->lift_state_update(std::move(msg));
+    });
 
   _emergency_notice_sub = create_subscription<EmergencyNotice>(
-        rmf_traffic_ros2::EmergencyTopicName, default_qos,
-        [&](EmergencyNotice::UniquePtr msg)
-  {
-    this->emergency_notice_update(std::move(msg));
-  });
+    rmf_traffic_ros2::EmergencyTopicName, default_qos,
+    [&](EmergencyNotice::UniquePtr msg)
+    {
+      this->emergency_notice_update(std::move(msg));
+    });
 
   path_request_publisher = create_publisher<PathRequest>(
-        PathRequestTopicName, default_qos);
+    PathRequestTopicName, default_qos);
 
   mode_request_publisher = create_publisher<ModeRequest>(
-        ModeRequestTopicName, default_qos);
+    ModeRequestTopicName, default_qos);
 
   door_request_publisher = create_publisher<DoorRequest>(
-        AdapterDoorRequestTopicName, default_qos);
+    AdapterDoorRequestTopicName, default_qos);
 
   lift_request_publisher = create_publisher<LiftRequest>(
-        AdapterLiftRequestTopicName, default_qos);
+    AdapterLiftRequestTopicName, default_qos);
 
   dispenser_request_publisher = create_publisher<DispenserRequest>(
-        DispenserRequestTopicName, default_qos);
+    DispenserRequestTopicName, default_qos);
 
   task_summary_publisher = create_publisher<TaskSummary>(
-        TaskSummaryTopicName, default_qos);
+    TaskSummaryTopicName, default_qos);
 }
 
 //==============================================================================
@@ -445,16 +445,16 @@ void FleetAdapterNode::delivery_request(Delivery::UniquePtr msg)
   if (_in_emergency_mode)
   {
     RCLCPP_ERROR(
-          get_logger(),
-          "We do not currently support receiving tasks during emergencies!");
+      get_logger(),
+      "We do not currently support receiving tasks during emergencies!");
     return;
   }
 
   if (_contexts.empty())
   {
     RCLCPP_ERROR(
-          get_logger(),
-          "No robots appear to be online!");
+      get_logger(),
+      "No robots appear to be online!");
     return;
   }
 
@@ -464,9 +464,9 @@ void FleetAdapterNode::delivery_request(Delivery::UniquePtr msg)
     // We've already received and processed this task in the past, so we can
     // ignore it.
     RCLCPP_INFO(
-          get_logger(),
-          "Already received delivery task [" + msg->task_id + "] so it will "
-          "be ignored");
+      get_logger(),
+      "Already received delivery task [" + msg->task_id + "] so it will "
+      "be ignored");
     return;
   }
 
@@ -477,8 +477,8 @@ void FleetAdapterNode::delivery_request(Delivery::UniquePtr msg)
   auto context = _contexts.begin()->second.get();
 
   RCLCPP_INFO(
-        get_logger(),
-        "Assigning delivery task to [" + context->robot_name() + "]");
+    get_logger(),
+    "Assigning delivery task to [" + context->robot_name() + "]");
 
   std::cout << "Robot name: [" << context->robot_name() << "]  | ptr: ["
             << context << "]" << std::endl;
@@ -497,8 +497,8 @@ void FleetAdapterNode::loop_request(LoopRequest::UniquePtr msg)
   if (_in_emergency_mode)
   {
     RCLCPP_ERROR(
-          get_logger(),
-          "We do not currently support receiving tasks during emergencies!");
+      get_logger(),
+      "We do not currently support receiving tasks during emergencies!");
     return;
   }
 
@@ -524,16 +524,16 @@ void FleetAdapterNode::loop_request(LoopRequest::UniquePtr msg)
     if (!_received_tasks.insert(msg->task_id).second)
     {
       RCLCPP_INFO(
-            get_logger(),
-            "Already received looping task request [" + msg->task_id
-            + "] so it will be ignored");
+        get_logger(),
+        "Already received looping task request [" + msg->task_id
+        + "] so it will be ignored");
       return;
     }
 
     RCLCPP_INFO(
-          get_logger(),
-          "Received looping task ID [" + msg->task_id + "] and assigned "
-          "it to [" + fewest_context->robot_name() + "]");
+      get_logger(),
+      "Received looping task ID [" + msg->task_id + "] and assigned "
+      "it to [" + fewest_context->robot_name() + "]");
 
     auto task = make_loop(this, fewest_context, std::move(*msg));
     if (task)
@@ -543,9 +543,9 @@ void FleetAdapterNode::loop_request(LoopRequest::UniquePtr msg)
   }
 
   RCLCPP_ERROR(
-        get_logger(),
-        "Cannot assign a robot to looping task [" + msg->task_id
-        + "] because no robots have reported their existence.");
+    get_logger(),
+    "Cannot assign a robot to looping task [" + msg->task_id
+    + "] because no robots have reported their existence.");
 
   rmf_task_msgs::msg::TaskSummary summary;
   summary.status = "Services unavailable";
@@ -583,7 +583,7 @@ void FleetAdapterNode::fleet_state_update(FleetState::UniquePtr msg)
   for (const auto& robot : fleet_state.robots)
   {
     const auto insertion = _contexts.insert(
-          std::make_pair(robot.name, nullptr));
+      std::make_pair(robot.name, nullptr));
     const bool inserted = insertion.second;
     const auto it = insertion.first;
 
@@ -600,20 +600,20 @@ void FleetAdapterNode::fleet_state_update(FleetState::UniquePtr msg)
       };
 
       async_make_schedule_manager(
-            *this,
-            *_field->writer,
-            &_field->negotiation,
-            std::move(description),
-            [this, name = robot.name, location = robot.location](
-              ScheduleManager manager)
-      {
-        this->_contexts.at(name) = std::make_unique<RobotContext>(
-              name, location, std::move(manager));
-      }, _async_mutex);
+        *this,
+        *_field->writer,
+        &_field->negotiation,
+        std::move(description),
+        [this, name = robot.name, location = robot.location](
+          ScheduleManager manager)
+        {
+          this->_contexts.at(name) = std::make_unique<RobotContext>(
+            name, location, std::move(manager));
+        }, _async_mutex);
 
       RCLCPP_INFO(
-            get_logger(),
-            "Found a robot: [" + robot.name + "]");
+        get_logger(),
+        "Found a robot: [" + robot.name + "]");
     }
     else if (it->second)
     {

--- a/rmf_fleet_adapter/src/full_control/FleetAdapterNode.hpp
+++ b/rmf_fleet_adapter/src/full_control/FleetAdapterNode.hpp
@@ -79,9 +79,9 @@ public:
   struct RobotContext
   {
     RobotContext(
-        std::string name,
-        Location location,
-        ScheduleManager schedule);
+      std::string name,
+      Location location,
+      ScheduleManager schedule);
 
     Location location;
 
@@ -98,9 +98,9 @@ public:
     void resume();
 
     void respond(
-        rmf_traffic::schedule::Negotiation::ConstTablePtr table,
-        const rmf_traffic::schedule::Negotiator::Responder& responder,
-        const bool* interrupt_flag);
+      rmf_traffic::schedule::Negotiation::ConstTablePtr table,
+      const rmf_traffic::schedule::Negotiator::Responder& responder,
+      const bool* interrupt_flag);
 
     std::size_t num_tasks() const;
 
@@ -149,11 +149,11 @@ public:
     rmf_traffic::agv::Planner planner;
 
     Fields(
-        rclcpp::Node& node_,
-        GraphInfo graph_info_,
-        rmf_traffic::agv::VehicleTraits traits_,
-        rmf_traffic_ros2::schedule::MirrorManager mirror_,
-        rmf_traffic_ros2::schedule::WriterPtr writer_)
+      rclcpp::Node& node_,
+      GraphInfo graph_info_,
+      rmf_traffic::agv::VehicleTraits traits_,
+      rmf_traffic_ros2::schedule::MirrorManager mirror_,
+      rmf_traffic_ros2::schedule::WriterPtr writer_)
     : mirror(std::move(mirror_)),
       writer(std::move(writer_)),
       negotiation(node_, mirror.viewer()),
@@ -183,11 +183,11 @@ public:
   using DispenserState = rmf_dispenser_msgs::msg::DispenserState;
 
   using DispenserResultListeners =
-      std::unordered_set<Listener<DispenserResult>*>;
+    std::unordered_set<Listener<DispenserResult>*>;
   DispenserResultListeners dispenser_result_listeners;
 
   using DispenserStateListeners =
-      std::unordered_set<Listener<DispenserState>*>;
+    std::unordered_set<Listener<DispenserState>*>;
   DispenserStateListeners dispenser_state_listeners;
 
   using PathRequest = rmf_fleet_msgs::msg::PathRequest;
@@ -278,7 +278,7 @@ private:
   bool _have_delivery_request = false;
 
   using Context =
-      std::unordered_map<std::string, std::unique_ptr<RobotContext>>;
+    std::unordered_map<std::string, std::unique_ptr<RobotContext>>;
   Context _contexts;
 };
 

--- a/rmf_fleet_adapter/src/full_control/MoveAction.cpp
+++ b/rmf_fleet_adapter/src/full_control/MoveAction.cpp
@@ -32,16 +32,17 @@ namespace full_control {
 namespace {
 //==============================================================================
 rmf_utils::optional<std::size_t> get_fastest_plan_index(
-    const std::vector<rmf_utils::optional<rmf_traffic::agv::Plan>>& plans)
+  const std::vector<rmf_utils::optional<rmf_traffic::agv::Plan>>& plans)
 {
   auto nearest = std::chrono::steady_clock::time_point::max();
   std::size_t i_nearest = std::numeric_limits<std::size_t>::max();
-  for (std::size_t i=0; i < plans.size(); ++i)
+  for (std::size_t i = 0; i < plans.size(); ++i)
   {
     const auto& plan = plans[i];
     if (plan)
     {
-      const auto finish_time = plan->get_itinerary().back().trajectory().finish_time();
+      const auto finish_time =
+        plan->get_itinerary().back().trajectory().finish_time();
       if (!finish_time)
       {
         // If this is an empty trajectory, then the robot is already sitting on
@@ -50,7 +51,7 @@ rmf_utils::optional<std::size_t> get_fastest_plan_index(
         assert(plan->get_waypoints().front().graph_index());
         assert(plan->get_waypoints().size() == 1);
         assert(*plan->get_waypoints().front().graph_index()
-               == *plan->get_waypoints().back().graph_index());
+          == *plan->get_waypoints().back().graph_index());
         return i;
       }
 
@@ -75,11 +76,11 @@ class MoveAction : public Action
 public:
 
   MoveAction(
-      FleetAdapterNode* node,
-      Task* parent,
-      FleetAdapterNode::RobotContext* state,
-      const std::size_t goal_wp_index,
-      const std::size_t move_id)
+    FleetAdapterNode* node,
+    Task* parent,
+    FleetAdapterNode::RobotContext* state,
+    const std::size_t goal_wp_index,
+    const std::size_t move_id)
   : _node(node),
     _task(parent),
     _context(state),
@@ -103,14 +104,14 @@ public:
   }
 
   std::vector<rmf_traffic::agv::Plan> find_plan(
-      const std::chrono::nanoseconds start_delay)
+    const std::chrono::nanoseconds start_delay)
   {
     return find_plan(start_delay, _validator);
   }
 
   std::vector<rmf_traffic::agv::Plan> find_plan(
-      const std::chrono::nanoseconds start_delay,
-      const rmf_utils::clone_ptr<rmf_traffic::agv::RouteValidator> validator)
+    const std::chrono::nanoseconds start_delay,
+    const rmf_utils::clone_ptr<rmf_traffic::agv::RouteValidator> validator)
   {
     _emergency_active = false;
     _waiting_on_emergency = false;
@@ -119,22 +120,22 @@ public:
     const auto& planner = _node->get_planner();
 
     Eigen::Vector3d pose =
-        {_context->location.x, _context->location.y, _context->location.yaw};
-    const auto start_time = 
-        rmf_traffic_ros2::convert(_node->get_clock()->now()) + start_delay;
+    {_context->location.x, _context->location.y, _context->location.yaw};
+    const auto start_time =
+      rmf_traffic_ros2::convert(_node->get_clock()->now()) + start_delay;
 
     // TODO: further parameterize waypoint and lane merging distance
-    const auto plan_starts = 
-        rmf_traffic::agv::compute_plan_starts(
-            planner.get_configuration().graph(), pose, start_time, 0.1, 1.0, 
-            1e-8);
+    const auto plan_starts =
+      rmf_traffic::agv::compute_plan_starts(
+      planner.get_configuration().graph(), pose, start_time, 0.1, 1.0,
+      1e-8);
 
     if (plan_starts.empty())
     {
       RCLCPP_WARN(
-          _node->get_logger(), 
-          "The robot appears to be in an unrecoverable state, failed to find "
-          "suitable waypoints on the graph to start planning.");
+        _node->get_logger(),
+        "The robot appears to be in an unrecoverable state, failed to find "
+        "suitable waypoints on the graph to start planning.");
       return {};
     }
 
@@ -148,55 +149,56 @@ public:
     std::condition_variable plan_solved_cv;
     rmf_utils::optional<rmf_traffic::agv::Plan> main_plan;
     std::thread main_plan_thread = std::thread(
-          [&]()
-    {
-      main_plan =
-          planner.plan(
-            plan_starts,
-            rmf_traffic::agv::Plan::Goal(_goal_wp_index),
-            _planner_options);
+      [&]()
+      {
+        main_plan =
+        planner.plan(
+          plan_starts,
+          rmf_traffic::agv::Plan::Goal(_goal_wp_index),
+          _planner_options);
 
-      if (main_plan)
-      {
-        main_plan_solved = true;
-        plan_solved_cv.notify_all();
-      }
-      else
-      {
-        main_plan_failed = true;
-      }
-    });
+        if (main_plan)
+        {
+          main_plan_solved = true;
+          plan_solved_cv.notify_all();
+        }
+        else
+        {
+          main_plan_failed = true;
+        }
+      });
 
     std::vector<std::thread> fallback_plan_threads;
     std::vector<rmf_utils::optional<rmf_traffic::agv::Plan>> fallback_plans;
     std::mutex fallback_plan_mutex;
     for (const std::size_t goal_wp : _fallback_wps)
     {
-      fallback_plan_threads.emplace_back(std::thread([&, goal_wp]()
-      {
-        auto fallback_plan = 
-            planner.plan(
-              plan_starts,
-              rmf_traffic::agv::Plan::Goal(goal_wp),
-              _planner_options);
-
-        std::unique_lock<std::mutex> lock(fallback_plan_mutex);
-        if (fallback_plan)
+      fallback_plan_threads.emplace_back(
+        std::thread([&, goal_wp]()
         {
-          fallback_plan_solved = true;
-          plan_solved_cv.notify_all();
-        }
-        fallback_plans.emplace_back(std::move(fallback_plan));
-      }));
+          auto fallback_plan =
+          planner.plan(
+            plan_starts,
+            rmf_traffic::agv::Plan::Goal(goal_wp),
+            _planner_options);
+
+          std::unique_lock<std::mutex> lock(fallback_plan_mutex);
+          if (fallback_plan)
+          {
+            fallback_plan_solved = true;
+            plan_solved_cv.notify_all();
+          }
+          fallback_plans.emplace_back(std::move(fallback_plan));
+        }));
     }
 
     const auto giveup_time =
-        std::chrono::steady_clock::now() + _node->get_plan_time();
+      std::chrono::steady_clock::now() + _node->get_plan_time();
 
     const auto done_searching = [&]() -> bool
-    {
-      return main_plan_solved || (main_plan_failed && fallback_plan_solved);
-    };
+      {
+        return main_plan_solved || (main_plan_failed && fallback_plan_solved);
+      };
 
     // Waiting for the main planning thread is a bit complicated, because we
     // want to avoid the possibility that the plan finishes and triggers the
@@ -206,8 +208,8 @@ public:
       std::mutex placeholder;
       std::unique_lock<std::mutex> lock(placeholder);
       plan_solved_cv.wait_for(
-            lock, std::chrono::milliseconds(100),
-            [&](){ return done_searching(); });
+        lock, std::chrono::milliseconds(100),
+        [&]() { return done_searching(); });
     }
 
     interrupt_flag = true;
@@ -231,9 +233,9 @@ public:
       return execute_plan(std::move(plans));
 
     RCLCPP_INFO(
-          _node->get_logger(),
-          "Looking for a plan to open a schedule conflict for ["
-          + _context->robot_name() + "]");
+      _node->get_logger(),
+      "Looking for a plan to open a schedule conflict for ["
+      + _context->robot_name() + "]");
     plans = find_plan(start_delay, nullptr);
     if (plans.empty())
     {
@@ -243,10 +245,10 @@ public:
         wp_name = it->second;
 
       RCLCPP_ERROR(
-            _node->get_logger(),
-            "Unable to find a feasible plan for [" + _context->robot_name()
-            + "] to reach waypoint [" + wp_name
-            + "]. This is a critical error.");
+        _node->get_logger(),
+        "Unable to find a feasible plan for [" + _context->robot_name()
+        + "] to reach waypoint [" + wp_name
+        + "]. This is a critical error.");
       return;
     }
 
@@ -254,9 +256,9 @@ public:
   }
 
   void respond(
-      rmf_traffic::schedule::Negotiation::ConstTablePtr table,
-      const Responder& responder,
-      const bool* interrupt_flag) final
+    rmf_traffic::schedule::Negotiation::ConstTablePtr table,
+    const Responder& responder,
+    const bool* interrupt_flag) final
   {
     if (_event_executor.do_not_negotiate())
     {
@@ -267,7 +269,7 @@ public:
       for (const auto& p : proposal)
       {
         const auto other_participant =
-            _node->get_fields().mirror.viewer().get_participant(p.participant);
+          _node->get_fields().mirror.viewer().get_participant(p.participant);
         if (!other_participant)
         {
           // TODO(MXG): This is lazy and sloppy. For now we just reject the
@@ -288,10 +290,10 @@ public:
               continue;
 
             if (rmf_traffic::DetectConflict::between(
-                  profile,
-                  item.route->trajectory(),
-                  other_profile,
-                  other_route->trajectory()))
+                profile,
+                item.route->trajectory(),
+                other_profile,
+                other_route->trajectory()))
             {
               return responder.reject();
             }
@@ -309,10 +311,10 @@ public:
 
     // TODO(MXG): Do something with the interrupt flag
     std::vector<rmf_traffic::agv::Plan> plans =
-        find_plan(
-          std::chrono::seconds(0),
-          rmf_utils::make_clone<rmf_traffic::agv::NegotiatingRouteValidator>(
-            *table, _context->schedule.description().profile()));
+      find_plan(
+      std::chrono::seconds(0),
+      rmf_utils::make_clone<rmf_traffic::agv::NegotiatingRouteValidator>(
+        *table, _context->schedule.description().profile()));
 
     if (plans.empty())
     {
@@ -323,24 +325,24 @@ public:
     auto itinerary = collect_routes(plans);
     std::weak_ptr<void> weak_handle = _handle;
     responder.submit(
-          std::move(itinerary),
-          [this, table, plans = std::move(plans),
-           weak_handle = std::move(weak_handle)]()
-          -> rmf_utils::optional<rmf_traffic::schedule::ItineraryVersion>
-    {
-      auto handle = weak_handle.lock();
-      if (!handle)
+      std::move(itinerary),
+      [this, table, plans = std::move(plans),
+      weak_handle = std::move(weak_handle)]()
+      -> rmf_utils::optional<rmf_traffic::schedule::ItineraryVersion>
       {
-        return rmf_utils::nullopt;
-      }
+        auto handle = weak_handle.lock();
+        if (!handle)
+        {
+          return rmf_utils::nullopt;
+        }
 
-      execute_plan(std::move(plans));
-      return _context->schedule.participant().version();
-    });
+        execute_plan(std::move(plans));
+        return _context->schedule.participant().version();
+      });
   }
 
   std::vector<rmf_traffic::agv::Plan> use_fallback(
-      std::vector<rmf_utils::optional<rmf_traffic::agv::Plan>> fallback_plans)
+    std::vector<rmf_utils::optional<rmf_traffic::agv::Plan>> fallback_plans)
   {
     std::vector<rmf_traffic::agv::Plan> plans;
 
@@ -353,11 +355,11 @@ public:
 
     const auto& fallback_plan = *fallback_plans[i_nearest];
     const std::size_t fallback_waypoint =
-        *fallback_plan.get_waypoints().back().graph_index();
+      *fallback_plan.get_waypoints().back().graph_index();
     const double fallback_orientation =
-        fallback_plan.get_waypoints().back().position()[2];
+      fallback_plan.get_waypoints().back().position()[2];
     const auto fallback_end_time =
-        fallback_plan.get_waypoints().back().time();
+      fallback_plan.get_waypoints().back().time();
 
     const auto& planner = _node->get_planner();
 
@@ -371,35 +373,35 @@ public:
     std::mutex resume_plan_mutex;
     std::condition_variable resume_plan_cv;
 
-    for (std::size_t i=1; i < 9; ++i)
+    for (std::size_t i = 1; i < 9; ++i)
     {
       resume_plan_threads.emplace_back(std::thread([&, i]()
-      {
-        const auto resume_time = fallback_end_time + i*t_spread;
-        auto resume_plan = planner.plan(
-              rmf_traffic::agv::Plan::Start(
-                resume_time, fallback_waypoint, fallback_orientation),
-              rmf_traffic::agv::Plan::Goal(
-                _goal_wp_index),
-              _planner_options);
+        {
+          const auto resume_time = fallback_end_time + i*t_spread;
+          auto resume_plan = planner.plan(
+            rmf_traffic::agv::Plan::Start(
+              resume_time, fallback_waypoint, fallback_orientation),
+            rmf_traffic::agv::Plan::Goal(
+              _goal_wp_index),
+            _planner_options);
 
-        std::unique_lock<std::mutex> lock(resume_plan_mutex);
-        if (resume_plan)
-          have_resume_plan = true;
-        resume_plans.emplace_back(std::move(resume_plan));
-        resume_plan_cv.notify_all();
-      }));
+          std::unique_lock<std::mutex> lock(resume_plan_mutex);
+          if (resume_plan)
+            have_resume_plan = true;
+          resume_plans.emplace_back(std::move(resume_plan));
+          resume_plan_cv.notify_all();
+        }));
     }
 
     const auto giveup_time =
-        std::chrono::steady_clock::now() + _node->get_plan_time();
+      std::chrono::steady_clock::now() + _node->get_plan_time();
 
     while (std::chrono::steady_clock::now() < giveup_time && !have_resume_plan)
     {
       std::mutex placeholder;
       std::unique_lock<std::mutex> lock(placeholder);
       resume_plan_cv.wait_for(lock, std::chrono::milliseconds(100),
-                              [&](){ return have_resume_plan; });
+        [&]() { return have_resume_plan; });
     }
 
     interrupt_flag = true;
@@ -410,9 +412,9 @@ public:
     if (!quickest_finish_opt)
     {
       RCLCPP_WARN(
-            _node->get_logger(),
-            "Robot [" + _context->robot_name() + "] is stuck! We will try to "
-            "find a path again soon.");
+        _node->get_logger(),
+        "Robot [" + _context->robot_name() + "] is stuck! We will try to "
+        "find a path again soon.");
 
       return plans;
     }
@@ -426,8 +428,8 @@ public:
   }
 
   std::vector<rmf_traffic::Route> collect_routes(
-      std::vector<rmf_traffic::agv::Plan> plans,
-      std::chrono::nanoseconds delay = std::chrono::seconds(0)) const
+    std::vector<rmf_traffic::agv::Plan> plans,
+    std::chrono::nanoseconds delay = std::chrono::seconds(0)) const
   {
     std::vector<rmf_traffic::Route> routes;
     bool first_trajectory = true;
@@ -444,9 +446,9 @@ public:
           {
             const auto& s = r.trajectory().front();
             r.trajectory().insert(
-                  now,
-                  s.position(),
-                  Eigen::Vector3d::Zero());
+              now,
+              s.position(),
+              Eigen::Vector3d::Zero());
           }
         }
 
@@ -476,6 +478,8 @@ public:
       for (const auto& wp : plan.get_waypoints())
         _remaining_waypoints.emplace_back(wp);
 
+
+
     return send_next_command(false);
   }
 
@@ -504,20 +508,20 @@ public:
     const auto& graph = _node->get_graph();
 
     auto make_location = [&](
-        const Eigen::Vector3d& p,
-        const rmf_traffic::Time t)
-    {
-      rmf_fleet_msgs::msg::Location location;
-      location.t = rmf_traffic_ros2::convert(t);
-      location.x = p[0];
-      location.y = p[1];
-      location.yaw = p[2];
+      const Eigen::Vector3d& p,
+      const rmf_traffic::Time t)
+      {
+        rmf_fleet_msgs::msg::Location location;
+        location.t = rmf_traffic_ros2::convert(t);
+        location.x = p[0];
+        location.y = p[1];
+        location.yaw = p[2];
 
-      // TODO(MXG): Fix this assumption that every waypoint is on one map
-      location.level_name = graph.get_waypoint(0).get_map_name();
+        // TODO(MXG): Fix this assumption that every waypoint is on one map
+        location.level_name = graph.get_waypoint(0).get_map_name();
 
-      return location;
-    };
+        return location;
+      };
 
     _command->path.clear();
 
@@ -534,7 +538,7 @@ public:
       _command->path.emplace_back(make_location(wp.position(), wp.time()));
     }
 
-    std::size_t i=0;
+    std::size_t i = 0;
     for (; i < _remaining_waypoints.size(); ++i)
     {
       const auto& wp = _remaining_waypoints[i];
@@ -551,12 +555,12 @@ public:
 
     _issued_waypoints.clear();
     _issued_waypoints.insert(
-                _issued_waypoints.end(),
-                _remaining_waypoints.begin(),
-                _remaining_waypoints.begin()+i);
+      _issued_waypoints.end(),
+      _remaining_waypoints.begin(),
+      _remaining_waypoints.begin()+i);
     _remaining_waypoints.erase(
-                _remaining_waypoints.begin(),
-                _remaining_waypoints.begin()+i);
+      _remaining_waypoints.begin(),
+      _remaining_waypoints.begin()+i);
 
     if (_issued_waypoints.empty())
     {
@@ -564,11 +568,12 @@ public:
       return;
     }
 
-    const std::string& map_name = _node->get_graph().get_waypoint(0).get_map_name();
+    const std::string& map_name =
+      _node->get_graph().get_waypoint(0).get_map_name();
     const auto trajectory = make_trajectory(
-          _issued_waypoints.front().time(),
-          _command->path,
-          _node->get_fields().traits);
+      _issued_waypoints.front().time(),
+      _command->path,
+      _node->get_fields().traits);
     _context->schedule.push_routes({{map_name, trajectory}});
 
     const auto previous_delay = _finish_estimate - _original_finish_estimate;
@@ -584,18 +589,19 @@ public:
 
   void report_holding()
   {
-    const std::string& map_name = _node->get_graph().get_waypoint(0).get_map_name();
+    const std::string& map_name =
+      _node->get_graph().get_waypoint(0).get_map_name();
     // NOTE(MXG): 10 minutes is a crazy estimate, but it should help keep other
     // vehicles from disrupting the traversal.
     _context->schedule.push_routes({
-          rmf_traffic::Route{
-            map_name,
-            make_hold(
-              _context->location,
-              rmf_traffic_ros2::convert(_node->now()),
-              std::chrono::minutes(10))
-          }
-    });
+        rmf_traffic::Route{
+          map_name,
+          make_hold(
+            _context->location,
+            rmf_traffic_ros2::convert(_node->now()),
+            std::chrono::minutes(10))
+        }
+      });
   }
 
   void publish_command()
@@ -646,12 +652,12 @@ public:
 
       // Recompute a plan if the fleet driver has a huge delay.
       if (!_reported_excessive_delay
-          && now - _command_time > _node->get_delay_threshold())
+        && now - _command_time > _node->get_delay_threshold())
       {
         RCLCPP_ERROR(
-              _node->get_logger(),
-              "The fleet driver is being unresponsive to task plan ["
-              + task_id() + "]");
+          _node->get_logger(),
+          "The fleet driver is being unresponsive to task plan ["
+          + task_id() + "]");
         _reported_excessive_delay = true;
       }
 
@@ -670,9 +676,9 @@ public:
       // be to optimally reroute the robot onto the intended itinerary, but that
       // can be saved for future work.
       RCLCPP_INFO(
-            _node->get_logger(),
-            "Replanning for [" + _context->robot_name()
-            + "] due to an adapter error");
+        _node->get_logger(),
+        "Replanning for [" + _context->robot_name()
+        + "] due to an adapter error");
       if (_emergency_active)
         find_and_execute_emergency_plan();
       else
@@ -696,30 +702,30 @@ public:
     if (!event_wp.event())
     {
       const Eigen::Vector3d next_stop =
-          _issued_waypoints.back().position();
+        _issued_waypoints.back().position();
 
       const auto& l = msg.location;
       const Eigen::Vector3d p{l.x, l.y, l.yaw};
       const double dist =
-          (p.block<2,1>(0,0) - next_stop.block<2,1>(0,0)).norm();
+        (p.block<2, 1>(0, 0) - next_stop.block<2, 1>(0, 0)).norm();
 
       // TODO(MXG) Make this threshold configurable
       if (dist > 2.0)
       {
         RCLCPP_ERROR(
-              _node->get_logger(),
-              "The robot is very far [" + std::to_string(dist) + "m] from "
-              "where it is supposed to be, but its path is empty");
+          _node->get_logger(),
+          "The robot is very far [" + std::to_string(dist) + "m] from "
+          "where it is supposed to be, but its path is empty");
         return;
       }
 
       // TODO(MXG) Make this threshold configurable
-      if ( dist > 0.1 )
+      if (dist > 0.1)
       {
         RCLCPP_WARN(
-              _node->get_logger(),
-              "The robot is somewhat far [" + std::to_string(dist) + "m] from "
-              "where it is supposed to be, but we will proceed anyway.");
+          _node->get_logger(),
+          "The robot is somewhat far [" + std::to_string(dist) + "m] from "
+          "where it is supposed to be, but we will proceed anyway.");
       }
 
       send_next_command();
@@ -732,7 +738,7 @@ public:
 
     const auto& l = msg.location;
     const Eigen::Vector2d p{l.x, l.y};
-    const Eigen::Vector2d target = event_wp.position().block<2,1>(0,0);
+    const Eigen::Vector2d target = event_wp.position().block<2, 1>(0, 0);
 
     // TODO(MXG): Consider making this threshold configurable
     if ((p - target).norm() < 0.5)
@@ -771,18 +777,18 @@ public:
 
     bool s;
     auto trajectory_estimate =
-        make_trajectory(msg, _node->get_fields().traits, s);
+      make_trajectory(msg, _node->get_fields().traits, s);
 
     const auto new_finish_estimate = *trajectory_estimate.finish_time();
 
     const auto total_delay = new_finish_estimate - _original_finish_estimate;
     if (!_event_executor.do_not_negotiate()
-        && std::chrono::seconds(10) < total_delay)
+      && std::chrono::seconds(10) < total_delay)
     {
       RCLCPP_INFO(
-            _node->get_logger(),
-            "Replanning for [" + _context->robot_name()
-            + "] due to excessive delays");
+        _node->get_logger(),
+        "Replanning for [" + _context->robot_name()
+        + "] due to excessive delays");
       if (_emergency_active)
         find_and_execute_emergency_plan();
       else
@@ -793,15 +799,16 @@ public:
     const auto tweaked_delay = new_finish_estimate - _tweaked_finish_estimate;
     if (std::chrono::seconds(2) < tweaked_delay)
     {
-      const std::string& map_name = _node->get_graph().get_waypoint(0).get_map_name();
+      const std::string& map_name =
+        _node->get_graph().get_waypoint(0).get_map_name();
       _context->schedule.push_routes({{map_name, trajectory_estimate}});
       _finish_estimate = new_finish_estimate;
       RCLCPP_INFO(
-            _node->get_logger(),
-            "Recomputing itinerary for [" + _context->robot_name()
-            + "] due to excess delays ["
-            + std::to_string(rmf_traffic::time::to_seconds(total_delay))
-            + "s]");
+        _node->get_logger(),
+        "Recomputing itinerary for [" + _context->robot_name()
+        + "] due to excess delays ["
+        + std::to_string(rmf_traffic::time::to_seconds(total_delay))
+        + "s]");
       _tweaked_finish_estimate = _finish_estimate;
       return;
     }
@@ -811,13 +818,13 @@ public:
     if (std::chrono::milliseconds(500) < new_delay)
     {
       RCLCPP_INFO(
-            _node->get_logger(),
-            "Adding a delay of [%f] for [%s]",
-            rmf_traffic::time::to_seconds(new_delay),
-            _context->robot_name().c_str());
+        _node->get_logger(),
+        "Adding a delay of [%f] for [%s]",
+        rmf_traffic::time::to_seconds(new_delay),
+        _context->robot_name().c_str());
 
       const auto from_time =
-          rmf_traffic_ros2::convert(msg.location.t) - new_delay;
+        rmf_traffic_ros2::convert(msg.location.t) - new_delay;
       _context->schedule.push_delay(new_delay, from_time);
       _finish_estimate = new_finish_estimate;
     }
@@ -829,9 +836,9 @@ public:
     if (!_waiting_on_emergency)
     {
       RCLCPP_INFO(
-            _node->get_logger(),
-            "Robot [" + _context->robot_name() + "] has arrived at its "
-            "emergency parking spot and is waiting.");
+        _node->get_logger(),
+        "Robot [" + _context->robot_name() + "] has arrived at its "
+        "emergency parking spot and is waiting.");
       _waiting_on_emergency = true;
       const auto& p = _context->location;
       const Eigen::Vector3d position{p.x, p.y, p.yaw};
@@ -843,23 +850,23 @@ public:
       _original_finish_estimate = _finish_estimate;
 
       wait_trajectory.insert(
-            _finish_estimate, position, Eigen::Vector3d::Zero());
+        _finish_estimate, position, Eigen::Vector3d::Zero());
 
       const std::string& map_name =
-          _node->get_graph().get_waypoint(0).get_map_name();
+        _node->get_graph().get_waypoint(0).get_map_name();
       _context->schedule.push_routes({{map_name, wait_trajectory}});
     }
     else
     {
       const auto remaining_scheduled_time =
-          _finish_estimate - rmf_traffic_ros2::convert(_node->now());
+        _finish_estimate - rmf_traffic_ros2::convert(_node->now());
 
       if (remaining_scheduled_time < std::chrono::minutes(3))
       {
         RCLCPP_INFO(
-              _node->get_logger(),
-              "Robot [" + _context->robot_name() +"] is continuing to wait "
-              "at its emergency parking spot.");
+          _node->get_logger(),
+          "Robot [" + _context->robot_name() +"] is continuing to wait "
+          "at its emergency parking spot.");
         const auto new_finish_estimate = now + std::chrono::minutes(5);
         const auto schedule_delay = new_finish_estimate - _finish_estimate;
         _finish_estimate = new_finish_estimate;
@@ -873,8 +880,8 @@ public:
   using DoorState = rmf_door_msgs::msg::DoorState;
   using LiftState = rmf_lift_msgs::msg::LiftState;
   class EventListener
-      : public Listener<DoorState>,
-        public Listener<LiftState>
+    : public Listener<DoorState>,
+    public Listener<LiftState>
   {
   public:
 
@@ -968,7 +975,7 @@ public:
       _parent->_current_dock_name = dock.dock_name();
 
       status = " - Waiting for docking into ["
-          + _parent->_current_dock_name + "]";
+        + _parent->_current_dock_name + "]";
 
       ++_parent->_command_id;
       _parent->_task->report_status();
@@ -978,8 +985,8 @@ public:
     }
 
     void request_door_mode(
-        const std::string& door_name,
-        const uint32_t mode)
+      const std::string& door_name,
+      const uint32_t mode)
     {
       _command_time = _parent->_node->get_clock()->now();
 
@@ -988,16 +995,16 @@ public:
       request.request_time = _command_time;
       request.requested_mode.value = mode;
       request.requester_id = _parent->_node->get_fleet_name()
-          + "/" + _parent->_context->robot_name();
+        + "/" + _parent->_context->robot_name();
 
       _parent->_node->door_request_publisher->publish(request);
     }
 
     void wait_for_door_mode(
-        const DoorState& msg,
-        const uint32_t mode,
-        const std::string& door_name,
-        const rclcpp::Time& initial_time)
+      const DoorState& msg,
+      const uint32_t mode,
+      const std::string& door_name,
+      const rclcpp::Time& initial_time)
     {
       const auto time = rclcpp::Time(msg.door_time);
       if (time < initial_time)
@@ -1038,11 +1045,11 @@ public:
       status = " - Waiting for door [" + door_name + "] to open";
 
       _parent->_event_listener.door =
-          [=](const DoorState& msg)
-      {
-        this->wait_for_door_mode(
-              msg, DoorMode::MODE_OPEN, door_name, initial_time);
-      };
+        [=](const DoorState& msg)
+        {
+          this->wait_for_door_mode(
+            msg, DoorMode::MODE_OPEN, door_name, initial_time);
+        };
 
       _parent->_task->report_status();
       request_door_mode(door_name, DoorMode::MODE_OPEN);
@@ -1062,11 +1069,11 @@ public:
       status = " - Waiting for door [" + door_name + "] to close";
 
       _parent->_event_listener.door =
-          [=](const DoorState& msg)
-      {
-        this->wait_for_door_mode(
-              msg, DoorMode::MODE_CLOSED, door_name, initial_time);
-      };
+        [=](const DoorState& msg)
+        {
+          this->wait_for_door_mode(
+            msg, DoorMode::MODE_CLOSED, door_name, initial_time);
+        };
 
       _parent->_task->report_status();
       request_door_mode(door_name, DoorMode::MODE_CLOSED);
@@ -1074,17 +1081,17 @@ public:
     }
 
     void request_lift_mode(
-        const std::string& lift_name,
-        const std::string& floor_name,
-        uint8_t lift_mode,
-        uint8_t door_state)
+      const std::string& lift_name,
+      const std::string& floor_name,
+      uint8_t lift_mode,
+      uint8_t door_state)
     {
       _command_time = _parent->_node->get_clock()->now();
 
       LiftRequest request;
       request.lift_name = lift_name;
       request.session_id = _parent->_node->get_fleet_name()
-          + "/" + _parent->_context->robot_name();
+        + "/" + _parent->_context->robot_name();
       request.request_type = lift_mode;
       request.destination_floor = floor_name;
       request.door_state = door_state;
@@ -1093,11 +1100,11 @@ public:
     }
 
     void wait_for_lift_mode(
-        const LiftState& msg,
-        const std::string& lift_name,
-        const std::string& floor_name,
-        const uint8_t lift_mode,
-        const uint8_t door_state)
+      const LiftState& msg,
+      const std::string& lift_name,
+      const std::string& floor_name,
+      const uint8_t lift_mode,
+      const uint8_t door_state)
     {
       // TODO(MXG): Accepting any lift when lift_name is empty is a temporary
       // hack for an upcoming demo, and it should be removed immediately.
@@ -1108,7 +1115,7 @@ public:
       {
         // Send the command periodically as a precaution
         request_lift_mode(
-              lift_name, floor_name, lift_mode, door_state);
+          lift_name, floor_name, lift_mode, door_state);
       }
 
       if (msg.current_floor != floor_name)
@@ -1135,22 +1142,22 @@ public:
       const auto initial_time = _parent->_node->get_clock()->now();
 
       status = " - Waiting for lift [" + lift_name + "] to open on floor ["
-          + floor_name + "]";
+        + floor_name + "]";
 
       _parent->_event_listener.lift =
-          [=](const LiftState& msg)
-      {
-        this->wait_for_lift_mode(
-              msg, lift_name, floor_name,
-              LiftRequest::REQUEST_AGV_MODE,
-              LiftRequest::DOOR_OPEN);
-      };
+        [=](const LiftState& msg)
+        {
+          this->wait_for_lift_mode(
+            msg, lift_name, floor_name,
+            LiftRequest::REQUEST_AGV_MODE,
+            LiftRequest::DOOR_OPEN);
+        };
 
       _parent->_task->report_status();
       request_lift_mode(
-            lift_name, floor_name,
-            LiftRequest::REQUEST_AGV_MODE,
-            LiftRequest::DOOR_OPEN);
+        lift_name, floor_name,
+        LiftRequest::REQUEST_AGV_MODE,
+        LiftRequest::DOOR_OPEN);
       _parent->report_holding();
     }
 
@@ -1169,9 +1176,9 @@ public:
       // just shoot off the END_SESSION message and carry on with the next
       // step of the plan.
       request_lift_mode(
-            lift_name, floor_name,
-            LiftRequest::REQUEST_END_SESSION,
-            LiftRequest::DOOR_CLOSED);
+        lift_name, floor_name,
+        LiftRequest::REQUEST_END_SESSION,
+        LiftRequest::DOOR_CLOSED);
 
       return _parent->send_next_command();
     }
@@ -1188,13 +1195,13 @@ public:
       const auto initial_time = _parent->_node->get_clock()->now();
 
       _parent->_event_listener.lift =
-          [=](const LiftState& msg)
-      {
-        this->wait_for_lift_mode(
-              msg, lift_name, floor_name,
-              LiftRequest::REQUEST_AGV_MODE,
-              LiftRequest::DOOR_OPEN);
-      };
+        [=](const LiftState& msg)
+        {
+          this->wait_for_lift_mode(
+            msg, lift_name, floor_name,
+            LiftRequest::REQUEST_AGV_MODE,
+            LiftRequest::DOOR_OPEN);
+        };
 
       _parent->report_holding();
     }
@@ -1227,30 +1234,30 @@ public:
   }
 
   std::vector<rmf_traffic::agv::Plan> find_emergency_plan(
-      const rmf_utils::clone_ptr<rmf_traffic::agv::RouteValidator> validator)
+    const rmf_utils::clone_ptr<rmf_traffic::agv::RouteValidator> validator)
   {
     _emergency_active = true;
 
     const auto& planner = _node->get_planner();
 
-    Eigen::Vector3d pose = 
-        {_context->location.x, _context->location.y, _context->location.yaw};
-    const auto start_time = 
-        rmf_traffic_ros2::convert(_node->get_clock()->now()) + 
-        std::chrono::nanoseconds(0);
+    Eigen::Vector3d pose =
+    {_context->location.x, _context->location.y, _context->location.yaw};
+    const auto start_time =
+      rmf_traffic_ros2::convert(_node->get_clock()->now()) +
+      std::chrono::nanoseconds(0);
 
     // TODO: further parameterize waypoint and lane merging distance
     const auto plan_starts =
-        rmf_traffic::agv::compute_plan_starts(
-            planner.get_configuration().graph(), pose, start_time, 0.1, 1.0,
-            1e-8);
+      rmf_traffic::agv::compute_plan_starts(
+      planner.get_configuration().graph(), pose, start_time, 0.1, 1.0,
+      1e-8);
 
     if (plan_starts.empty())
     {
       RCLCPP_WARN(
-          _node->get_logger(), 
-          "The robot appears to be in an unrecoverable state, failed to find "
-          "suitable waypoints on the graph to start planning.");
+        _node->get_logger(),
+        "The robot appears to be in an unrecoverable state, failed to find "
+        "suitable waypoints on the graph to start planning.");
       return {};
     }
 
@@ -1266,33 +1273,33 @@ public:
     for (const std::size_t goal_wp : _fallback_wps)
     {
       plan_threads.emplace_back(std::thread([&, goal_wp]()
-      {
-        auto emergency_plan = 
-            planner.plan(
-              plan_starts,
-              rmf_traffic::agv::Plan::Goal(goal_wp),
-              _planner_options);
+        {
+          auto emergency_plan =
+          planner.plan(
+            plan_starts,
+            rmf_traffic::agv::Plan::Goal(goal_wp),
+            _planner_options);
 
-        std::unique_lock<std::mutex> lock(plans_mutex);
-        if (emergency_plan)
-          have_plan = true;
+          std::unique_lock<std::mutex> lock(plans_mutex);
+          if (emergency_plan)
+            have_plan = true;
 
-        candidate_plans.emplace_back(std::move(emergency_plan));
-        plans_cv.notify_all();
-      }));
+          candidate_plans.emplace_back(std::move(emergency_plan));
+          plans_cv.notify_all();
+        }));
     }
 
     const auto giveup_time =
-        std::chrono::steady_clock::now() + 5*_node->get_plan_time();
+      std::chrono::steady_clock::now() + 5*_node->get_plan_time();
 
     while (std::chrono::steady_clock::now() < giveup_time && !have_plan)
     {
       std::unique_lock<std::mutex> lock(plans_mutex);
       plans_cv.wait_for(lock, std::chrono::milliseconds(100),
-                        [&](){ return have_plan; });
+        [&]() { return have_plan; });
     }
 
-    interrupt_flag =  true;
+    interrupt_flag = true;
     for (auto& plan_thread : plan_threads)
       plan_thread.join();
 
@@ -1300,23 +1307,23 @@ public:
     if (!quickest_finish_opt)
     {
       RCLCPP_WARN(
-            _node->get_logger(),
-            "Robot [" + _context->robot_name() + "] is stuck while searching "
-            "for an emergency plan! We will try to find a path again soon.");
+        _node->get_logger(),
+        "Robot [" + _context->robot_name() + "] is stuck while searching "
+        "for an emergency plan! We will try to find a path again soon.");
 
       return {};
     }
 
     const std::size_t emergency_wp_index =
-        *candidate_plans[*quickest_finish_opt]->get_waypoints().back().graph_index();
-    const auto it =_node->get_waypoint_names().find(emergency_wp_index);
+      *candidate_plans[*quickest_finish_opt]->get_waypoints().back().graph_index();
+    const auto it = _node->get_waypoint_names().find(emergency_wp_index);
     const auto emergency_wp_name =
-        (it == _node->get_waypoint_names().end()) ? "" : (":" + it->second);
+      (it == _node->get_waypoint_names().end()) ? "" : (":" + it->second);
 
     RCLCPP_INFO(
-          _node->get_logger(),
-          "Choosing emergency waypoint [" + std::to_string(emergency_wp_index)
-          + emergency_wp_name + "] for [" + _context->robot_name() + "]");
+      _node->get_logger(),
+      "Choosing emergency waypoint [" + std::to_string(emergency_wp_index)
+      + emergency_wp_name + "] for [" + _context->robot_name() + "]");
 
     return {*candidate_plans[*quickest_finish_opt]};
   }
@@ -1331,9 +1338,9 @@ public:
     if (plans.empty())
     {
       RCLCPP_ERROR(
-            _node->get_logger(),
-            "Unable to find a feasible emergency plan for ["
-            + _context->robot_name() + "]. This is a critical error.");
+        _node->get_logger(),
+        "Unable to find a feasible emergency plan for ["
+        + _context->robot_name() + "]. This is a critical error.");
       return;
     }
 
@@ -1346,8 +1353,8 @@ public:
       return;
 
     RCLCPP_INFO(
-          _node->get_logger(),
-          "Interrupting move task for [" + _context->robot_name() + "]");
+      _node->get_logger(),
+      "Interrupting move task for [" + _context->robot_name() + "]");
     find_and_execute_emergency_plan();
   }
 
@@ -1357,8 +1364,8 @@ public:
       return;
 
     RCLCPP_INFO(
-          _node->get_logger(),
-          "Resuming normal operations for [" + _context->robot_name() + "]");
+      _node->get_logger(),
+      "Resuming normal operations for [" + _context->robot_name() + "]");
     find_and_execute_plan(std::chrono::seconds(0));
   }
 
@@ -1368,12 +1375,13 @@ public:
 
     const auto& waypoint_names = _node->get_waypoint_names();
 
-    auto name_of = [&](std::size_t wp_index) -> std::string
-    {
-      const auto wp_it = waypoint_names.find(wp_index);
-      return wp_it == waypoint_names.end()?
-            "#" + std::to_string(_goal_wp_index) : wp_it->second;
-    };
+    auto name_of =
+      [&](std::size_t wp_index) -> std::string
+      {
+        const auto wp_it = waypoint_names.find(wp_index);
+        return wp_it == waypoint_names.end() ?
+          "#" + std::to_string(_goal_wp_index) : wp_it->second;
+      };
 
     status = "Moving to waypoint [" + name_of(_goal_wp_index) + "]";
 
@@ -1396,7 +1404,7 @@ public:
     rmf_utils::optional<rmf_traffic::agv::Plan::Waypoint> final_wp;
     if (!_remaining_waypoints.empty())
       final_wp = _remaining_waypoints.back();
-    else if(!_issued_waypoints.empty())
+    else if (!_issued_waypoints.empty())
       final_wp = _issued_waypoints.back();
 
     if (final_wp)
@@ -1420,9 +1428,12 @@ private:
   bool _reported_excessive_delay = true;
   std::vector<rmf_traffic::agv::Plan::Waypoint> _remaining_waypoints;
   std::vector<rmf_traffic::agv::Plan::Waypoint> _issued_waypoints;
-  rmf_traffic::Time _finish_estimate = rmf_traffic::Time(std::chrono::seconds(0));
-  rmf_traffic::Time _tweaked_finish_estimate = rmf_traffic::Time(std::chrono::seconds(0));
-  rmf_traffic::Time _original_finish_estimate = rmf_traffic::Time(std::chrono::seconds(0));
+  rmf_traffic::Time _finish_estimate =
+    rmf_traffic::Time(std::chrono::seconds(0));
+  rmf_traffic::Time _tweaked_finish_estimate = rmf_traffic::Time(std::chrono::seconds(
+        0));
+  rmf_traffic::Time _original_finish_estimate = rmf_traffic::Time(std::chrono::seconds(
+        0));
   rmf_utils::optional<Eigen::Vector3d> _next_stop;
   rmf_utils::optional<rmf_fleet_msgs::msg::PathRequest> _command;
   std::size_t _command_id = 0;
@@ -1450,14 +1461,14 @@ MoveAction::~MoveAction()
 
 //==============================================================================
 std::unique_ptr<Action> make_move(
-    FleetAdapterNode* node,
-    FleetAdapterNode::RobotContext* state,
-    Task* parent,
-    const std::size_t goal_wp_index,
-    const std::size_t move_id)
+  FleetAdapterNode* node,
+  FleetAdapterNode::RobotContext* state,
+  Task* parent,
+  const std::size_t goal_wp_index,
+  const std::size_t move_id)
 {
   return std::make_unique<MoveAction>(
-        node, parent, state, goal_wp_index, move_id);
+    node, parent, state, goal_wp_index, move_id);
 }
 
 } // namespace full_control

--- a/rmf_fleet_adapter/src/full_control/Tasks.cpp
+++ b/rmf_fleet_adapter/src/full_control/Tasks.cpp
@@ -27,9 +27,9 @@ class GenericTask : public Task
 public:
 
   GenericTask(
-      FleetAdapterNode* node,
-      FleetAdapterNode::RobotContext* context,
-      std::string task_id)
+    FleetAdapterNode* node,
+    FleetAdapterNode::RobotContext* context,
+    std::string task_id)
   : _node(node),
     _context(context),
     _task_id(std::move(task_id)),
@@ -66,9 +66,9 @@ public:
     if (!_action)
     {
       RCLCPP_WARN(
-            _node->get_logger(),
-            "No action for this task [" + id() + "] to interrupt. This might "
-            "indicate a bug!");
+        _node->get_logger(),
+        "No action for this task [" + id() + "] to interrupt. This might "
+        "indicate a bug!");
       return;
     }
 
@@ -80,9 +80,9 @@ public:
     if (!_action)
     {
       RCLCPP_WARN(
-            _node->get_logger(),
-            "No action for this task [" + id() + "] to resume. This might "
-            "indicate a bug!");
+        _node->get_logger(),
+        "No action for this task [" + id() + "] to resume. This might "
+        "indicate a bug!");
       return;
     }
 
@@ -104,16 +104,16 @@ public:
 //  }
 
   void respond(
-      rmf_traffic::schedule::Negotiation::ConstTablePtr table,
-      const Responder& responder,
-      const bool* interrupt_flag) final
+    rmf_traffic::schedule::Negotiation::ConstTablePtr table,
+    const Responder& responder,
+    const bool* interrupt_flag) final
   {
     if (!_action)
     {
       RCLCPP_WARN(
-            _node->get_logger(),
-            "No action for this task [" + id() + "] to respond with. This "
-            "might indicate a bug!");
+        _node->get_logger(),
+        "No action for this task [" + id() + "] to respond with. This "
+        "might indicate a bug!");
       responder.submit({});
       return;
     }
@@ -185,9 +185,9 @@ private:
 };
 
 void report_impossible(
-    FleetAdapterNode* const node,
-    std::string task_id,
-    std::string error)
+  FleetAdapterNode* const node,
+  std::string task_id,
+  std::string error)
 {
   rmf_task_msgs::msg::TaskSummary summary;
   summary.status = std::move(error);
@@ -203,9 +203,9 @@ void report_impossible(
 
 //==============================================================================
 std::unique_ptr<Task> make_delivery(
-    FleetAdapterNode* const node,
-    FleetAdapterNode::RobotContext* const context,
-    rmf_task_msgs::msg::Delivery delivery)
+  FleetAdapterNode* const node,
+  FleetAdapterNode::RobotContext* const context,
+  rmf_task_msgs::msg::Delivery delivery)
 {
   const auto& waypoint_keys = node->get_fields().graph_info.keys;
   const auto& dispenser_names = node->get_fields().graph_info.workcell_names;
@@ -215,8 +215,8 @@ std::unique_ptr<Task> make_delivery(
   if (pickup_wp == waypoint_keys.end())
   {
     std::string error =
-        "Unknown pickup location [" + delivery.pickup_place_name
-        + "] in delivery request [" + delivery.task_id + "]";
+      "Unknown pickup location [" + delivery.pickup_place_name
+      + "] in delivery request [" + delivery.task_id + "]";
 
     RCLCPP_ERROR(node->get_logger(), error);
     report_impossible(node, task_id, std::move(error));
@@ -227,9 +227,9 @@ std::unique_ptr<Task> make_delivery(
   if (pickup_dispenser == dispenser_names.end())
   {
     std::string error =
-        "No known workcell available at pickup location ["
-        + delivery.pickup_place_name + "] in delivery request ["
-        + delivery.task_id + "]";
+      "No known workcell available at pickup location ["
+      + delivery.pickup_place_name + "] in delivery request ["
+      + delivery.task_id + "]";
 
     RCLCPP_ERROR(node->get_logger(), error);
     report_impossible(node, task_id, std::move(error));
@@ -240,8 +240,8 @@ std::unique_ptr<Task> make_delivery(
   if (dropoff_wp == waypoint_keys.end())
   {
     std::string error =
-        "Unknown dropoff location [" + delivery.dropoff_place_name + "] in "
-        + "delivery request [" + delivery.task_id + "]";
+      "Unknown dropoff location [" + delivery.dropoff_place_name + "] in "
+      + "delivery request [" + delivery.task_id + "]";
 
     RCLCPP_ERROR(node->get_logger(), error);
     report_impossible(node, task_id, std::move(error));
@@ -252,9 +252,9 @@ std::unique_ptr<Task> make_delivery(
   if (dropoff_dispenser == dispenser_names.end())
   {
     std::string error =
-        "No known workcell available at dropoff location ["
-        + delivery.dropoff_place_name + "] in delivery request ["
-        + delivery.task_id + "]";
+      "No known workcell available at dropoff location ["
+      + delivery.dropoff_place_name + "] in delivery request ["
+      + delivery.task_id + "]";
 
     RCLCPP_ERROR(node->get_logger(), error);
     report_impossible(node, task_id, std::move(error));
@@ -267,18 +267,18 @@ std::unique_ptr<Task> make_delivery(
 
   std::size_t move_id = 0;
   action_queue.push(
-        make_move(node, context, task.get(), pickup_wp->second, move_id++));
+    make_move(node, context, task.get(), pickup_wp->second, move_id++));
 
   action_queue.push(
-        make_dispense(node, context, task.get(), pickup_dispenser->second,
-                      delivery.items, delivery.pickup_behavior));
+    make_dispense(node, context, task.get(), pickup_dispenser->second,
+    delivery.items, delivery.pickup_behavior));
 
   action_queue.push(
-        make_move(node, context, task.get(), dropoff_wp->second, move_id++));
+    make_move(node, context, task.get(), dropoff_wp->second, move_id++));
 
   action_queue.push(
-        make_dispense(node, context, task.get(), dropoff_dispenser->second,
-                      delivery.items, delivery.dropoff_behavior));
+    make_dispense(node, context, task.get(), dropoff_dispenser->second,
+    delivery.items, delivery.dropoff_behavior));
 
   task->fill_queue(std::move(action_queue));
 
@@ -288,9 +288,9 @@ std::unique_ptr<Task> make_delivery(
 
 //==============================================================================
 std::unique_ptr<Task> make_loop(
-    FleetAdapterNode* node,
-    FleetAdapterNode::RobotContext* context,
-    rmf_task_msgs::msg::Loop loop)
+  FleetAdapterNode* node,
+  FleetAdapterNode::RobotContext* context,
+  rmf_task_msgs::msg::Loop loop)
 {
   const auto& waypoint_keys = node->get_waypoint_keys();
   const auto& task_id = loop.task_id;
@@ -299,8 +299,8 @@ std::unique_ptr<Task> make_loop(
   if (start_wp == waypoint_keys.end())
   {
     std::string error =
-        "Unknown start location [" + loop.start_name + "] in loop request ["
-        + task_id + "]";
+      "Unknown start location [" + loop.start_name + "] in loop request ["
+      + task_id + "]";
 
     RCLCPP_ERROR(node->get_logger(), error);
     report_impossible(node, task_id, std::move(error));
@@ -311,8 +311,8 @@ std::unique_ptr<Task> make_loop(
   if (finish_wp == waypoint_keys.end())
   {
     std::string error =
-        "Unknown finish location [" + loop.finish_name + "] in loop request ["
-        + task_id + "]";
+      "Unknown finish location [" + loop.finish_name + "] in loop request ["
+      + task_id + "]";
 
     RCLCPP_ERROR(node->get_logger(), error);
     report_impossible(node, task_id, std::move(error));
@@ -323,13 +323,13 @@ std::unique_ptr<Task> make_loop(
 
   std::size_t move_id = 0;
   std::queue<std::unique_ptr<Action>> action_queue;
-  for (std::size_t i=0; i < loop.num_loops; ++i)
+  for (std::size_t i = 0; i < loop.num_loops; ++i)
   {
     action_queue.push(
-          make_move(node, context, task.get(), start_wp->second, move_id++));
+      make_move(node, context, task.get(), start_wp->second, move_id++));
 
     action_queue.push(
-          make_move(node, context, task.get(), finish_wp->second, move_id++));
+      make_move(node, context, task.get(), finish_wp->second, move_id++));
   }
 
   task->fill_queue(std::move(action_queue));

--- a/rmf_fleet_adapter/src/full_control/Tasks.hpp
+++ b/rmf_fleet_adapter/src/full_control/Tasks.hpp
@@ -24,20 +24,20 @@ namespace rmf_fleet_adapter {
 namespace full_control {
 
 std::unique_ptr<Task> make_delivery(
-    FleetAdapterNode* node,
-    FleetAdapterNode::RobotContext* context,
-    rmf_task_msgs::msg::Delivery delivery);
+  FleetAdapterNode* node,
+  FleetAdapterNode::RobotContext* context,
+  rmf_task_msgs::msg::Delivery delivery);
 
 std::unique_ptr<Task> make_loop(
-    FleetAdapterNode* node,
-    FleetAdapterNode::RobotContext* context,
-    rmf_task_msgs::msg::Loop loop);
+  FleetAdapterNode* node,
+  FleetAdapterNode::RobotContext* context,
+  rmf_task_msgs::msg::Loop loop);
 
 
 void report_impossible(
-    FleetAdapterNode* const node,
-    std::string task_id,
-    std::string error);
+  FleetAdapterNode* const node,
+  std::string task_id,
+  std::string error);
 
 } // namespace full_control
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -33,7 +33,8 @@ int main(int argc, char* argv[])
     return 1;
 
 //  RCLCPP_INFO(fleet_adapter_node->get_logger(), "Starting Fleet Adapter");
-  std::cout << "Starting [" << fleet_adapter_node->get_fleet_name() << "]" << std::endl;
+  std::cout << "Starting [" << fleet_adapter_node->get_fleet_name() << "]" <<
+    std::endl;
   rclcpp::spin(fleet_adapter_node);
   RCLCPP_INFO(fleet_adapter_node->get_logger(), "Closing Fleet Adapter");
 

--- a/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
+++ b/rmf_fleet_adapter/src/lift_supervisor/Node.cpp
@@ -30,24 +30,24 @@ Node::Node()
   const auto default_qos = rclcpp::SystemDefaultsQoS();
 
   _lift_request_pub = create_publisher<LiftRequest>(
-        FinalLiftRequestTopicName, default_qos);
+    FinalLiftRequestTopicName, default_qos);
 
   _adapter_lift_request_sub = create_subscription<LiftRequest>(
-        AdapterLiftRequestTopicName, default_qos,
-        [&](LiftRequest::UniquePtr msg)
-  {
-    _adapter_lift_request_update(std::move(msg));
-  });
+    AdapterLiftRequestTopicName, default_qos,
+    [&](LiftRequest::UniquePtr msg)
+    {
+      _adapter_lift_request_update(std::move(msg));
+    });
 
   _lift_state_sub = create_subscription<LiftState>(
-        LiftStateTopicName, default_qos,
-        [&](LiftState::UniquePtr msg)
-  {
-    _lift_state_update(std::move(msg));
-  });
+    LiftStateTopicName, default_qos,
+    [&](LiftState::UniquePtr msg)
+    {
+      _lift_state_update(std::move(msg));
+    });
 
   _emergency_notice_pub = create_publisher<EmergencyNotice>(
-        rmf_traffic_ros2::EmergencyTopicName, default_qos);
+    rmf_traffic_ros2::EmergencyTopicName, default_qos);
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
+++ b/rmf_fleet_adapter/src/read_only/FleetAdapterNode.cpp
@@ -41,10 +41,10 @@ std::shared_ptr<FleetAdapterNode> FleetAdapterNode::make()
   auto node = std::shared_ptr<FleetAdapterNode>(new FleetAdapterNode);
 
   const auto wait_time =
-      get_parameter_or_default_time(*node, "discovery_timeout", 10.0);
+    get_parameter_or_default_time(*node, "discovery_timeout", 10.0);
 
   node->_delay_threshold =
-      get_parameter_or_default_time(*node, "delay_threshold", 5.0);
+    get_parameter_or_default_time(*node, "delay_threshold", 5.0);
 
   node->_writer = rmf_traffic_ros2::schedule::Writer::make(*node);
 
@@ -58,16 +58,16 @@ std::shared_ptr<FleetAdapterNode> FleetAdapterNode::make()
   }
 
   RCLCPP_INFO(
-        node->get_logger(),
-        "Timeout while trying to connect to traffic schedule");
+    node->get_logger(),
+    "Timeout while trying to connect to traffic schedule");
   return nullptr;
 }
 
 //==============================================================================
 FleetAdapterNode::ScheduleEntry::ScheduleEntry(
-    FleetAdapterNode* node,
-    std::string name,
-    std::mutex& async_mutex)
+  FleetAdapterNode* node,
+  std::string name,
+  std::mutex& async_mutex)
 {
   rmf_traffic::schedule::ParticipantDescription description{
     std::move(name),
@@ -77,11 +77,11 @@ FleetAdapterNode::ScheduleEntry::ScheduleEntry(
   };
 
   async_make_schedule_manager(
-        *node, *node->_writer, nullptr, std::move(description),
-        [this](ScheduleManager manager)
-  {
-    this->schedule = std::move(manager);
-  }, async_mutex);
+    *node, *node->_writer, nullptr, std::move(description),
+    [this](ScheduleManager manager)
+    {
+      this->schedule = std::move(manager);
+    }, async_mutex);
 }
 
 //==============================================================================
@@ -100,12 +100,12 @@ FleetAdapterNode::FleetAdapterNode()
   _traits(get_traits_or_default(*this, 0.7, 0.3, 0.5, 1.5, 0.6))
 {
   _fleet_state_subscription =
-      create_subscription<FleetState>(
-        FleetStateTopicName, rclcpp::SystemDefaultsQoS(),
-        [&](FleetState::UniquePtr msg)
-  {
-    this->fleet_state_update(std::move(msg));
-  });
+    create_subscription<FleetState>(
+    FleetStateTopicName, rclcpp::SystemDefaultsQoS(),
+    [&](FleetState::UniquePtr msg)
+    {
+      this->fleet_state_update(std::move(msg));
+    });
 }
 
 //==============================================================================
@@ -114,10 +114,10 @@ void FleetAdapterNode::fleet_state_update(FleetState::UniquePtr state)
   if (ignore_fleet(state->name))
     return;
 
-  for(const auto& robot : state->robots)
+  for (const auto& robot : state->robots)
   {
     const auto insertion = _schedule_entries.insert(
-          std::make_pair(robot.name, nullptr));
+      std::make_pair(robot.name, nullptr));
 
     if (insertion.second)
       register_robot(robot, insertion.first);
@@ -128,8 +128,8 @@ void FleetAdapterNode::fleet_state_update(FleetState::UniquePtr state)
 
 //==============================================================================
 void FleetAdapterNode::push_route(
-    const RobotState& state,
-    const ScheduleEntries::iterator& it)
+  const RobotState& state,
+  const ScheduleEntries::iterator& it)
 {
   it->second->path.clear();
   for (const auto& location : state.path)
@@ -142,8 +142,8 @@ void FleetAdapterNode::push_route(
 
 //==============================================================================
 void FleetAdapterNode::register_robot(
-    const RobotState& state,
-    const ScheduleEntries::iterator& it)
+  const RobotState& state,
+  const ScheduleEntries::iterator& it)
 {
   it->second = std::make_unique<ScheduleEntry>(this, state.name, _async_mutex);
   // TODO(MXG): We could consider queuing up the current route of this robot
@@ -154,8 +154,8 @@ void FleetAdapterNode::register_robot(
 
 //==============================================================================
 void FleetAdapterNode::update_robot(
-    const RobotState& state,
-    const ScheduleEntries::iterator& it)
+  const RobotState& state,
+  const ScheduleEntries::iterator& it)
 {
   if (handle_delay(state, it))
     return;
@@ -165,8 +165,8 @@ void FleetAdapterNode::update_robot(
 
 //==============================================================================
 bool FleetAdapterNode::handle_delay(
-    const RobotState& state,
-    const ScheduleEntries::iterator& it)
+  const RobotState& state,
+  const ScheduleEntries::iterator& it)
 {
   if (!it->second->route)
     return false;
@@ -181,7 +181,7 @@ bool FleetAdapterNode::handle_delay(
     return false;
   }
 
-  for (std::size_t i=1; i <= state.path.size(); ++i)
+  for (std::size_t i = 1; i <= state.path.size(); ++i)
   {
     const auto& l_state = state.path[state.path.size()-i];
     const auto& l_entry = entry.path[entry.path.size()-i];
@@ -205,14 +205,16 @@ bool FleetAdapterNode::handle_delay(
   {
     // Check if the robot is still sitting in the same location.
     const Eigen::Vector3d p_entry =
-        entry.route->trajectory().back().position();
-    assert((entry.route->trajectory().front().position() - p_entry).norm() < 1e-12);
+      entry.route->trajectory().back().position();
+    assert(
+      (entry.route->trajectory().front().position() - p_entry).norm() <
+      1e-12);
 
     const auto& l_state = state.location;
     const Eigen::Vector3d p_state{l_state.x, l_state.y, l_state.yaw};
 
     // TODO(MXG): Make this threshold configurable
-    if ((p_state.block<2,1>(0,0) - p_entry.block<2,1>(0,0)).norm() > 0.05)
+    if ((p_state.block<2, 1>(0, 0) - p_entry.block<2, 1>(0, 0)).norm() > 0.05)
       return false;
 
     // TODO(MXG): Make this threshold configurable
@@ -223,7 +225,8 @@ bool FleetAdapterNode::handle_delay(
     // TODO(MXG): Make these parameters configurable
     const auto current_time = rmf_traffic_ros2::convert(state.location.t);
     const auto next_finish_time = current_time + std::chrono::seconds(10);
-    const auto delay = next_finish_time - *entry.route->trajectory().finish_time();
+    const auto delay = next_finish_time -
+      *entry.route->trajectory().finish_time();
     if (delay > std::chrono::seconds(1))
     {
       entry.cumulative_delay += delay;
@@ -245,7 +248,7 @@ bool FleetAdapterNode::handle_delay(
   }
 
   const auto time_difference =
-      *new_trajectory.finish_time() - *entry.route->trajectory().finish_time();
+    *new_trajectory.finish_time() - *entry.route->trajectory().finish_time();
 
 //  std::cout << "Calculating delay: ["
 //            << rmf_traffic::time::to_seconds(time_difference) << "]" << std::endl;
@@ -270,7 +273,7 @@ bool FleetAdapterNode::handle_delay(
   // estimate and the latest finishing time estimate, so we will notify the
   // schedule of a delay.
   const auto from_time =
-      rmf_traffic_ros2::convert(state.location.t) - time_difference;
+    rmf_traffic_ros2::convert(state.location.t) - time_difference;
 
   const auto t_it = entry.route->trajectory().find(from_time);
   if (t_it == entry.route->trajectory().end())
@@ -287,17 +290,17 @@ bool FleetAdapterNode::handle_delay(
       // I can't think of a situation where this could happen, so let's report
       // it as an error and debug it later.
       const auto t_start =
-          entry.route->trajectory().start_time()->time_since_epoch().count();
+        entry.route->trajectory().start_time()->time_since_epoch().count();
       const auto t_finish =
-          entry.route->trajectory().finish_time()->time_since_epoch().count();
+        entry.route->trajectory().finish_time()->time_since_epoch().count();
 
       RCLCPP_ERROR(
-            get_logger(),
-            "BUG: Robot [" + state.name + "] has a delay which starts from ["
-            + std::to_string(from_time.time_since_epoch().count()) + "], but "
-            "we cannot identify where its schedule should be pushed back ["
-            + std::to_string(t_start) + " --> " + std::to_string(t_finish)
-            + "]. This should not happen; please report this.");
+        get_logger(),
+        "BUG: Robot [" + state.name + "] has a delay which starts from ["
+        + std::to_string(from_time.time_since_epoch().count()) + "], but "
+        "we cannot identify where its schedule should be pushed back ["
+        + std::to_string(t_start) + " --> " + std::to_string(t_finish)
+        + "]. This should not happen; please report this.");
 
       // We'll return false so that the old trajectory can be replaced with the
       // new one, and hopefully everything keeps working okay.

--- a/rmf_fleet_adapter/src/read_only/FleetAdapterNode.hpp
+++ b/rmf_fleet_adapter/src/read_only/FleetAdapterNode.hpp
@@ -74,32 +74,32 @@ private:
     bool sitting = false;
 
     ScheduleEntry(
-        FleetAdapterNode* node,
-        std::string name,
-        std::mutex& async_mutex);
+      FleetAdapterNode* node,
+      std::string name,
+      std::mutex& async_mutex);
   };
 
   using ScheduleEntries =
-      std::unordered_map<std::string, std::unique_ptr<ScheduleEntry>>;
+    std::unordered_map<std::string, std::unique_ptr<ScheduleEntry>>;
   ScheduleEntries _schedule_entries;
 
   using RobotState = rmf_fleet_msgs::msg::RobotState;
 
   void push_route(
-      const RobotState& state,
-      const ScheduleEntries::iterator& it);
+    const RobotState& state,
+    const ScheduleEntries::iterator& it);
 
   void register_robot(
-      const RobotState& state,
-      const ScheduleEntries::iterator& it);
+    const RobotState& state,
+    const ScheduleEntries::iterator& it);
 
   void update_robot(
-      const RobotState& state,
-      const ScheduleEntries::iterator& it);
+    const RobotState& state,
+    const ScheduleEntries::iterator& it);
 
   bool handle_delay(
-      const RobotState& state,
-      const ScheduleEntries::iterator& it);
+    const RobotState& state,
+    const ScheduleEntries::iterator& it);
 
   const rmf_traffic::Duration MaxCumulativeDelay = std::chrono::seconds(5);
 };

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ParseArgs.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ParseArgs.cpp
@@ -24,26 +24,26 @@ namespace rmf_fleet_adapter {
 
 //==============================================================================
 bool get_arg(
-    const std::vector<std::string>& args,
-    const std::string& key,
-    std::string& value,
-    const std::string& desc,
-    const bool mandatory)
+  const std::vector<std::string>& args,
+  const std::string& key,
+  std::string& value,
+  const std::string& desc,
+  const bool mandatory)
 {
   const auto key_arg = std::find(args.begin(), args.end(), key);
-  if(key_arg == args.end())
+  if (key_arg == args.end())
   {
     // TODO(MXG): See if there's a way to use RCLCPP_ERROR here without first
     // constructing a node. If not, we could consider constructing the
     // FleetAdapterNode in two parts.
-    if(mandatory)
+    if (mandatory)
     {
       std::cerr << "You must specify a " << desc <<" using the " << key
                 << " argument!" << std::endl;
     }
     return false;
   }
-  else if(key_arg+1 == args.end())
+  else if (key_arg+1 == args.end())
   {
     std::cerr << "The " << key << " argument must be followed by a " << desc
               << "!" << std::endl;
@@ -56,10 +56,10 @@ bool get_arg(
 
 //==============================================================================
 double get_double_arg(
-    const std::vector<std::string>& args,
-    const std::string& key,
-    const std::string& desc,
-    const double default_value)
+  const std::vector<std::string>& args,
+  const std::string& key,
+  const std::string& desc,
+  const double default_value)
 {
   std::string cli_value;
   if (get_arg(args, key, cli_value, desc, false))
@@ -73,15 +73,15 @@ double get_double_arg(
 
 //==============================================================================
 std::chrono::nanoseconds get_time_arg(
-    const std::vector<std::string>& args,
-    const std::string& key,
-    const std::string& desc,
-    const double default_value)
+  const std::vector<std::string>& args,
+  const std::string& key,
+  const std::string& desc,
+  const double default_value)
 {
   const double value = get_double_arg(args, key, desc, default_value);
 
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::duration<double, std::ratio<1>>(value));
+    std::chrono::duration<double, std::ratio<1>>(value));
 }
 
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ParseArgs.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ParseArgs.hpp
@@ -27,23 +27,23 @@ namespace rmf_fleet_adapter {
 // TODO(MXG): Use something like boost::program_options instead of a custom CLI
 // interpreter
 bool get_arg(
-    const std::vector<std::string>& args,
-    const std::string& key,
-    std::string& value,
-    const std::string& desc,
-    const bool mandatory = true);
+  const std::vector<std::string>& args,
+  const std::string& key,
+  std::string& value,
+  const std::string& desc,
+  const bool mandatory = true);
 
 double get_double_arg(
-    const std::vector<std::string>& args,
-    const std::string& key,
-    const std::string& desc,
-    const double default_value);
+  const std::vector<std::string>& args,
+  const std::string& key,
+  const std::string& desc,
+  const double default_value);
 
 std::chrono::nanoseconds get_time_arg(
-    const std::vector<std::string>& args,
-    const std::string& key,
-    const std::string& desc,
-    const double default_value);
+  const std::vector<std::string>& args,
+  const std::string& key,
+  const std::string& desc,
+  const double default_value);
 
 } // namespace rmf_fleet_adapter
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ParseGraph.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ParseGraph.cpp
@@ -25,16 +25,16 @@ namespace rmf_fleet_adapter {
 
 //==============================================================================
 rmf_utils::optional<GraphInfo> parse_graph(
-    const std::string& graph_file,
-    const rmf_traffic::agv::VehicleTraits& vehicle_traits,
-    const rclcpp::Node& node)
+  const std::string& graph_file,
+  const rmf_traffic::agv::VehicleTraits& vehicle_traits,
+  const rclcpp::Node& node)
 {
   const YAML::Node graph_config = YAML::LoadFile(graph_file);
   if (!graph_config)
   {
     RCLCPP_ERROR(
-          node.get_logger(),
-          "Failed to load graph file [" + graph_file + "]");
+      node.get_logger(),
+      "Failed to load graph file [" + graph_file + "]");
     return rmf_utils::nullopt;
   }
 
@@ -42,17 +42,17 @@ rmf_utils::optional<GraphInfo> parse_graph(
   if (!levels)
   {
     RCLCPP_ERROR(
-          node.get_logger(),
-          "Graph file [" + graph_file + "] is missing the [levels] key");
+      node.get_logger(),
+      "Graph file [" + graph_file + "] is missing the [levels] key");
     return rmf_utils::nullopt;
   }
 
   if (!levels.IsMap())
   {
     RCLCPP_ERROR(
-          node.get_logger(),
-          "The [levels] key does not point to a map in graph file ["
-          + graph_file + "]");
+      node.get_logger(),
+      "The [levels] key does not point to a map in graph file ["
+      + graph_file + "]");
     return rmf_utils::nullopt;
   }
 
@@ -81,9 +81,9 @@ rmf_utils::optional<GraphInfo> parse_graph(
           if (!ins.second)
           {
             RCLCPP_ERROR(
-                  node.get_logger(),
-                  "Duplicated waypoint name [" + name + "] in graph ["
-                  + graph_file + "]");
+              node.get_logger(),
+              "Duplicated waypoint name [" + name + "] in graph ["
+              + graph_file + "]");
             return rmf_utils::nullopt;
           }
 
@@ -104,7 +104,8 @@ rmf_utils::optional<GraphInfo> parse_graph(
         const bool is_parking_spot = parking_spot_option.as<bool>();
         if (is_parking_spot)
         {
-          std::cout << "Adding waypoint [" << wp.index() << "] as a parking spot" << std::endl;
+          std::cout << "Adding waypoint [" << wp.index() <<
+            "] as a parking spot" << std::endl;
           info.parking_spots.push_back(wp.index());
         }
       }
@@ -120,32 +121,32 @@ rmf_utils::optional<GraphInfo> parse_graph(
 
       const YAML::Node& options = lane[2];
       const YAML::Node& orientation_constraint_option =
-          options["orientation_constraint"];
+        options["orientation_constraint"];
       if (orientation_constraint_option)
       {
         const std::string& constraint_label =
-            orientation_constraint_option.as<std::string>();
+          orientation_constraint_option.as<std::string>();
         if (constraint_label == "forward")
         {
           constraint = Constraint::make(
-                Constraint::Direction::Forward,
-                vehicle_traits.get_differential()->get_forward());
+            Constraint::Direction::Forward,
+            vehicle_traits.get_differential()->get_forward());
         }
         else if (constraint_label == "backward")
         {
           constraint = Constraint::make(
-                Constraint::Direction::Backward,
-                vehicle_traits.get_differential()->get_forward());
+            Constraint::Direction::Backward,
+            vehicle_traits.get_differential()->get_forward());
         }
         else
         {
           RCLCPP_ERROR(
-                node.get_logger(),
-                "Unrecognized orientation constraint label given to lane ["
-                + std::to_string(lane[0].as<std::size_t>()) + ", "
-                + std::to_string(lane[1].as<std::size_t>()) + "]: ["
-                + constraint_label + "] in graph ["
-                + graph_file + "]");
+            node.get_logger(),
+            "Unrecognized orientation constraint label given to lane ["
+            + std::to_string(lane[0].as<std::size_t>()) + ", "
+            + std::to_string(lane[1].as<std::size_t>()) + "]: ["
+            + constraint_label + "] in graph ["
+            + graph_file + "]");
           return rmf_utils::nullopt;
         }
       }
@@ -164,16 +165,16 @@ rmf_utils::optional<GraphInfo> parse_graph(
         if (!lift_name_option)
         {
           RCLCPP_ERROR(
-                node.get_logger(),
-                "Missing [demo_mock_lift_name] parameter which is required for "
-                "mock lifts");
+            node.get_logger(),
+            "Missing [demo_mock_lift_name] parameter which is required for "
+            "mock lifts");
           return rmf_utils::nullopt;
         }
 
         const std::string lift_name = lift_name_option.as<std::string>();
         const rmf_traffic::Duration duration = std::chrono::seconds(4);
         entry_event = Event::make(
-              Lane::LiftDoorOpen(lift_name, floor_name, duration));
+          Lane::LiftDoorOpen(lift_name, floor_name, duration));
         // NOTE(MXG): We do not need an exit event for lifts
       }
       else if (const YAML::Node door_name_option = options["door_name"])
@@ -189,9 +190,11 @@ rmf_utils::optional<GraphInfo> parse_graph(
         // TODO(MXG): Add support for this
         if (entry_event || exit_event)
         {
+          // *INDENT-OFF*
           throw std::runtime_error(
-              "We do not currently support a dock_name option when any other "
-              "lane options are also specified");
+            "We do not currently support a dock_name option when any other "
+            "lane options are also specified");
+          // *INDENT-ON*
         }
 
         const std::string dock_name = docking_option.as<std::string>();
@@ -200,16 +203,16 @@ rmf_utils::optional<GraphInfo> parse_graph(
       }
 
       info.graph.add_lane(
-          {lane[0].as<std::size_t>(), entry_event},
-          {lane[1].as<std::size_t>(), exit_event, std::move(constraint)});
+        {lane[0].as<std::size_t>(), entry_event},
+        {lane[1].as<std::size_t>(), exit_event, std::move(constraint)});
     }
   }
 
   std::unordered_set<std::size_t> generic_waypoint;
-  for (std::size_t i=0; i < info.graph.num_waypoints(); ++i)
+  for (std::size_t i = 0; i < info.graph.num_waypoints(); ++i)
     generic_waypoint.insert(i);
 
-  for (std::size_t i=0; i < info.graph.num_lanes(); ++i)
+  for (std::size_t i = 0; i < info.graph.num_lanes(); ++i)
   {
     const auto& lane = info.graph.get_lane(i);
     if (lane.entry().event())

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ParseGraph.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ParseGraph.hpp
@@ -54,9 +54,9 @@ struct GraphInfo
 
 //==============================================================================
 rmf_utils::optional<GraphInfo> parse_graph(
-    const std::string& filename,
-    const rmf_traffic::agv::VehicleTraits& vehicle_traits,
-    const rclcpp::Node& node);
+  const std::string& filename,
+  const rmf_traffic::agv::VehicleTraits& vehicle_traits,
+  const rclcpp::Node& node);
 
 } // namespace rmf_fleet_adapter
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.cpp
@@ -24,17 +24,17 @@ namespace rmf_fleet_adapter {
 
 //==============================================================================
 ScheduleManager::ScheduleManager(rclcpp::Node& node,
-    rmf_traffic::schedule::Participant participant,
-    rmf_traffic_ros2::schedule::Negotiation* negotiation)
-  : _node(&node),
-    _participant(std::move(participant))
+  rmf_traffic::schedule::Participant participant,
+  rmf_traffic_ros2::schedule::Negotiation* negotiation)
+: _node(&node),
+  _participant(std::move(participant))
 {
   if (negotiation)
   {
     auto negotiator = std::make_unique<Negotiator>();
     _negotiator = negotiator.get();
     _negotiator_handle = negotiation->register_negotiator(
-          _participant.id(), std::move(negotiator));
+      _participant.id(), std::move(negotiator));
   }
 }
 
@@ -67,18 +67,18 @@ void ScheduleManager::push_routes(const std::vector<rmf_traffic::Route>& routes)
 
 //==============================================================================
 void ScheduleManager::push_delay(
-    const rmf_traffic::Duration duration,
-    const rmf_traffic::Time from_time)
+  const rmf_traffic::Duration duration,
+  const rmf_traffic::Time from_time)
 {
   _participant.delay(from_time, duration);
 }
 
 //==============================================================================
 void ScheduleManager::set_negotiator(
-    std::function<void(
-      rmf_traffic::schedule::Negotiation::ConstTablePtr,
-      const Negotiator::Responder&,
-      const bool*)> negotiation_callback)
+  std::function<void(
+    rmf_traffic::schedule::Negotiation::ConstTablePtr,
+    const Negotiator::Responder&,
+    const bool*)> negotiation_callback)
 {
   if (_negotiator)
     _negotiator->callback = std::move(negotiation_callback);
@@ -105,9 +105,9 @@ ScheduleManager::description() const
 
 //==============================================================================
 void ScheduleManager::Negotiator::respond(
-    std::shared_ptr<const rmf_traffic::schedule::Negotiation::Table> table,
-    const Responder& responder,
-    const bool* interrupt_flag)
+  std::shared_ptr<const rmf_traffic::schedule::Negotiation::Table> table,
+  const Responder& responder,
+  const bool* interrupt_flag)
 {
   if (!callback)
     return;
@@ -117,52 +117,52 @@ void ScheduleManager::Negotiator::respond(
 
 //==============================================================================
 std::future<ScheduleManager> make_schedule_manager(
-    rclcpp::Node& node,
-    rmf_traffic_ros2::schedule::Writer& writer,
-    rmf_traffic_ros2::schedule::Negotiation* negotiation,
-    rmf_traffic::schedule::ParticipantDescription description,
-    std::function<void()> revision_callback)
+  rclcpp::Node& node,
+  rmf_traffic_ros2::schedule::Writer& writer,
+  rmf_traffic_ros2::schedule::Negotiation* negotiation,
+  rmf_traffic::schedule::ParticipantDescription description,
+  std::function<void()> revision_callback)
 {
   return std::async(
-        std::launch::async,
-        [&node,
-         &writer,
-         negotiation,
-         description = std::move(description),
-         revision_callback = std::move(revision_callback)]() -> ScheduleManager
-  {
-    return ScheduleManager(
-          node,
-          writer.make_participant(std::move(description)).get(),
-          negotiation);
-  });
+    std::launch::async,
+    [&node,
+    &writer,
+    negotiation,
+    description = std::move(description),
+    revision_callback = std::move(revision_callback)]() -> ScheduleManager
+    {
+      return ScheduleManager(
+        node,
+        writer.make_participant(std::move(description)).get(),
+        negotiation);
+    });
 }
 
 //==============================================================================
 void async_make_schedule_manager(
-    rclcpp::Node& node,
-    rmf_traffic_ros2::schedule::Writer& writer,
-    rmf_traffic_ros2::schedule::Negotiation* negotiation,
-    rmf_traffic::schedule::ParticipantDescription description,
-    std::function<void(ScheduleManager)> ready_callback,
-    std::mutex& ready_mutex)
+  rclcpp::Node& node,
+  rmf_traffic_ros2::schedule::Writer& writer,
+  rmf_traffic_ros2::schedule::Negotiation* negotiation,
+  rmf_traffic::schedule::ParticipantDescription description,
+  std::function<void(ScheduleManager)> ready_callback,
+  std::mutex& ready_mutex)
 {
   writer.async_make_participant(
-        std::move(description),
-        [&node,
-         negotiation,
-         ready_callback = std::move(ready_callback),
-         &ready_mutex](
-        rmf_traffic::schedule::Participant participant)
-  {
-    std::lock_guard<std::mutex> lock(ready_mutex);
-    ready_callback(
-          ScheduleManager{
-            node,
-            std::move(participant),
-            negotiation
-          });
-  });
+    std::move(description),
+    [&node,
+    negotiation,
+    ready_callback = std::move(ready_callback),
+    &ready_mutex](
+      rmf_traffic::schedule::Participant participant)
+    {
+      std::lock_guard<std::mutex> lock(ready_mutex);
+      ready_callback(
+        ScheduleManager{
+          node,
+          std::move(participant),
+          negotiation
+        });
+    });
 }
 
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/ScheduleManager.hpp
@@ -38,23 +38,23 @@ class ScheduleManager
 public:
 
   ScheduleManager(
-      rclcpp::Node& node,
-      rmf_traffic::schedule::Participant participant,
-      rmf_traffic_ros2::schedule::Negotiation* negotiation);
+    rclcpp::Node& node,
+    rmf_traffic::schedule::Participant participant,
+    rmf_traffic_ros2::schedule::Negotiation* negotiation);
 
   using TrajectorySet = std::vector<rmf_traffic::Trajectory>;
 
   void push_routes(const std::vector<rmf_traffic::Route>& routes);
 
   void push_delay(
-      const rmf_traffic::Duration duration,
-      const rmf_traffic::Time from_time);
+    const rmf_traffic::Duration duration,
+    const rmf_traffic::Time from_time);
 
   void set_negotiator(
-      std::function<void(
-        rmf_traffic::schedule::Negotiation::ConstTablePtr,
-        const rmf_traffic::schedule::Negotiator::Responder&,
-        const bool*)> negotiation_callback);
+    std::function<void(
+      rmf_traffic::schedule::Negotiation::ConstTablePtr,
+      const rmf_traffic::schedule::Negotiator::Responder&,
+      const bool*)> negotiation_callback);
 
   rmf_traffic::schedule::Participant& participant();
 
@@ -69,9 +69,9 @@ private:
   public:
 
     void respond(
-        std::shared_ptr<const rmf_traffic::schedule::Negotiation::Table> table,
-        const Responder& responder,
-        const bool* interrupt_flag) final;
+      std::shared_ptr<const rmf_traffic::schedule::Negotiation::Table> table,
+      const Responder& responder,
+      const bool* interrupt_flag) final;
 
     std::function<void(
         rmf_traffic::schedule::Negotiation::ConstTablePtr,
@@ -87,19 +87,19 @@ private:
 
 //==============================================================================
 std::future<ScheduleManager> make_schedule_manager(
-    rclcpp::Node& node,
-    rmf_traffic_ros2::schedule::Writer& writer,
-    rmf_traffic_ros2::schedule::Negotiation* negotiation,
-    rmf_traffic::schedule::ParticipantDescription description);
+  rclcpp::Node& node,
+  rmf_traffic_ros2::schedule::Writer& writer,
+  rmf_traffic_ros2::schedule::Negotiation* negotiation,
+  rmf_traffic::schedule::ParticipantDescription description);
 
 //==============================================================================
 void async_make_schedule_manager(
-    rclcpp::Node& node,
-    rmf_traffic_ros2::schedule::Writer& writer,
-    rmf_traffic_ros2::schedule::Negotiation* negotiation,
-    rmf_traffic::schedule::ParticipantDescription description,
-    std::function<void(ScheduleManager manager)> ready_callback,
-    std::mutex& ready_mutex);
+  rclcpp::Node& node,
+  rmf_traffic_ros2::schedule::Writer& writer,
+  rmf_traffic_ros2::schedule::Negotiation* negotiation,
+  rmf_traffic::schedule::ParticipantDescription description,
+  std::function<void(ScheduleManager manager)> ready_callback,
+  std::mutex& ready_mutex);
 
 } // namespace rmf_fleet_adapter
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/load_param.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/load_param.cpp
@@ -23,15 +23,15 @@ namespace rmf_fleet_adapter {
 
 //==============================================================================
 std::chrono::nanoseconds get_parameter_or_default_time(
-    rclcpp::Node& node,
-    const std::string& param_name,
-    const double default_value)
+  rclcpp::Node& node,
+  const std::string& param_name,
+  const double default_value)
 {
   const double value =
-      get_parameter_or_default(node, param_name, default_value);
+    get_parameter_or_default(node, param_name, default_value);
 
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::duration<double, std::ratio<1>>(value));
+    std::chrono::duration<double, std::ratio<1>>(value));
 }
 
 //==============================================================================
@@ -41,8 +41,8 @@ std::string get_fleet_name_parameter(rclcpp::Node& node)
   if (fleet_name.empty())
   {
     RCLCPP_ERROR(
-          node.get_logger(),
-          "The fleet_name parameter must be specified!");
+      node.get_logger(),
+      "The fleet_name parameter must be specified!");
     throw std::runtime_error("fleet_name parameter is missing");
   }
 
@@ -51,23 +51,23 @@ std::string get_fleet_name_parameter(rclcpp::Node& node)
 
 //==============================================================================
 rmf_traffic::agv::VehicleTraits get_traits_or_default(
-    rclcpp::Node& node,
-    const double default_v_nom, const double default_w_nom,
-    const double default_a_nom, const double default_alpha_nom,
-    const double default_radius)
+  rclcpp::Node& node,
+  const double default_v_nom, const double default_w_nom,
+  const double default_a_nom, const double default_alpha_nom,
+  const double default_radius)
 {
   const double v_nom =
-      get_parameter_or_default(node, "linear_velocity", default_v_nom);
+    get_parameter_or_default(node, "linear_velocity", default_v_nom);
   const double w_nom =
-      get_parameter_or_default(node, "angular_velocity", default_w_nom);
+    get_parameter_or_default(node, "angular_velocity", default_w_nom);
   const double a_nom =
-      get_parameter_or_default(node, "linear_acceleration", default_a_nom);
+    get_parameter_or_default(node, "linear_acceleration", default_a_nom);
   const double b_nom =
-      get_parameter_or_default(node, "angular_acceleration", default_alpha_nom);
+    get_parameter_or_default(node, "angular_acceleration", default_alpha_nom);
   const double r =
-      get_parameter_or_default(node, "profile_radius", default_radius);
+    get_parameter_or_default(node, "profile_radius", default_radius);
   const bool reversible =
-      get_parameter_or_default(node, "reversible", true);
+    get_parameter_or_default(node, "reversible", true);
 
   if (!reversible)
     std::cout << " ===== We have an irreversible robot" << std::endl;
@@ -76,8 +76,8 @@ rmf_traffic::agv::VehicleTraits get_traits_or_default(
     {v_nom, a_nom},
     {w_nom, b_nom},
     rmf_traffic::Profile{
-          rmf_traffic::geometry::make_final_convex<
-            rmf_traffic::geometry::Circle>(r)}
+      rmf_traffic::geometry::make_final_convex<
+        rmf_traffic::geometry::Circle>(r)}
   };
 
   traits.get_differential()->set_reversible(reversible);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/load_param.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/load_param.hpp
@@ -30,17 +30,17 @@ namespace rmf_fleet_adapter {
 //==============================================================================
 template<typename T>
 T get_parameter_or_default(
-    rclcpp::Node& node,
-    const std::string& param_name,
-    const T& default_value)
+  rclcpp::Node& node,
+  const std::string& param_name,
+  const T& default_value)
 {
   // TODO(MXG): Consider a way to automatically make a callback that will update
   // a target variable when the parameter value gets changed.
 
   const T value = node.declare_parameter(param_name, default_value);
   RCLCPP_INFO(
-        node.get_logger(),
-        "Parameter [" + param_name + "] set to: " + std::to_string(value));
+    node.get_logger(),
+    "Parameter [" + param_name + "] set to: " + std::to_string(value));
   return value;
 }
 
@@ -49,16 +49,16 @@ std::string get_fleet_name_parameter(rclcpp::Node& node);
 
 //==============================================================================
 std::chrono::nanoseconds get_parameter_or_default_time(
-    rclcpp::Node& node,
-    const std::string& param_name,
-    const double default_value);
+  rclcpp::Node& node,
+  const std::string& param_name,
+  const double default_value);
 
 //==============================================================================
 rmf_traffic::agv::VehicleTraits get_traits_or_default(
-    rclcpp::Node& node,
-    const double default_v_nom, const double default_w_nom,
-    const double default_a_nom, const double default_alpha_nom,
-    const double default_radius);
+  rclcpp::Node& node,
+  const double default_v_nom, const double default_w_nom,
+  const double default_a_nom, const double default_alpha_nom,
+  const double default_radius);
 
 } // namespace rmf_fleet_adapter
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/make_trajectory.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/make_trajectory.cpp
@@ -24,9 +24,9 @@
 
 //==============================================================================
 rmf_traffic::Trajectory make_trajectory(
-    const rmf_fleet_msgs::msg::RobotState& state,
-    const rmf_traffic::agv::VehicleTraits& traits,
-    bool& is_sitting)
+  const rmf_fleet_msgs::msg::RobotState& state,
+  const rmf_traffic::agv::VehicleTraits& traits,
+  bool& is_sitting)
 {
   // TODO(MXG): Account for the multi-floor use case
   std::string map_name = state.location.level_name;
@@ -42,7 +42,7 @@ rmf_traffic::Trajectory make_trajectory(
   const auto start_time = rmf_traffic_ros2::convert(state.location.t);
 
   auto trajectory = rmf_traffic::agv::Interpolate::positions(
-        traits, start_time, positions);
+    traits, start_time, positions);
 
   if (trajectory.size() < 2)
   {
@@ -66,23 +66,23 @@ rmf_traffic::Trajectory make_trajectory(
 
 //==============================================================================
 rmf_traffic::Trajectory make_trajectory(
-    const rmf_traffic::Time start_time,
-    const std::vector<rmf_fleet_msgs::msg::Location>& path,
-    const rmf_traffic::agv::VehicleTraits& traits)
+  const rmf_traffic::Time start_time,
+  const std::vector<rmf_fleet_msgs::msg::Location>& path,
+  const rmf_traffic::agv::VehicleTraits& traits)
 {
   std::vector<Eigen::Vector3d> positions;
   for (const auto& location : path)
     positions.push_back({location.x, location.y, location.yaw});
 
   return rmf_traffic::agv::Interpolate::positions(
-        traits, start_time, positions);
+    traits, start_time, positions);
 }
 
 //==============================================================================
 rmf_traffic::Route make_route(
-    const rmf_fleet_msgs::msg::RobotState& state,
-    const rmf_traffic::agv::VehicleTraits& traits,
-    bool& is_sitting)
+  const rmf_fleet_msgs::msg::RobotState& state,
+  const rmf_traffic::agv::VehicleTraits& traits,
+  bool& is_sitting)
 {
   return rmf_traffic::Route{
     state.location.level_name,
@@ -92,9 +92,9 @@ rmf_traffic::Route make_route(
 
 //==============================================================================
 rmf_traffic::Trajectory make_hold(
-    const rmf_fleet_msgs::msg::Location& l,
-    const rmf_traffic::Time t,
-    rmf_traffic::Duration duration)
+  const rmf_fleet_msgs::msg::Location& l,
+  const rmf_traffic::Time t,
+  rmf_traffic::Duration duration)
 {
   rmf_traffic::Trajectory hold;
   const Eigen::Vector3d p{l.x, l.y, l.yaw};

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/make_trajectory.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/make_trajectory.hpp
@@ -26,26 +26,26 @@
 
 //==============================================================================
 rmf_traffic::Trajectory make_trajectory(
-    const rmf_fleet_msgs::msg::RobotState& state,
-    const rmf_traffic::agv::VehicleTraits& traits,
-    bool& is_sitting);
+  const rmf_fleet_msgs::msg::RobotState& state,
+  const rmf_traffic::agv::VehicleTraits& traits,
+  bool& is_sitting);
 
 //==============================================================================
 rmf_traffic::Trajectory make_trajectory(
-    const rmf_traffic::Time start_time,
-    const std::vector<rmf_fleet_msgs::msg::Location>& path,
-    const rmf_traffic::agv::VehicleTraits& traits);
+  const rmf_traffic::Time start_time,
+  const std::vector<rmf_fleet_msgs::msg::Location>& path,
+  const rmf_traffic::agv::VehicleTraits& traits);
 
 //==============================================================================
 rmf_traffic::Route make_route(
-    const rmf_fleet_msgs::msg::RobotState& state,
-    const rmf_traffic::agv::VehicleTraits& traits,
-    bool& is_sitting);
+  const rmf_fleet_msgs::msg::RobotState& state,
+  const rmf_traffic::agv::VehicleTraits& traits,
+  bool& is_sitting);
 
 //==============================================================================
 rmf_traffic::Trajectory make_hold(
-    const rmf_fleet_msgs::msg::Location& location,
-    const rmf_traffic::Time time,
-    rmf_traffic::Duration duration);
+  const rmf_fleet_msgs::msg::Location& location,
+  const rmf_traffic::Time time,
+  rmf_traffic::Duration duration);
 
 #endif // SRC__RMF_FLEET_ADAPTER__MAKE_TRAJECTORY_HPP

--- a/rmf_fleet_adapter/src/robot_state_aggregator/main.cpp
+++ b/rmf_fleet_adapter/src/robot_state_aggregator/main.cpp
@@ -32,15 +32,15 @@ public:
   static std::shared_ptr<RobotStateAggregator> make()
   {
     const auto node = std::shared_ptr<RobotStateAggregator>(
-          new RobotStateAggregator);
+      new RobotStateAggregator);
 
     const auto prefix = node->declare_parameter("robot_prefix", "");
     const auto fleet_name = node->declare_parameter("fleet_name", "");
     if (fleet_name.empty())
     {
       RCLCPP_FATAL(
-            node->get_logger(),
-            "Missing required parameter: [fleet_adapter]");
+        node->get_logger(),
+        "Missing required parameter: [fleet_adapter]");
       return nullptr;
     }
 
@@ -58,14 +58,14 @@ private:
     const auto default_qos = rclcpp::SystemDefaultsQoS();
 
     _fleet_state_pub = create_publisher<FleetState>(
-          rmf_fleet_adapter::FleetStateTopicName, default_qos);
+      rmf_fleet_adapter::FleetStateTopicName, default_qos);
 
     _robot_state_sub = create_subscription<RobotState>(
-          "robot_state", default_qos,
-          [&](RobotState::UniquePtr msg)
-    {
-      _robot_state_update(std::move(msg));
-    });
+      "robot_state", default_qos,
+      [&](RobotState::UniquePtr msg)
+      {
+        _robot_state_update(std::move(msg));
+      });
   }
 
   std::string _prefix;

--- a/rmf_fleet_adapter/src/task_aggregator/main.cpp
+++ b/rmf_fleet_adapter/src/task_aggregator/main.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2019 Open Source Robotics Foundation
  *
@@ -27,46 +26,46 @@
 class TaskAggregator : public rclcpp::Node
 {
 
-using TaskSummary = rmf_task_msgs::msg::TaskSummary;
-using Tasks = rmf_task_msgs::msg::Tasks;
+  using TaskSummary = rmf_task_msgs::msg::TaskSummary;
+  using Tasks = rmf_task_msgs::msg::Tasks;
 
 public:
   TaskAggregator(
-      std::string node_name,
-      std::string input_topic,
-      double rate)
+    std::string node_name,
+    std::string input_topic,
+    double rate)
   : Node(node_name),
     _rate(rate)
   {
     // Create a wall timer to periodically publish Tasks msg
     const double period = 1.0/_rate;
     auto timer_period = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::duration<double, std::ratio<1>>(period));
+      std::chrono::duration<double, std::ratio<1>>(period));
     _timer = this->create_wall_timer(
-        timer_period, std::bind(&TaskAggregator::timer_callback, this));
-    
+      timer_period, std::bind(&TaskAggregator::timer_callback, this));
+
     // Create publisher for Tasks msg
     _tasks_pub = this->create_publisher<Tasks>(
-        "/tasks",
-        rclcpp::ServicesQoS());
+      "/tasks",
+      rclcpp::ServicesQoS());
 
     // Create subscription to receive TaskSummary msgs from fleet adapters
     _cb_group_task_summary = this->create_callback_group(
-    rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
+      rclcpp::callback_group::CallbackGroupType::MutuallyExclusive);
     auto sub_map_opt = rclcpp::SubscriptionOptions();
     sub_map_opt.callback_group = _cb_group_task_summary;
     auto qos_profile = rclcpp::QoS(10);
     _task_summary_sub = this->create_subscription<TaskSummary>(
-        input_topic,
-        qos_profile,
-        std::bind(
-            &TaskAggregator::task_summary_cb,
-            this,
-            std::placeholders::_1),
-        sub_map_opt);
+      input_topic,
+      qos_profile,
+      std::bind(
+        &TaskAggregator::task_summary_cb,
+        this,
+        std::placeholders::_1),
+      sub_map_opt);
 
     RCLCPP_INFO(get_logger(),
-        "Listening for Task Summaries on topic /" + input_topic);
+      "Listening for Task Summaries on topic /" + input_topic);
   }
 
 private:
@@ -89,12 +88,12 @@ private:
     }
     else
     {
-     _db.insert(std::make_pair(msg->task_id, *msg));
+      _db.insert(std::make_pair(msg->task_id, *msg));
     }
   }
 
   double _rate;
-  
+
   std::unordered_map<std::string, TaskSummary> _db;
 
   rclcpp::TimerBase::SharedPtr _timer;
@@ -104,23 +103,23 @@ private:
 };
 
 bool get_arg(
-    const std::vector<std::string>& args,
-    const std::string& key,
-    std::string& value,
-    const std::string& desc,
-    const bool mandatory = true)
+  const std::vector<std::string>& args,
+  const std::string& key,
+  std::string& value,
+  const std::string& desc,
+  const bool mandatory = true)
 {
   const auto key_arg = std::find(args.begin(), args.end(), key);
-  if(key_arg == args.end())
+  if (key_arg == args.end())
   {
-    if(mandatory)
+    if (mandatory)
     {
       std::cerr << "You must specify a " << desc <<" using the " << key
                 << " argument!" << std::endl;
     }
     return false;
   }
-  else if(key_arg+1 == args.end())
+  else if (key_arg+1 == args.end())
   {
     std::cerr << "The " << key << " argument must be followed by a " << desc
               << "!" << std::endl;
@@ -134,7 +133,7 @@ bool get_arg(
 int main(int argc, char* argv[])
 {
   const std::vector<std::string> args =
-      rclcpp::init_and_remove_ros_arguments(argc, argv);
+    rclcpp::init_and_remove_ros_arguments(argc, argv);
 
   std::string node_name = "task_aggregator";
   get_arg(args, "-n", node_name, "node name", false);
@@ -143,19 +142,19 @@ int main(int argc, char* argv[])
   get_arg(args, "-t", input_topic, "node name", false);
 
   std::string rate_string;
-  get_arg(args, "-r", rate_string, "rate",false);
-  double rate = rate_string.empty()? 1.0 : std::stod(rate_string);
+  get_arg(args, "-r", rate_string, "rate", false);
+  double rate = rate_string.empty() ? 1.0 : std::stod(rate_string);
 
   auto task_aggregator_node = std::make_shared<TaskAggregator>(
-      node_name,
-      input_topic,
-      rate);
+    node_name,
+    input_topic,
+    rate);
 
   rclcpp::spin(task_aggregator_node);
 
   RCLCPP_INFO(
-        task_aggregator_node->get_logger(),
-        "Closing down");
+    task_aggregator_node->get_logger(),
+    "Closing down");
 
   rclcpp::shutdown();
 }

--- a/rmf_fleet_adapter/test/dump_fleet_states.cpp
+++ b/rmf_fleet_adapter/test/dump_fleet_states.cpp
@@ -60,10 +60,10 @@ public:
   : rclcpp::Node("dump_test_fleet_states")
   {
     fleet_state_publisher = create_publisher<FleetState>(
-          "/fleet_states", rclcpp::SystemDefaultsQoS());
+      "/fleet_states", rclcpp::SystemDefaultsQoS());
 
     timer = create_wall_timer(
-          std::chrono::milliseconds(period_ms), [&](){ update(); });
+      std::chrono::milliseconds(period_ms), [&]() { update(); });
 
     current_location = Eigen::Vector3d(0.0, 0.0, 0.0);
 
@@ -78,15 +78,16 @@ private:
 
   void update()
   {
-    std::cout << "Current location: " << current_location.transpose() << std::endl;
+    std::cout << "Current location: " << current_location.transpose() <<
+      std::endl;
 
     if (path.empty())
       return publish();
 
     const Eigen::Vector3d next_location = to_eigen(path.front());
 
-    const Eigen::Vector2d p = current_location.block<2,1>(0,0);
-    const Eigen::Vector2d p_next = next_location.block<2,1>(0,0);
+    const Eigen::Vector2d p = current_location.block<2, 1>(0, 0);
+    const Eigen::Vector2d p_next = next_location.block<2, 1>(0, 0);
 
     const Eigen::Vector2d n = p_next - p;
     const double dist = n.norm();
@@ -102,14 +103,14 @@ private:
         return publish();
       }
 
-      current_location.block<2,1>(0,0) = p_next;
+      current_location.block<2, 1>(0, 0) = p_next;
       current_location[2] += d_yaw;
 
       return publish();
     }
 
     const Eigen::Vector2d dir = n/dist;
-    current_location.block<2,1>(0,0) += velocity*timestep*dir;
+    current_location.block<2, 1>(0, 0) += velocity*timestep*dir;
     return publish();
   }
 

--- a/rmf_fleet_adapter/test/test_read_only_adapter.cpp
+++ b/rmf_fleet_adapter/test/test_read_only_adapter.cpp
@@ -41,55 +41,56 @@ public:
   using String = std_msgs::msg::String;
 
   TestReadOnly(
-      std::string& fleet_name,
-      std::string& viz_name)
+    std::string& fleet_name,
+    std::string& viz_name)
   : Node("test_adapter_" + fleet_name),
     _fleet_name(fleet_name),
     _viz_name(viz_name)
   {
-    // msg to publish to rmf_schedule_visualizer node to print 
-    // information of trajectoies in the mirror 
+    // msg to publish to rmf_schedule_visualizer node to print
+    // information of trajectoies in the mirror
     _viz_info_msg.data = "info";
 
     // publisher to send FleetState messages to fleet adapter
     _fleet_state_pub = create_publisher<FleetState>(
-        rmf_fleet_adapter::FleetStateTopicName,
-        rclcpp::SystemDefaultsQoS());
-    
+      rmf_fleet_adapter::FleetStateTopicName,
+      rclcpp::SystemDefaultsQoS());
+
     // publisher to send String messages to rmf_schedule_visualizer node
     _viz_pub = create_publisher<String>(
-        _viz_name + "/debug", rclcpp::SystemDefaultsQoS());
+      _viz_name + "/debug", rclcpp::SystemDefaultsQoS());
 
     // subscription to receive String messages which control execution of
     // this node
-    _cmd_sub= create_subscription<String>(
-        "test_adapter_" + _fleet_name+"/cmd",rclcpp::SystemDefaultsQoS(),
-        [&](String::UniquePtr msg)
-    {
-      // receive commands through ros2 msg
-      if (msg->data == "test_insert")
+    _cmd_sub = create_subscription<String>(
+      "test_adapter_" + _fleet_name+"/cmd", rclcpp::SystemDefaultsQoS(),
+      [&](String::UniquePtr msg)
       {
-        test_insert();
-      }
-      else if (msg->data == "test_advance")
-      {
-        test_advance();
-      }
-      else if (msg->data == "test_delay")
-      {
-        test_delay();
-      }
-      else if (msg->data == "test_replace")
-      {
-        test_replace();
-      }
-      else
-      {
-        RCLCPP_INFO(this->get_logger(),
-        "Invalid cmd, try: test_insert, test_advance,test_delay, test_replace");
-      }
+        // receive commands through ros2 msg
+        if (msg->data == "test_insert")
+        {
+          test_insert();
+        }
+        else if (msg->data == "test_advance")
+        {
+          test_advance();
+        }
+        else if (msg->data == "test_delay")
+        {
+          test_delay();
+        }
+        else if (msg->data == "test_replace")
+        {
+          test_replace();
+        }
+        else
+        {
+          RCLCPP_INFO(
+            this->get_logger(),
+            "Invalid cmd, try: test_insert, test_advance,test_delay, test_replace");
+        }
 
-    });
+      });
 
     RobotState robot;
     robot.name = "TestBot";
@@ -101,19 +102,19 @@ public:
     _start_time = std::chrono::steady_clock::now();
 
     robot.location = get_location(
-        rmf_traffic_ros2::convert(
+      rmf_traffic_ros2::convert(
         _start_time),
-        0.0,
-        0.0,
-        0.0,
-        "level1");
+      0.0,
+      0.0,
+      0.0,
+      "level1");
 
     RCLCPP_INFO(this->get_logger(),
-        "start_time: " + std::to_string(
-              _start_time.time_since_epoch().count()));
+      "start_time: " + std::to_string(
+        _start_time.time_since_epoch().count()));
 
     robot.path.push_back(
-        get_location(
+      get_location(
         modify_time(robot.location.t, 100),
         70.0,
         0.0,
@@ -121,7 +122,7 @@ public:
         "level1"));
 
     robot.path.push_back(
-        get_location(
+      get_location(
         modify_time(robot.location.t, 200),
         140.0,
         0.0,
@@ -135,32 +136,32 @@ public:
 
 private:
   Location get_location(
-      builtin_interfaces::msg::Time t,
-      double x,
-      double y,
-      double yaw,
-      std::string level)
-      {
-        Location location;
-        location.t = t;
-        location.x = x;
-        location.y = y;
-        location.yaw = yaw;
-        location.level_name = level;
-        return location;
-      }
-  
-  builtin_interfaces::msg::Time modify_time (
-      builtin_interfaces::msg::Time t_, double delta)
-      {
-        t_.sec += delta;
-        return t_; 
-      }
+    builtin_interfaces::msg::Time t,
+    double x,
+    double y,
+    double yaw,
+    std::string level)
+  {
+    Location location;
+    location.t = t;
+    location.x = x;
+    location.y = y;
+    location.yaw = yaw;
+    location.level_name = level;
+    return location;
+  }
+
+  builtin_interfaces::msg::Time modify_time(
+    builtin_interfaces::msg::Time t_, double delta)
+  {
+    t_.sec += delta;
+    return t_;
+  }
 
   void test_insert()
   {
     // send first FirstState msg to fleet adapter
-    if(!_inserted)
+    if (!_inserted)
     {
       RCLCPP_INFO(this->get_logger(), "Testing Insert");
       _fleet_state_pub->publish(_fleet_state_msg);
@@ -170,13 +171,13 @@ private:
     }
     else
       RCLCPP_ERROR(this->get_logger(),
-          "Default FleetState already inserted...");
+        "Default FleetState already inserted...");
 
   }
   void test_advance()
   {
 
-    // Update the robot path to make robot ahead of schedule 
+    // Update the robot path to make robot ahead of schedule
     if (_inserted)
     {
       RCLCPP_INFO(this->get_logger(), "Testing Advance");
@@ -187,31 +188,31 @@ private:
       // the real robots should only ever be behind the predicted schedule.
 
 
-      // modify location.t of last location in path to smaller value 
+      // modify location.t of last location in path to smaller value
       FleetState new_msg = _fleet_state_msg;
 
       RobotState robot = new_msg.robots[0];
 
       // advance robot location to first location in current path
       robot.location = robot.path[0];
-      
+
       // robot arrived at the next location 20 seconds earlier
       robot.location.t = modify_time(robot.location.t, -20);
 
       // make a copy of the final location
       // clear robot path and append copy with modified time
       Location last_location = robot.path[robot.path.size()-1];
-      last_location.t = modify_time(last_location.t , -20);
+      last_location.t = modify_time(last_location.t, -20);
 
-      //updating new FleetState msg 
+      //updating new FleetState msg
       robot.path.clear();
       robot.path.push_back(last_location);
       new_msg.robots.clear();
       new_msg.robots.push_back(robot);
 
       std::cout<<"Delta: "<<std::to_string(
-        new_msg.robots[0].path[new_msg.robots[0].path.size()-1].t.sec
-        -_fleet_state_msg.robots[0].path[1].t.sec)<<std::endl;
+          new_msg.robots[0].path[new_msg.robots[0].path.size()-1].t.sec
+          -_fleet_state_msg.robots[0].path[1].t.sec)<<std::endl;
 
       //publishing new FleetState msg
       _fleet_state_pub->publish(new_msg);
@@ -228,13 +229,13 @@ private:
     {
       RCLCPP_INFO(this->get_logger(), "Testing Delay");
 
-      // modify location.t of last location in path to larger value 
+      // modify location.t of last location in path to larger value
       FleetState new_msg;
       new_msg.name = _fleet_state_msg.name;
 
       RobotState robot = _fleet_state_msg.robots[0];
       // for debugging
-      
+
       // advance robot location to first location in current path
       robot.location = robot.path[0];
 
@@ -243,8 +244,8 @@ private:
 
       // make a copy of the final location and extend finish time by 20s
       Location last_location = robot.path[robot.path.size()-1];
-      last_location.t = modify_time(last_location.t , 20);
-      
+      last_location.t = modify_time(last_location.t, 20);
+
       robot.path.clear();
       robot.path.push_back(last_location);
 
@@ -252,14 +253,15 @@ private:
       new_msg.robots.clear();
       new_msg.robots.push_back(robot);
 
-      //debugging 
+      //debugging
       std::cout<< "New msg name: "<<new_msg.name<<std::endl;
       std::cout<<"Original Path Count: "<<
-          _fleet_state_msg.robots[0].path.size()<<std::endl;
+        _fleet_state_msg.robots[0].path.size()<<std::endl;
       std::cout<<"New Path Count: "<<
-          std::to_string(new_msg.robots[0].path.size())<<std::endl;
+        std::to_string(new_msg.robots[0].path.size())<<std::endl;
       std::cout<<"New path has "<<std::to_string(new_msg.robots[0].path.size() -
-          _fleet_state_msg.robots[0].path.size())<< " more locations"<<std::endl;
+          _fleet_state_msg.robots[0].path.size())<< " more locations"<<
+        std::endl;
 
       std::cout<<"Delta: "<<std::to_string(
           new_msg.robots[0].path[new_msg.robots[0].path.size() -1].t.sec -
@@ -280,7 +282,7 @@ private:
     {
       RCLCPP_INFO(this->get_logger(), "Testing Replace");
 
-      // modify location.t of last location in path to larger value 
+      // modify location.t of last location in path to larger value
       FleetState new_msg = _fleet_state_msg;
 
       RobotState robot = _fleet_state_msg.robots[0];
@@ -295,15 +297,15 @@ private:
       robot.path.push_back(last_location);
 
       // adding two additional locations to path
-      for(int i = 0; i < 2; i++)
+      for (int i = 0; i < 2; i++)
       {
-        auto modified_t = modify_time(last_location.t , 100*(i+1));
+        auto modified_t = modify_time(last_location.t, 100*(i+1));
         auto l = get_location(
-            modified_t,
-            last_location.x + 70*(i+1),
-            last_location.y,
-            last_location.yaw,
-            last_location.level_name);
+          modified_t,
+          last_location.x + 70*(i+1),
+          last_location.y,
+          last_location.yaw,
+          last_location.level_name);
         robot.path.push_back(l);
       }
 
@@ -313,11 +315,11 @@ private:
 
       // debugging
       std::cout<<"New path has "<<new_msg.robots[0].path.size() -
-          _fleet_state_msg.robots[0].path.size()<< " more locations"<<std::endl;
+        _fleet_state_msg.robots[0].path.size()<< " more locations"<<std::endl;
 
       std::cout<<"Delta: "<<std::to_string(
           new_msg.robots[0].path[new_msg.robots[0].path.size() -1].t.sec
-            -_fleet_state_msg.robots[0].path[1].t.sec)<<std::endl;
+          -_fleet_state_msg.robots[0].path[1].t.sec)<<std::endl;
 
       //publishing new FleetState msg
       _fleet_state_pub->publish(new_msg);
@@ -343,10 +345,10 @@ private:
 int main(int argc, char* argv[])
 {
   const std::vector<std::string> args =
-      rclcpp::init_and_remove_ros_arguments(argc, argv);
+    rclcpp::init_and_remove_ros_arguments(argc, argv);
 
   std::string fleet_name = "test_fleet";
   std::string viz_name = "viz";
-  rclcpp::spin(std::make_shared<TestReadOnly>(fleet_name,viz_name));
+  rclcpp::spin(std::make_shared<TestReadOnly>(fleet_name, viz_name));
   rclcpp::shutdown();
 }

--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -57,6 +57,15 @@ if(BUILD_TESTING)
     PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   )
+  
+  find_package(rmf_cmake_uncrustify REQUIRED)
+  find_file(uncrustify_config_file NAMES "share/format/rmf_code_style.cfg")
+                
+  rmf_uncrustify(
+    ARGN include src test
+    CONFIG_FILE ${uncrustify_config_file}
+    MAX_LINE_LENGTH 80
+  )
 endif()
 
 target_link_libraries(rmf_traffic

--- a/rmf_traffic/include/rmf_traffic/DetectConflict.hpp
+++ b/rmf_traffic/include/rmf_traffic/DetectConflict.hpp
@@ -52,11 +52,11 @@ public:
   /// \return true if a conflict exists between the trajectories, false
   /// otherwise.
   static bool between(
-      const Profile& profile_a,
-      const Trajectory& trajectory_a,
-      const Profile& profile_b,
-      const Trajectory& trajectory_b,
-      Interpolate interpolation = Interpolate::CubicSpline);
+    const Profile& profile_a,
+    const Trajectory& trajectory_a,
+    const Profile& profile_b,
+    const Trajectory& trajectory_b,
+    Interpolate interpolation = Interpolate::CubicSpline);
 
   class Implementation;
 };

--- a/rmf_traffic/include/rmf_traffic/Motion.hpp
+++ b/rmf_traffic/include/rmf_traffic/Motion.hpp
@@ -75,12 +75,12 @@ public:
   ///   include all the way to the end of the trajectory, pass in
   ///   Trajectory::end(). An exception will be thrown if begin == end.
   static std::unique_ptr<Motion> compute_cubic_splines(
-      const Trajectory::const_iterator& begin,
-      const Trajectory::const_iterator& end);
+    const Trajectory::const_iterator& begin,
+    const Trajectory::const_iterator& end);
 
   /// Compute a piecewise cubic spline motion object for an entire Trajectory.
   static std::unique_ptr<Motion> compute_cubic_splines(
-      const Trajectory& trajectory);
+    const Trajectory& trajectory);
 };
 
 } // namespace rmf_traffic

--- a/rmf_traffic/include/rmf_traffic/Profile.hpp
+++ b/rmf_traffic/include/rmf_traffic/Profile.hpp
@@ -41,8 +41,8 @@ public:
   ///   this, the footprint shape will be used as the vicinity.
   ///
   Profile(
-      geometry::ConstFinalConvexShapePtr footprint,
-      geometry::ConstFinalConvexShapePtr vicinity = nullptr);
+    geometry::ConstFinalConvexShapePtr footprint,
+    geometry::ConstFinalConvexShapePtr vicinity = nullptr);
 
   /// Set the footprint of the participant.
   Profile& footprint(geometry::ConstFinalConvexShapePtr shape);

--- a/rmf_traffic/include/rmf_traffic/Region.hpp
+++ b/rmf_traffic/include/rmf_traffic/Region.hpp
@@ -63,10 +63,10 @@ public:
   ///   A vector of geometry::Space objects to define the desired regions
   ///   in space.
   Region(
-      std::string map,
-      Time lower_bound,
-      Time upper_bound,
-      std::vector<Space> spaces);
+    std::string map,
+    Time lower_bound,
+    Time upper_bound,
+    std::vector<Space> spaces);
 
   /// Construct a region with no time constraints.
   ///
@@ -78,8 +78,8 @@ public:
   ///   A vector of geometry::Space objects to define the desired regions
   ///   in space.
   Region(
-      std::string map,
-      std::vector<Space> spaces);
+    std::string map,
+    std::vector<Space> spaces);
 
   /// Get the name of the map that this Spacetime refers to.
   const std::string& get_map() const;

--- a/rmf_traffic/include/rmf_traffic/Route.hpp
+++ b/rmf_traffic/include/rmf_traffic/Route.hpp
@@ -43,8 +43,8 @@ public:
   ///   The scheduled trajectory
   ///
   Route(
-      std::string map,
-      Trajectory trajectory);
+    std::string map,
+    Trajectory trajectory);
 
   /// Set the map for this route
   Route& map(std::string value);

--- a/rmf_traffic/include/rmf_traffic/Time.hpp
+++ b/rmf_traffic/include/rmf_traffic/Time.hpp
@@ -56,7 +56,6 @@ Time apply_offset(Time start_time, double delta_seconds);
 } // namespace time
 
 
-
 // TODO(MXG): Make user-friendly interfaces for interacting with the STL
 // time points and durations. They have good semantics from a technical point
 // of view, but they tend to be difficult for users to do tests and experiments

--- a/rmf_traffic/include/rmf_traffic/Trajectory.hpp
+++ b/rmf_traffic/include/rmf_traffic/Trajectory.hpp
@@ -173,9 +173,9 @@ public:
   /// The Waypoint will be inserted into the Trajectory according to its time,
   /// ensuring correct ordering of all Waypoints.
   InsertionResult insert(
-      Time time,
-      Eigen::Vector3d position,
-      Eigen::Vector3d velocity);
+    Time time,
+    Eigen::Vector3d position,
+    Eigen::Vector3d velocity);
 
   /// Insert a copy of another Trajectory's Waypoint into this one.
   InsertionResult insert(const Waypoint& other);

--- a/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
@@ -111,8 +111,8 @@ public:
     /// \return True if the constraint is satisfied with the new value of
     /// position. False if the constraint could not be satisfied.
     virtual bool apply(
-        Eigen::Vector3d& position,
-        const Eigen::Vector2d& course_vector) const = 0;
+      Eigen::Vector3d& position,
+      const Eigen::Vector2d& course_vector) const = 0;
 
     /// Clone this OrientationConstraint.
     virtual rmf_utils::clone_ptr<OrientationConstraint> clone() const = 0;
@@ -142,8 +142,8 @@ public:
     /// \return True if the constraint is satisfied with the new value of
     /// velocity. False if the constraint could not be satisfied.
     virtual bool apply(
-        Eigen::Vector3d& velocity,
-        const Eigen::Vector2d& course_vector) const = 0;
+      Eigen::Vector3d& velocity,
+      const Eigen::Vector2d& course_vector) const = 0;
 
     /// Clone this VelocityConstraint.
     virtual std::unique_ptr<VelocityConstraint> clone() const = 0;
@@ -209,9 +209,9 @@ public:
       /// \param[in] duration
       ///   How long the door takes to open or close.
       LiftDoor(
-          std::string lift_name,
-          std::string floor_name,
-          Duration duration);
+        std::string lift_name,
+        std::string floor_name,
+        Duration duration);
 
       /// Get the name of the lift that the door belongs to
       const std::string& lift_name() const;
@@ -254,9 +254,9 @@ public:
       /// \param[in] duration
       ///   How long the lift will take to move.
       LiftMove(
-          std::string lift_name,
-          std::string destination_floor_name,
-          Duration duration);
+        std::string lift_name,
+        std::string destination_floor_name,
+        Duration duration);
 
       /// Get the name of the lift that needs to move
       const std::string& lift_name() const;
@@ -293,7 +293,7 @@ public:
       /// \param[in]
       ///   How long the robot will take to dock
       Dock(std::string dock_name,
-           Duration duration);
+        Duration duration);
 
       /// Get the name of the dock
       const std::string& dock_name() const;
@@ -343,7 +343,7 @@ public:
       DerivedExecutor& execute(DerivedExecutor& executor) const
       {
         return static_cast<DerivedExecutor&>(execute(
-              static_cast<Executor&>(executor)));
+            static_cast<Executor&>(executor)));
       }
 
       /// Execute this event
@@ -387,9 +387,9 @@ public:
       ///   Any velocity constraints for moving to/from this Node (depending on
       ///   whether it's an entry Node or an exit Node).
       Node(std::size_t waypoint_index,
-           rmf_utils::clone_ptr<Event> event = nullptr,
-           rmf_utils::clone_ptr<OrientationConstraint> orientation = nullptr,
-           rmf_utils::clone_ptr<VelocityConstraint> velocity = nullptr);
+        rmf_utils::clone_ptr<Event> event = nullptr,
+        rmf_utils::clone_ptr<OrientationConstraint> orientation = nullptr,
+        rmf_utils::clone_ptr<VelocityConstraint> velocity = nullptr);
 
       /// Constructor, event and velocity_constraint parameters will be nullptr
       ///
@@ -400,7 +400,7 @@ public:
       ///   Any orientation constraints for moving to/from this Node (depending
       ///   on whether it's an entry Node or an exit Node).
       Node(std::size_t waypoint_index,
-           rmf_utils::clone_ptr<OrientationConstraint> orientation);
+        rmf_utils::clone_ptr<OrientationConstraint> orientation);
 
       /// Get the index of the waypoint that this Node is wrapped around.
       std::size_t waypoint_index() const;
@@ -454,9 +454,9 @@ public:
   /// this version, it is not supported. This is to avoid confusion for Lanes if
   /// a Waypoint that they depend on is erased.
   Waypoint& add_waypoint(
-      std::string map_name,
-      Eigen::Vector2d location,
-      bool is_holding_point = false);
+    std::string map_name,
+    Eigen::Vector2d location,
+    bool is_holding_point = false);
 
   // TODO(MXG): Allow waypoints to have keynames so that they can be gotten by
   // a string value instead of an index value.
@@ -473,8 +473,8 @@ public:
   /// Make a lane for this graph. Lanes connect waypoints together, allowing the
   /// graph to know how the robot is allowed to traverse between waypoints.
   Lane& add_lane(
-      Lane::Node entry,
-      Lane::Node exit);
+    Lane::Node entry,
+    Lane::Node exit);
 
   /// Get the lane at the specified index
   Lane& get_lane(std::size_t index);

--- a/rmf_traffic/include/rmf_traffic/agv/Interpolate.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Interpolate.hpp
@@ -50,10 +50,10 @@ public:
   public:
 
     Options(
-        bool always_stop = false,
-        double translation_thresh = 1e-3,
-        double rotation_thresh = 1.0 * M_PI/180.0,
-        double corner_angle_thresh = 1.0 * M_PI/180.0);
+      bool always_stop = false,
+      double translation_thresh = 1e-3,
+      double rotation_thresh = 1.0* M_PI/180.0,
+      double corner_angle_thresh = 1.0* M_PI/180.0);
 
     /// The robot must always come to a complete stop at every position. When
     /// this is true, all other properties in the options will have no effect.
@@ -94,10 +94,10 @@ public:
     rmf_utils::impl_ptr<Implementation> _pimpl;
   };
   static Trajectory positions(
-      const VehicleTraits& traits,
-      Time start_time,
-      const std::vector<Eigen::Vector3d>& input_positions,
-      const Options& options = Options());
+    const VehicleTraits& traits,
+    Time start_time,
+    const std::vector<Eigen::Vector3d>& input_positions,
+    const Options& options = Options());
 
 };
 

--- a/rmf_traffic/include/rmf_traffic/agv/Negotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Negotiator.hpp
@@ -43,7 +43,7 @@ public:
     ///   The minimum amount of time that the planner should spend waiting at
     ///   holding points. See Planner::Options for more information.
     Options(
-        Duration min_hold_time = Planner::Options::DefaultMinHoldingTime);
+      Duration min_hold_time = Planner::Options::DefaultMinHoldingTime);
 
     /// Set the minimum amount of time to spend waiting at holding points
     Options& minimum_holding_time(Duration holding_time);
@@ -71,15 +71,15 @@ public:
   /// \param[in] options
   ///   Additional options that will be used by the Negotiator.
   SimpleNegotiator(
-      Planner::Start start,
-      Planner::Goal goal,
-      Planner::Configuration planner_configuration,
-      const Options& options = Options());
+    Planner::Start start,
+    Planner::Goal goal,
+    Planner::Configuration planner_configuration,
+    const Options& options = Options());
 
   // Documentation inherited
   void respond(std::shared_ptr<const schedule::Negotiation::Table> table,
-      const Responder& responder,
-      const bool* interrupt_flag = nullptr) final;
+    const Responder& responder,
+    const bool* interrupt_flag = nullptr) final;
 
   // TODO(MXG): How should we implement fallback behaviors when a different
   // negotiator rejects our proposal?

--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright (C) 2019 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -57,9 +57,9 @@ public:
     /// \param[in] graph
     ///   The graph which is being planned over
     Configuration(
-        Graph graph,
-        VehicleTraits traits,
-        Interpolate::Options interpolation = Interpolate::Options());
+      Graph graph,
+      VehicleTraits traits,
+      Interpolate::Options interpolation = Interpolate::Options());
 
     /// Set the graph to use for planning
     Configuration& graph(Graph graph);
@@ -125,9 +125,9 @@ public:
     ///   then pass in a nullptr. It is the user's responsibility to make sure
     ///   that this flag remains valid.
     Options(
-        rmf_utils::clone_ptr<RouteValidator> validator,
-        Duration min_hold_time = DefaultMinHoldingTime,
-        const bool* interrupt_flag = nullptr);
+      rmf_utils::clone_ptr<RouteValidator> validator,
+      Duration min_hold_time = DefaultMinHoldingTime,
+      const bool* interrupt_flag = nullptr);
 
     /// Set the route validator
     Options& validator(rmf_utils::clone_ptr<RouteValidator> v);
@@ -179,11 +179,11 @@ public:
     ///   Optional field to specify if the robot is starting in a certain lane.
     ///   This will only be used if an initial_location is specified.
     Start(
-        Time initial_time,
-        std::size_t initial_waypoint,
-        double initial_orientation,
-        rmf_utils::optional<Eigen::Vector2d> location = rmf_utils::nullopt,
-        rmf_utils::optional<std::size_t> initial_lane = rmf_utils::nullopt);
+      Time initial_time,
+      std::size_t initial_waypoint,
+      double initial_orientation,
+      rmf_utils::optional<Eigen::Vector2d> location = rmf_utils::nullopt,
+      rmf_utils::optional<std::size_t> initial_lane = rmf_utils::nullopt);
 
     /// Set the starting time of a plan
     Start& time(Time initial_time);
@@ -286,8 +286,8 @@ public:
   ///   set them here and then forget about them. These options can be overriden
   ///   each time you request a plan.
   Planner(
-      Configuration config,
-      Options default_options);
+    Configuration config,
+    Options default_options);
 
   /// Get a const reference to the configuration for this Planner. Note that the
   /// configuration of a planner cannot be changed once it is set.
@@ -333,9 +333,9 @@ public:
   ///   The Options to use for this plan. This overrides the default Options of
   ///   the Planner instance.
   rmf_utils::optional<Plan> plan(
-      const Start& start,
-      Goal goal,
-      Options options) const;
+    const Start& start,
+    Goal goal,
+    Options options) const;
 
 
   /// Produces a plan for the given set of starting conditions and goal. The
@@ -373,9 +373,9 @@ public:
   ///   The options to use for this plan. This overrides the default Options of
   ///   the Planner instance.
   rmf_utils::optional<Plan> plan(
-      const StartSet& starts,
-      Goal goal,
-      Options options) const;
+    const StartSet& starts,
+    Goal goal,
+    Options options) const;
 
   class Implementation;
 private:
@@ -464,8 +464,8 @@ public:
   /// \param[in] new_options
   ///   The options that should be used for replanning.
   rmf_utils::optional<Plan> replan(
-      const Planner::Start& new_start,
-      Options new_options) const;
+    const Planner::Start& new_start,
+    Options new_options) const;
 
   /// Replan to the same goal from a new set of start locations using the same
   /// options.
@@ -483,8 +483,8 @@ public:
   /// \param[in] new_options
   ///   The options that should be used for replanning.
   rmf_utils::optional<Plan> replan(
-      const StartSet& new_starts,
-      Options new_options) const;
+    const StartSet& new_starts,
+    Options new_options) const;
 
   /// If this Plan is valid, this will return the Planner::Start that was used
   /// to produce it.
@@ -540,7 +540,7 @@ private:
 ///   network delays.
 ///
 /// \param[in] max_merge_waypoint_distance
-///   The maximum distance allowed to automatically merge onto a waypoint in 
+///   The maximum distance allowed to automatically merge onto a waypoint in
 ///   the graph. Default value as 0.1 meters.
 ///
 /// \param[in] max_merge_lane_distance
@@ -553,12 +553,12 @@ private:
 ///   any lanes shorter than this value will not be evaluated. Default value as
 ///   1e-8 meters.
 std::vector<Plan::Start> compute_plan_starts(
-    const rmf_traffic::agv::Graph& graph,
-    const Eigen::Vector3d pose,
-    const rmf_traffic::Time start_time,
-    const double max_merge_waypoint_distance = 0.1,
-    const double max_merge_lane_distance = 1.0,
-    const double min_lane_length = 1e-8);
+  const rmf_traffic::agv::Graph& graph,
+  const Eigen::Vector3d pose,
+  const rmf_traffic::Time start_time,
+  const double max_merge_waypoint_distance = 0.1,
+  const double max_merge_lane_distance = 1.0,
+  const double min_lane_length = 1e-8);
 
 } // namespace agv
 } // namespace rmf_traffic

--- a/rmf_traffic/include/rmf_traffic/agv/RouteValidator.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/RouteValidator.hpp
@@ -63,9 +63,9 @@ public:
   ///   viewer because the viewer might not be synced with the schedule by the
   ///   time this validator is being used.
   ScheduleRouteValidator(
-      const schedule::Viewer& viewer,
-      schedule::ParticipantId participant_id,
-      Profile profile);
+    const schedule::Viewer& viewer,
+    schedule::ParticipantId participant_id,
+    Profile profile);
 
   /// Change the schedule viewer to use for planning.
   ///
@@ -111,8 +111,8 @@ public:
   /// \param[in] profile
   ///   The profile of the participant that is being planned for.
   NegotiatingRouteValidator(
-      const schedule::Negotiation::Table& table,
-      rmf_traffic::Profile profile);
+    const schedule::Negotiation::Table& table,
+    rmf_traffic::Profile profile);
 
   // Documentation inherited
   bool valid(const Route& route) const final;

--- a/rmf_traffic/include/rmf_traffic/agv/VehicleTraits.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/VehicleTraits.hpp
@@ -34,8 +34,8 @@ public:
   public:
 
     Limits(
-        double velocity = 0.0,
-        double acceleration = 0.0);
+      double velocity = 0.0,
+      double acceleration = 0.0);
 
     Limits& set_nominal_velocity(double nom_vel);
     double get_nominal_velocity() const;
@@ -68,8 +68,8 @@ public:
   public:
 
     Differential(
-        Eigen::Vector2d forward = Eigen::Vector2d::UnitX(),
-        bool reversible = true);
+      Eigen::Vector2d forward = Eigen::Vector2d::UnitX(),
+      bool reversible = true);
 
     Differential& set_forward(Eigen::Vector2d forward);
 
@@ -102,10 +102,10 @@ public:
 
   /// Constructor.
   VehicleTraits(
-      Limits linear,
-      Limits angular,
-      Profile profile,
-      Differential steering = Differential());
+    Limits linear,
+    Limits angular,
+    Profile profile,
+    Differential steering = Differential());
 
   Limits& linear();
   const Limits& linear() const;

--- a/rmf_traffic/include/rmf_traffic/detail/bidirectional_iterator.hpp
+++ b/rmf_traffic/include/rmf_traffic/detail/bidirectional_iterator.hpp
@@ -77,7 +77,8 @@ public:
   bool operator!=(const bidirectional_iterator& other) const;
 
   // Allow implicit conversion to const_iterator type
-  operator bidirectional_iterator<const Element, Implementation, Friend>() const;
+  operator bidirectional_iterator<const Element, Implementation,
+    Friend>() const;
 
   // Allow typical copying and moving
   bidirectional_iterator(const bidirectional_iterator&) = default;

--- a/rmf_traffic/include/rmf_traffic/geometry/ConvexShape.hpp
+++ b/rmf_traffic/include/rmf_traffic/geometry/ConvexShape.hpp
@@ -68,10 +68,10 @@ using ConstFinalConvexShapePtr = std::shared_ptr<const FinalConvexShape>;
 
 //==============================================================================
 template<typename T, typename... Args>
-FinalConvexShapePtr make_final_convex(Args&&... args)
+FinalConvexShapePtr make_final_convex(Args&& ... args)
 {
   return std::make_shared<FinalConvexShape>(
-        T(std::forward<Args>(args)...).finalize_convex());
+    T(std::forward<Args>(args)...).finalize_convex());
 }
 
 //==============================================================================

--- a/rmf_traffic/include/rmf_traffic/geometry/Shape.hpp
+++ b/rmf_traffic/include/rmf_traffic/geometry/Shape.hpp
@@ -78,7 +78,7 @@ public:
 
   /// Look at the source of this FinalShape to inspect its parameters.
   const Shape& source() const;
-  
+
   /// Get the characteristic length of this FinalShape
   double get_characteristic_length() const;
 
@@ -95,10 +95,10 @@ using ConstFinalShapePtr = std::shared_ptr<const FinalShape>;
 
 //==============================================================================
 template<typename T, typename... Args>
-FinalShapePtr make_final(Args&&... args)
+FinalShapePtr make_final(Args&& ... args)
 {
   return std::make_shared<FinalShape>(
-        T(std::forward<Args>(args)...).finalize());
+    T(std::forward<Args>(args)...).finalize());
 }
 
 //==============================================================================

--- a/rmf_traffic/include/rmf_traffic/geometry/SimplePolygon.hpp
+++ b/rmf_traffic/include/rmf_traffic/geometry/SimplePolygon.hpp
@@ -118,8 +118,8 @@ struct InvalidSimplePolygonException : public std::exception
 {
   /// \brief Constructor for an invalid Polygon that has self-intersections.
   InvalidSimplePolygonException(
-      SimplePolygon::Intersections intersections,
-      std::size_t num_vertices);
+    SimplePolygon::Intersections intersections,
+    std::size_t num_vertices);
 
   /// \brief Constructor for an invalid Polygon that has too few vertices.
   InvalidSimplePolygonException(std::size_t num_vertices);

--- a/rmf_traffic/include/rmf_traffic/schedule/Change.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Change.hpp
@@ -74,8 +74,8 @@ public:
     /// \param[in] duration
     ///   The duration of that delay.
     Delay(
-        Time from,
-        Duration duration);
+      Time from,
+      Duration duration);
 
     /// The time that the delay began.
     Time from() const;
@@ -121,8 +121,8 @@ public:
     /// \param[in] description
     ///   The description of the participant
     RegisterParticipant(
-        ParticipantId id,
-        ParticipantDescription description);
+      ParticipantId id,
+      ParticipantDescription description);
 
     /// The ID for the participant
     ParticipantId id() const;

--- a/rmf_traffic/include/rmf_traffic/schedule/Database.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Database.hpp
@@ -49,44 +49,44 @@ public:
 
   // Documentation inherited from Writer
   void set(
-      ParticipantId participant,
-      const Input& itinerary,
-      ItineraryVersion version) final;
+    ParticipantId participant,
+    const Input& itinerary,
+    ItineraryVersion version) final;
 
   // Documentation inherited from Writer
   void extend(
-      ParticipantId participant,
-      const Input& routes,
-      ItineraryVersion version) final;
+    ParticipantId participant,
+    const Input& routes,
+    ItineraryVersion version) final;
 
   // Documentation inherited from Writer
   void delay(
-      ParticipantId participant,
-      Time from,
-      Duration delay,
-      ItineraryVersion version) final;
+    ParticipantId participant,
+    Time from,
+    Duration delay,
+    ItineraryVersion version) final;
 
   // Documentation inherited from Writer
   void erase(
-      ParticipantId participant,
-      ItineraryVersion version) final;
+    ParticipantId participant,
+    ItineraryVersion version) final;
 
   // Documentation inherited from Writer
   void erase(
-      ParticipantId participant,
-      const std::vector<RouteId>& routes,
-      ItineraryVersion version) final;
+    ParticipantId participant,
+    const std::vector<RouteId>& routes,
+    ItineraryVersion version) final;
 
   // Documentation inherited from Writer
   ParticipantId register_participant(
-      ParticipantDescription participant_info) final;
+    ParticipantDescription participant_info) final;
 
   /// Before calling this function on a Database, you should set the current
   /// time for the database by calling set_current_time(). This will allow the
   /// database to cull this participant after a reasonable amount of time has
   /// passed.
   void unregister_participant(
-      ParticipantId participant) final;
+    ParticipantId participant) final;
 
 
   //============================================================================
@@ -101,11 +101,11 @@ public:
 
   // Documentation inherited from Viewer
   std::shared_ptr<const ParticipantDescription> get_participant(
-      std::size_t participant_id) const final;
+    std::size_t participant_id) const final;
 
   // Documentation inherited from Viewer
   rmf_utils::optional<Itinerary> get_itinerary(
-      std::size_t participant_id) const final;
+    std::size_t participant_id) const final;
 
   // Documentation inherited from Viewer
   Version latest_version() const final;
@@ -147,8 +147,8 @@ public:
   /// \return A Patch of schedule changes that are relevant to the specified
   /// query parameters.
   Patch changes(
-      const Query& parameters,
-      rmf_utils::optional<Version> after) const;
+    const Query& parameters,
+    rmf_utils::optional<Version> after) const;
 
   /// View the routes that match the parameters and have changed (been added or
   /// delayed) since the specified version. This is useful for viewing
@@ -166,8 +166,8 @@ public:
   ///
   // TODO(MXG): Consider adding this function to the Viewer class.
   View query(
-      const Query& parameters,
-      Version after) const;
+    const Query& parameters,
+    Version after) const;
 
   /// Throw away all itineraries up to the specified time.
   ///

--- a/rmf_traffic/include/rmf_traffic/schedule/Mirror.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Mirror.hpp
@@ -46,11 +46,11 @@ public:
 
   // Documentation inherited from Viewer
   std::shared_ptr<const ParticipantDescription> get_participant(
-      std::size_t participant_id) const final;
+    std::size_t participant_id) const final;
 
   // Documentation inherited from Viewer
   rmf_utils::optional<Itinerary> get_itinerary(
-      std::size_t participant_id) const final;
+    std::size_t participant_id) const final;
 
   // Documentation inherited from Viewer
   Version latest_version() const final;

--- a/rmf_traffic/include/rmf_traffic/schedule/Negotiation.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Negotiation.hpp
@@ -46,8 +46,8 @@ public:
   ///   The participants who are involved in the schedule negotiation.
   ///
   Negotiation(
-      const Viewer& viewer,
-      std::vector<ParticipantId> participants);
+    const Viewer& viewer,
+    std::vector<ParticipantId> participants);
 
   /// Get the participants that are currently involved in this negotiation.
   const std::unordered_set<ParticipantId>& participants() const;
@@ -133,8 +133,8 @@ public:
     /// \return True if the submission was accepted. False if the version was
     /// out of date and nothing changed in the negotiation.
     bool submit(
-        std::vector<Route> itinerary,
-        Version version);
+      std::vector<Route> itinerary,
+      Version version);
 
     /// Reject the proposals that underlie this Negotiation::Table. This
     /// indicates that the underlying proposals are infeasible for the
@@ -197,13 +197,13 @@ public:
   ///   participant is accommodating all of the participants that come before
   ///   it.
   TablePtr table(
-      ParticipantId for_participant,
-      const std::vector<ParticipantId>& to_accommodate);
+    ParticipantId for_participant,
+    const std::vector<ParticipantId>& to_accommodate);
 
   // const-qualified table()
   ConstTablePtr table(
-      ParticipantId for_participant,
-      const std::vector<ParticipantId>& to_accommodate) const;
+    ParticipantId for_participant,
+    const std::vector<ParticipantId>& to_accommodate) const;
 
   /// Get a Negotiation::Table that corresponds to the given participant
   /// sequence. For a table in terms of for_participant and to_accomodate, you
@@ -226,7 +226,7 @@ public:
     /// Given a set of proposals, choose the one that is the "best". It is up to
     /// the implementation of the Evaluator to decide how to rank proposals.
     virtual std::size_t choose(
-        const std::vector<const Proposal*>& proposals) const = 0;
+      const std::vector<const Proposal*>& proposals) const = 0;
 
     virtual ~Evaluator() = default;
   };
@@ -252,7 +252,7 @@ public:
 
   // Documentation inherited
   std::size_t choose(
-      const std::vector<const Negotiation::Proposal*>& proposals) const final;
+    const std::vector<const Negotiation::Proposal*>& proposals) const final;
 
 };
 

--- a/rmf_traffic/include/rmf_traffic/schedule/Negotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Negotiator.hpp
@@ -115,8 +115,8 @@ public:
   /// \param[in] table_sequence
   ///   The sequence that identifies what table this responder should submit to
   SimpleResponder(
-      std::shared_ptr<schedule::Negotiation> negotiation,
-      std::vector<schedule::ParticipantId> table_sequence);
+    std::shared_ptr<schedule::Negotiation> negotiation,
+    std::vector<schedule::ParticipantId> table_sequence);
 
   // Documentation inherited
   // NOTE: approval_callback does not get used

--- a/rmf_traffic/include/rmf_traffic/schedule/Negotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Negotiator.hpp
@@ -53,8 +53,8 @@ public:
     ///   negotiation (or a nullopt if no update will be performed). Pass in a
     ///   nullptr if an approval callback is not necessary.
     virtual void submit(
-        std::vector<Route> itinerary,
-        std::function<UpdateVersion()> approval_callback = nullptr) const = 0;
+      std::vector<Route> itinerary,
+      std::function<UpdateVersion()> approval_callback = nullptr) const = 0;
 
     /// The negotiator will call this function if it has decided to reject an
     /// attempt to negotiate.
@@ -78,9 +78,9 @@ public:
   ///   has been running for too long. If the planner should run indefinitely,
   ///   then pass a nullptr.
   virtual void respond(
-      std::shared_ptr<const schedule::Negotiation::Table> table,
-      const Responder& responder,
-      const bool* interrupt_flag = nullptr) = 0;
+    std::shared_ptr<const schedule::Negotiation::Table> table,
+    const Responder& responder,
+    const bool* interrupt_flag = nullptr) = 0;
 
   virtual ~Negotiator() = default;
 };
@@ -103,15 +103,15 @@ public:
   /// \param[in] to_accommodate
   ///   The participants that will be accommodated by the response
   SimpleResponder(
-      std::shared_ptr<schedule::Negotiation> negotiation,
-      schedule::ParticipantId for_participant,
-      std::vector<schedule::ParticipantId> to_accommodate);
+    std::shared_ptr<schedule::Negotiation> negotiation,
+    schedule::ParticipantId for_participant,
+    std::vector<schedule::ParticipantId> to_accommodate);
 
   // Documentation inherited
   // NOTE: approval_callback does not get used
   void submit(
-      std::vector<Route> itinerary,
-      std::function<UpdateVersion()> approval_callback=nullptr) const final;
+    std::vector<Route> itinerary,
+    std::function<UpdateVersion()> approval_callback = nullptr) const final;
 
   // Documentation inherited
   void reject() const final;

--- a/rmf_traffic/include/rmf_traffic/schedule/Participant.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Participant.hpp
@@ -135,9 +135,9 @@ private:
 ///   For example, if the \code{writer} argument refers to a Database instance,
 ///   then there is no need for a RectifierRequesterFactory.
 Participant make_participant(
-    ParticipantDescription description,
-    Writer& writer,
-    RectificationRequesterFactory* rectifier_factory = nullptr);
+  ParticipantDescription description,
+  Writer& writer,
+  RectificationRequesterFactory* rectifier_factory = nullptr);
 
 // TODO(MXG): Consider creating an overload of make_participant() that accepts
 // a std::shared_ptr<Writer> to ensure that the writer's lifecycle is long

--- a/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/ParticipantDescription.hpp
@@ -67,10 +67,10 @@ public:
   ///   participant might be able to react to a conflict or a request for
   ///   accommodations.
   ParticipantDescription(
-      std::string name,
-      std::string owner,
-      Rx responsiveness,
-      Profile profile);
+    std::string name,
+    std::string owner,
+    Rx responsiveness,
+    Profile profile);
 
   /// Set the name of the participant.
   ParticipantDescription& name(std::string value);

--- a/rmf_traffic/include/rmf_traffic/schedule/Patch.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Patch.hpp
@@ -54,10 +54,10 @@ public:
     /// \param[in] additions
     ///   The information about which routes to add
     Participant(
-        ParticipantId id,
-        Change::Erase erasures,
-        std::vector<Change::Delay> delays,
-        Change::Add additions);
+      ParticipantId id,
+      Change::Erase erasures,
+      std::vector<Change::Delay> delays,
+      Change::Add additions);
 
     /// The ID of the participant that this set of changes will patch.
     ParticipantId participant_id() const;
@@ -108,11 +108,11 @@ public:
   /// \param[in] latest_version
   ///   The lastest version of the database that this Patch represents.
   Patch(
-      std::vector<Change::UnregisterParticipant> removed_participants,
-      std::vector<Change::RegisterParticipant> new_participants,
-      std::vector<Participant> changes,
-      rmf_utils::optional<Change::Cull> cull,
-      Version latest_version);
+    std::vector<Change::UnregisterParticipant> removed_participants,
+    std::vector<Change::RegisterParticipant> new_participants,
+    std::vector<Participant> changes,
+    rmf_utils::optional<Change::Cull> cull,
+    Version latest_version);
 
   // TODO(MXG): Consider using a persistent reliable topic to broadcast the
   // active participant information instead of making it part of the patch.

--- a/rmf_traffic/include/rmf_traffic/schedule/Query.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Query.hpp
@@ -214,8 +214,8 @@ public:
     /// \param[in] lower_bound
     ///   The lower bound on time
     Spacetime(
-        std::vector<std::string> maps,
-        Time lower_bound);
+      std::vector<std::string> maps,
+      Time lower_bound);
 
     /// Timespan mode constructor.
     ///
@@ -231,9 +231,9 @@ public:
     /// \param[in] upper_bound
     ///   The upper bound on time
     Spacetime(
-        std::vector<std::string> maps,
-        Time lower_bound,
-        Time upper_bound);
+      std::vector<std::string> maps,
+      Time lower_bound,
+      Time upper_bound);
 
     /// Get the current Spacetime Mode of this query.
     Mode get_mode() const;
@@ -257,14 +257,14 @@ public:
 
     /// Query a timespan between two bounds for a set of maps
     Timespan& query_timespan(
-        std::vector<std::string> maps,
-        Time lower_bound,
-        Time upper_bound);
+      std::vector<std::string> maps,
+      Time lower_bound,
+      Time upper_bound);
 
     /// Query from a lower bound in time for a set of maps
     Timespan& query_timespan(
-        std::vector<std::string> maps,
-        Time lower_bound);
+      std::vector<std::string> maps,
+      Time lower_bound);
 
     /// Query for all trajectories on a set of maps
     Timespan& query_timespan(std::vector<std::string> maps);
@@ -448,7 +448,7 @@ Query query_all();
 /// \param[in] regions
 ///   Only query Trajectories that intersect with the specified regions.
 Query make_query(
-    std::vector<Region> regions);
+  std::vector<Region> regions);
 
 //==============================================================================
 /// Query for all Trajectories that fall within a time range.
@@ -461,9 +461,9 @@ Query make_query(
 ///   A pointer to the upper bound for the time range. Pass in a nullptr to
 ///   indicate that there is no upper bound.
 Query make_query(
-    std::vector<std::string> maps,
-    const Time* start_time,
-    const Time* finish_time);
+  std::vector<std::string> maps,
+  const Time* start_time,
+  const Time* finish_time);
 
 } // namespace schedule
 

--- a/rmf_traffic/include/rmf_traffic/schedule/Rectifier.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Rectifier.hpp
@@ -66,8 +66,8 @@ public:
   /// \param[in] last_known_version
   ///   The last ItineraryVersion known upstream.
   void retransmit(
-      const std::vector<Range>& ranges,
-      ItineraryVersion last_known_version);
+    const std::vector<Range>& ranges,
+    ItineraryVersion last_known_version);
 
   /// Get the current ItineraryVersion of the Participant.
   ItineraryVersion current_version() const;
@@ -119,8 +119,8 @@ public:
   ///   RectificationRequester. This is the same participant that the rectifier
   ///   will request retransmissions to.
   virtual std::unique_ptr<RectificationRequester> make(
-      Rectifier rectifier,
-      ParticipantId participant_id) = 0;
+    Rectifier rectifier,
+    ParticipantId participant_id) = 0;
 
   // virtual destructor
   virtual ~RectificationRequesterFactory() = default;
@@ -137,7 +137,7 @@ class Database;
 /// instance and issues rectification requests when told to based on the current
 /// inconsistencies in the Database.
 class DatabaseRectificationRequesterFactory
-    : public RectificationRequesterFactory
+  : public RectificationRequesterFactory
 {
 public:
 
@@ -149,8 +149,8 @@ public:
   DatabaseRectificationRequesterFactory(const Database& database);
 
   std::unique_ptr<RectificationRequester> make(
-      Rectifier rectifier,
-      ParticipantId participant_id) final;
+    Rectifier rectifier,
+    ParticipantId participant_id) final;
 
   /// Call this function to instruct all the RectificationRequestors produced
   /// by this factory to perform their rectifications.

--- a/rmf_traffic/include/rmf_traffic/schedule/Viewer.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Viewer.hpp
@@ -95,13 +95,13 @@ public:
   /// If a participant with the specified ID is not registered with the
   /// schedule, then this will return a nullptr.
   virtual std::shared_ptr<const ParticipantDescription> get_participant(
-      ParticipantId participant_id) const = 0;
+    ParticipantId participant_id) const = 0;
 
   /// Get the itinerary of a specific participant if it is available. If a
   /// participant with the specified ID is not registered with the schedule or
   /// has never submitted an itinerary, then this will return a nullopt.
   virtual rmf_utils::optional<Itinerary> get_itinerary(
-      std::size_t participant_id) const = 0;
+    std::size_t participant_id) const = 0;
 
   /// Get the latest version number of this Database.
   virtual Version latest_version() const = 0;

--- a/rmf_traffic/include/rmf_traffic/schedule/Writer.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Writer.hpp
@@ -54,9 +54,9 @@ public:
   ///   The version for this itinerary change
   ///
   virtual void set(
-      ParticipantId participant,
-      const Input& itinerary,
-      ItineraryVersion version) = 0;
+    ParticipantId participant,
+    const Input& itinerary,
+    ItineraryVersion version) = 0;
 
   /// Add a set of routes to the itinerary of this participant.
   ///
@@ -70,9 +70,9 @@ public:
   ///   The version for this itinerary change
   ///
   virtual void extend(
-      ParticipantId participant,
-      const Input& routes,
-      ItineraryVersion version) = 0;
+    ParticipantId participant,
+    const Input& routes,
+    ItineraryVersion version) = 0;
 
   /// Add a delay to the itinerary from the specified Time.
   ///
@@ -99,10 +99,10 @@ public:
   ///   The version for this itinerary change
   ///
   virtual void delay(
-      ParticipantId participant,
-      Time from,
-      Duration delay,
-      ItineraryVersion version) = 0;
+    ParticipantId participant,
+    Time from,
+    Duration delay,
+    ItineraryVersion version) = 0;
 
   /// Erase an itinerary from this database.
   ///
@@ -113,8 +113,8 @@ public:
   ///   The version for this itinerary change
   ///
   virtual void erase(
-      ParticipantId participant,
-      ItineraryVersion version) = 0;
+    ParticipantId participant,
+    ItineraryVersion version) = 0;
 
   /// Erase a route from an itinerary.
   ///
@@ -128,9 +128,9 @@ public:
   ///   The version for this itinerary change
   ///
   virtual void erase(
-      ParticipantId participant,
-      const std::vector<RouteId>& routes,
-      ItineraryVersion version) = 0;
+    ParticipantId participant,
+    const std::vector<RouteId>& routes,
+    ItineraryVersion version) = 0;
 
   // TODO(MXG): Consider saying "add" instead of "register" and "remove" instead
   // of "unregister".
@@ -145,7 +145,7 @@ public:
   ///
   /// \return result of registering the new participant.
   virtual ParticipantId register_participant(
-      ParticipantDescription participant_info) = 0;
+    ParticipantDescription participant_info) = 0;
 
   /// Unregister an existing participant.
   ///
@@ -154,7 +154,7 @@ public:
   ///
   /// \return the new version of the schedule.
   virtual void unregister_participant(
-      ParticipantId participant) = 0;
+    ParticipantId participant) = 0;
 
   // virtual destructor
   virtual ~Writer() = default;

--- a/rmf_traffic/src/rmf_traffic/DetectConflict.cpp
+++ b/rmf_traffic/src/rmf_traffic/DetectConflict.cpp
@@ -38,27 +38,27 @@ public:
   std::string what;
 
   static invalid_trajectory_error make_segment_num_error(
-      std::size_t num_segments)
+    std::size_t num_segments)
   {
     invalid_trajectory_error error;
     error._pimpl->what = std::string()
-        + "[rmf_traffic::invalid_trajectory_error] Attempted to check a "
-        + "conflict with a Trajectory that has [" + std::to_string(num_segments)
-        + "] segments. This is not supported. Trajectories must have at least "
-        + "2 segments to check them for conflicts.";
+      + "[rmf_traffic::invalid_trajectory_error] Attempted to check a "
+      + "conflict with a Trajectory that has [" + std::to_string(num_segments)
+      + "] segments. This is not supported. Trajectories must have at least "
+      + "2 segments to check them for conflicts.";
     return error;
   }
 
   static invalid_trajectory_error make_missing_shape_error(
-      const Time time)
+    const Time time)
   {
     invalid_trajectory_error error;
     error._pimpl->what = std::string()
-        + "[rmf_traffic::invalid_trajectory_error] Attempting to check a "
-        + "conflict with a Trajectory that has no shape specified for the "
-        + "profile of its waypoint at time ["
-        + std::to_string(time.time_since_epoch().count())
-        + "ns]. This is not supported.";
+      + "[rmf_traffic::invalid_trajectory_error] Attempting to check a "
+      + "conflict with a Trajectory that has no shape specified for the "
+      + "profile of its waypoint at time ["
+      + std::to_string(time.time_since_epoch().count())
+      + "ns]. This is not supported.";
 
     return error;
   }
@@ -72,7 +72,7 @@ const char* invalid_trajectory_error::what() const noexcept
 
 //==============================================================================
 invalid_trajectory_error::invalid_trajectory_error()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // This constructor is a no-op, but we'll keep a definition for it in case we
   // need it in the future. Allowing the default constructor to be inferred
@@ -84,8 +84,8 @@ invalid_trajectory_error::invalid_trajectory_error()
 namespace {
 //==============================================================================
 bool have_time_overlap(
-    const Trajectory& trajectory_a,
-    const Trajectory& trajectory_b)
+  const Trajectory& trajectory_a,
+  const Trajectory& trajectory_b)
 {
   const auto* t_a0 = trajectory_a.start_time();
   const auto* t_bf = trajectory_b.finish_time();
@@ -95,7 +95,7 @@ bool have_time_overlap(
   assert(t_a0 != nullptr);
   assert(t_bf != nullptr);
 
-  if(*t_bf < *t_a0)
+  if (*t_bf < *t_a0)
   {
     // If Trajectory `b` finishes before Trajectory `a` starts, then there
     // cannot be any conflict.
@@ -110,7 +110,7 @@ bool have_time_overlap(
   assert(t_b0 != nullptr);
   assert(t_af != nullptr);
 
-  if(*t_af < *t_b0)
+  if (*t_af < *t_b0)
   {
     // If Trajectory `a` finished before Trajectory `b` starts, then there
     // cannot be any conflict.
@@ -123,8 +123,8 @@ bool have_time_overlap(
 //==============================================================================
 std::tuple<Trajectory::const_iterator, Trajectory::const_iterator>
 get_initial_iterators(
-    const Trajectory& trajectory_a,
-    const Trajectory& trajectory_b)
+  const Trajectory& trajectory_a,
+  const Trajectory& trajectory_b)
 {
   const Time& t_a0 = *trajectory_a.start_time();
   const Time& t_b0 = *trajectory_b.start_time();
@@ -132,14 +132,14 @@ get_initial_iterators(
   Trajectory::const_iterator a_it;
   Trajectory::const_iterator b_it;
 
-  if(t_a0 < t_b0)
+  if (t_a0 < t_b0)
   {
     // Trajectory `a` starts first, so we begin evaluating at the time
     // that `b` begins
     a_it = trajectory_a.find(t_b0);
     b_it = ++trajectory_b.begin();
   }
-  else if(t_b0 < t_a0)
+  else if (t_b0 < t_a0)
   {
     // Trajectory `b` starts first, so we begin evaluating at the time
     // that `a` begins
@@ -173,19 +173,19 @@ struct BoundingProfile
 
 //==============================================================================
 double evaluate_spline(
-    const Eigen::Vector4d& coeffs,
-    const double t)
+  const Eigen::Vector4d& coeffs,
+  const double t)
 {
   // Assume time is parameterized [0,1]
-  return (coeffs[3] * t * t * t
-      + coeffs[2] * t * t
-      + coeffs[1] * t
-      + coeffs[0]);
+  return coeffs[3] * t * t * t
+    + coeffs[2] * t * t
+    + coeffs[1] * t
+    + coeffs[0];
 }
 
 //==============================================================================
 std::array<double, 2> get_local_extrema(
-    const Eigen::Vector4d& coeffs)
+  const Eigen::Vector4d& coeffs)
 {
   std::vector<double> extrema_candidates;
   // Store boundary values as potential extrema
@@ -231,11 +231,11 @@ std::array<double, 2> get_local_extrema(
   std::array<double, 2> extrema;
   assert(!extrema_candidates.empty());
   extrema[0] = *std::min_element(
-      extrema_candidates.begin(),
-      extrema_candidates.end());
+    extrema_candidates.begin(),
+    extrema_candidates.end());
   extrema[1] = *std::max_element(
-      extrema_candidates.begin(),
-      extrema_candidates.end());
+    extrema_candidates.begin(),
+    extrema_candidates.end());
 
   return extrema;
 }
@@ -266,8 +266,8 @@ BoundingBox void_box()
 
 //==============================================================================
 BoundingBox adjust_bounding_box(
-    const BoundingBox& input,
-    const double value)
+  const BoundingBox& input,
+  const double value)
 {
   BoundingBox box = input;
   box.min -= Eigen::Vector2d{value, value};
@@ -278,30 +278,30 @@ BoundingBox adjust_bounding_box(
 
 //==============================================================================
 BoundingProfile get_bounding_profile(
-    const rmf_traffic::Spline& spline,
-    const Profile::Implementation& profile)
+  const rmf_traffic::Spline& spline,
+  const Profile::Implementation& profile)
 {
   BoundingBox base_box = get_bounding_box(spline);
 
   const auto& footprint = profile.footprint;
   const auto f_box = footprint ?
-        adjust_bounding_box(base_box, footprint->get_characteristic_length())
-      : void_box();
+    adjust_bounding_box(base_box, footprint->get_characteristic_length()) :
+    void_box();
 
   const auto& vicinity = profile.vicinity;
   const auto v_box = vicinity ?
-        adjust_bounding_box(base_box, vicinity->get_characteristic_length())
-      : void_box();
+    adjust_bounding_box(base_box, vicinity->get_characteristic_length()) :
+    void_box();
 
   return BoundingProfile{f_box, v_box};
 }
 
 //==============================================================================
 bool overlap(
-    const BoundingBox& box_a,
-    const BoundingBox& box_b)
+  const BoundingBox& box_a,
+  const BoundingBox& box_b)
 {
-  for (int i=0; i < 2; ++i)
+  for (int i = 0; i < 2; ++i)
   {
     if (box_a.max[i] < box_b.min[i])
       return false;
@@ -341,19 +341,19 @@ fcl::ContinuousCollisionRequest make_fcl_request()
 
 //==============================================================================
 rmf_utils::optional<fcl::FCL_REAL> check_collision(
-    const geometry::FinalConvexShape& shape_a,
-    const std::shared_ptr<fcl::SplineMotion>& motion_a,
-    const geometry::FinalConvexShape& shape_b,
-    const std::shared_ptr<fcl::SplineMotion>& motion_b,
-    const fcl::ContinuousCollisionRequest& request)
+  const geometry::FinalConvexShape& shape_a,
+  const std::shared_ptr<fcl::SplineMotion>& motion_a,
+  const geometry::FinalConvexShape& shape_b,
+  const std::shared_ptr<fcl::SplineMotion>& motion_b,
+  const fcl::ContinuousCollisionRequest& request)
 {
   const auto obj_a = fcl::ContinuousCollisionObject(
-        geometry::FinalConvexShape::Implementation::get_collision(shape_a),
-        motion_a);
+    geometry::FinalConvexShape::Implementation::get_collision(shape_a),
+    motion_a);
 
   const auto obj_b = fcl::ContinuousCollisionObject(
-        geometry::FinalConvexShape::Implementation::get_collision(shape_b),
-        motion_b);
+    geometry::FinalConvexShape::Implementation::get_collision(shape_b),
+    motion_b);
 
   fcl::ContinuousCollisionResult result;
   fcl::collide(&obj_a, &obj_b, request, result);
@@ -376,9 +376,9 @@ Profile::Implementation convert_profile(const Profile& profile)
 
 //==============================================================================
 Time compute_time(
-    const fcl::FCL_REAL scaled_time,
-    const Time start_time,
-    const Time finish_time)
+  const fcl::FCL_REAL scaled_time,
+  const Time start_time,
+  const Time finish_time)
 {
   const Duration delta_t{
     Duration::rep(scaled_time * (finish_time - start_time).count())
@@ -391,32 +391,34 @@ Time compute_time(
 
 //==============================================================================
 bool DetectConflict::between(
-    const Profile& profile_a,
-    const Trajectory& trajectory_a,
-    const Profile& profile_b,
-    const Trajectory& trajectory_b,
-    Interpolate interpolation)
+  const Profile& profile_a,
+  const Trajectory& trajectory_a,
+  const Profile& profile_b,
+  const Trajectory& trajectory_b,
+  Interpolate interpolation)
 {
   return Implementation::between(
-        profile_a, trajectory_a,
-        profile_b, trajectory_b,
-        interpolation);
+    profile_a, trajectory_a,
+    profile_b, trajectory_b,
+    interpolation);
 }
 
 bool DetectConflict::Implementation::between(
-    const Profile& input_profile_a,
-    const Trajectory& trajectory_a,
-    const Profile& input_profile_b,
-    const Trajectory& trajectory_b,
-    Interpolate /*interpolation*/,
-    std::vector<Conflict>* output_conflicts)
+  const Profile& input_profile_a,
+  const Trajectory& trajectory_a,
+  const Profile& input_profile_b,
+  const Trajectory& trajectory_b,
+  Interpolate /*interpolation*/,
+  std::vector<Conflict>* output_conflicts)
 {
   const std::size_t min_size =
-      std::min(trajectory_a.size(), trajectory_b.size());
-  if(min_size < 2)
+    std::min(trajectory_a.size(), trajectory_b.size());
+  if (min_size < 2)
   {
+    // *INDENT-OFF*
     throw invalid_trajectory_error::Implementation
-        ::make_segment_num_error(min_size);
+      ::make_segment_num_error(min_size);
+    // *INDENT-ON*
   }
 
   const Profile::Implementation profile_a = convert_profile(input_profile_a);
@@ -447,17 +449,17 @@ bool DetectConflict::Implementation::between(
   rmf_utils::optional<Spline> spline_b;
 
   std::shared_ptr<fcl::SplineMotion> motion_a =
-      make_uninitialized_fcl_spline_motion();
+    make_uninitialized_fcl_spline_motion();
   std::shared_ptr<fcl::SplineMotion> motion_b =
-      make_uninitialized_fcl_spline_motion();
+    make_uninitialized_fcl_spline_motion();
 
   const fcl::ContinuousCollisionRequest request = make_fcl_request();
 
   // This flag lets us know that we need to test both a's footprint in b's
   // vicinity and b's footprint in a's vicinity.
   const bool test_complement =
-         (profile_a.vicinity != profile_a.footprint)
-      || (profile_b.vicinity != profile_b.footprint);
+    (profile_a.vicinity != profile_a.footprint)
+    || (profile_b.vicinity != profile_b.footprint);
 
   if (output_conflicts)
     output_conflicts->clear();
@@ -471,10 +473,10 @@ bool DetectConflict::Implementation::between(
       spline_b = Spline(b_it);
 
     const Time start_time =
-        std::max(spline_a->start_time(), spline_b->start_time());
+      std::max(spline_a->start_time(), spline_b->start_time());
 
     const Time finish_time =
-        std::min(spline_a->finish_time(), spline_b->finish_time());
+      std::min(spline_a->finish_time(), spline_b->finish_time());
 
     *motion_a = spline_a->to_fcl(start_time, finish_time);
     *motion_b = spline_b->to_fcl(start_time, finish_time);
@@ -485,32 +487,32 @@ bool DetectConflict::Implementation::between(
     if (overlap(bound_a.footprint, bound_b.vicinity))
     {
       if (const auto collision = check_collision(
-            *profile_a.footprint, motion_a,
-            *profile_b.vicinity, motion_b, request))
+          *profile_a.footprint, motion_a,
+          *profile_b.vicinity, motion_b, request))
       {
         if (!output_conflicts)
           return true;
 
         output_conflicts->emplace_back(
-              Conflict{
-                a_it, b_it, compute_time(*collision, start_time, finish_time)
-              });
+          Conflict{
+            a_it, b_it, compute_time(*collision, start_time, finish_time)
+          });
       }
     }
 
     if (test_complement && overlap(bound_a.vicinity, bound_b.footprint))
     {
       if (const auto collision = check_collision(
-            *profile_a.vicinity, motion_a,
-            *profile_b.footprint, motion_b, request))
+          *profile_a.vicinity, motion_a,
+          *profile_b.footprint, motion_b, request))
       {
         if (!output_conflicts)
           return true;
 
         output_conflicts->emplace_back(
-              Conflict{
-                a_it, b_it, compute_time(*collision, start_time, finish_time)
-              });
+          Conflict{
+            a_it, b_it, compute_time(*collision, start_time, finish_time)
+          });
       }
     }
 
@@ -543,23 +545,25 @@ bool DetectConflict::Implementation::between(
 namespace internal {
 //==============================================================================
 bool detect_conflicts(
-    const Profile& profile,
-    const Trajectory& trajectory,
-    const Spacetime& region,
-    DetectConflict::Implementation::Conflicts* output_conflicts)
+  const Profile& profile,
+  const Trajectory& trajectory,
+  const Spacetime& region,
+  DetectConflict::Implementation::Conflicts* output_conflicts)
 {
 #ifndef NDEBUG
   // This should never actually happen because this function only gets used
   // internally, and so there should be several layers of quality checks on the
   // trajectories to prevent this. But we'll put it in here just in case.
-  if(trajectory.size() < 2)
+  if (trajectory.size() < 2)
   {
     std::cerr << "[rmf_traffic::internal::detect_conflicts] An invalid "
               << "trajectory was passed to detect_conflicts. This is a bug "
               << "that should never happen. Please alert the RMF developers."
               << std::endl;
+    // *INDENT-OFF*
     throw invalid_trajectory_error::Implementation
-        ::make_segment_num_error(trajectory.size());
+      ::make_segment_num_error(trajectory.size());
+    // *INDENT-ON*
   }
 #endif // NDEBUG
 
@@ -570,15 +574,15 @@ bool detect_conflicts(
   const Time trajectory_start_time = *trajectory.start_time();
   const Time trajectory_finish_time = *trajectory.finish_time();
 
-  const Time start_time = region.lower_time_bound?
-        std::max(*region.lower_time_bound, trajectory_start_time)
-      : trajectory_start_time;
+  const Time start_time = region.lower_time_bound ?
+    std::max(*region.lower_time_bound, trajectory_start_time) :
+    trajectory_start_time;
 
-  const Time finish_time = region.upper_time_bound?
-        std::min(*region.upper_time_bound, trajectory_finish_time)
-      : trajectory_finish_time;
+  const Time finish_time = region.upper_time_bound ?
+    std::min(*region.upper_time_bound, trajectory_finish_time) :
+    trajectory_finish_time;
 
-  if(finish_time < start_time)
+  if (finish_time < start_time)
   {
     // If the trajectory or region finishes before the other has started, that
     // means there is no overlap in time between the region and the trajectory,
@@ -587,67 +591,67 @@ bool detect_conflicts(
   }
 
   const Trajectory::const_iterator begin_it =
-      trajectory_start_time < start_time?
-        trajectory.find(start_time) : ++trajectory.begin();
+    trajectory_start_time < start_time ?
+    trajectory.find(start_time) : ++trajectory.begin();
 
   const Trajectory::const_iterator end_it =
-      finish_time < trajectory_finish_time?
-        ++trajectory.find(finish_time) : trajectory.end();
+    finish_time < trajectory_finish_time ?
+    ++trajectory.find(finish_time) : trajectory.end();
 
   std::shared_ptr<fcl::SplineMotion> motion_trajectory =
-      make_uninitialized_fcl_spline_motion();
+    make_uninitialized_fcl_spline_motion();
   std::shared_ptr<internal::StaticMotion> motion_region =
-      std::make_shared<internal::StaticMotion>(region.pose);
+    std::make_shared<internal::StaticMotion>(region.pose);
 
   const fcl::ContinuousCollisionRequest request = make_fcl_request();
 
   const std::shared_ptr<fcl::CollisionGeometry> vicinity_geom =
-      geometry::FinalConvexShape::Implementation::get_collision(*vicinity);
+    geometry::FinalConvexShape::Implementation::get_collision(*vicinity);
 
   if (output_conflicts)
     output_conflicts->clear();
 
-  for(auto it = begin_it; it != end_it; ++it)
+  for (auto it = begin_it; it != end_it; ++it)
   {
     Spline spline_trajectory{it};
 
     const Time spline_start_time =
-        std::max(spline_trajectory.start_time(), start_time);
+      std::max(spline_trajectory.start_time(), start_time);
     const Time spline_finish_time =
-        std::min(spline_trajectory.finish_time(), finish_time);
+      std::min(spline_trajectory.finish_time(), finish_time);
 
     *motion_trajectory = spline_trajectory.to_fcl(
-          spline_start_time, spline_finish_time);
+      spline_start_time, spline_finish_time);
 
     const auto obj_trajectory = fcl::ContinuousCollisionObject(
-          vicinity_geom, motion_trajectory);
+      vicinity_geom, motion_trajectory);
 
     assert(region.shape);
     const auto& region_shapes = geometry::FinalShape::Implementation
-        ::get_collisions(*region.shape);
-    for(const auto& region_shape : region_shapes)
+      ::get_collisions(*region.shape);
+    for (const auto& region_shape : region_shapes)
     {
       const auto obj_region = fcl::ContinuousCollisionObject(
-            region_shape, motion_region);
+        region_shape, motion_region);
 
       // TODO(MXG): We should do a broadphase test here before using
       // fcl::collide
 
       fcl::ContinuousCollisionResult result;
       fcl::collide(&obj_trajectory, &obj_region, request, result);
-      if(result.is_collide)
+      if (result.is_collide)
       {
         if (!output_conflicts)
           return true;
 
         output_conflicts->emplace_back(
-              DetectConflict::Implementation::Conflict{
-                it, it,
-                compute_time(
-                  result.time_of_contact,
-                  spline_start_time,
-                  spline_finish_time)
-              });
+          DetectConflict::Implementation::Conflict{
+            it, it,
+            compute_time(
+              result.time_of_contact,
+              spline_start_time,
+              spline_finish_time)
+          });
       }
     }
   }

--- a/rmf_traffic/src/rmf_traffic/DetectConflictInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/DetectConflictInternal.hpp
@@ -43,12 +43,12 @@ public:
   using Conflicts = std::vector<Conflict>;
 
   static bool between(
-      const Profile& profile_a,
-      const Trajectory& trajectory_a,
-      const Profile& profile_b,
-      const Trajectory& trajectory_b,
-      Interpolate interpolation,
-      std::vector<Conflict>* output_conflicts = nullptr);
+    const Profile& profile_a,
+    const Trajectory& trajectory_a,
+    const Profile& profile_b,
+    const Trajectory& trajectory_b,
+    Interpolate interpolation,
+    std::vector<Conflict>* output_conflicts = nullptr);
 
 };
 
@@ -66,10 +66,10 @@ struct Spacetime
 
 //==============================================================================
 bool detect_conflicts(
-    const Profile& profile,
-    const Trajectory& trajectory,
-    const Spacetime& region,
-    DetectConflict::Implementation::Conflicts* output_conflicts = nullptr);
+  const Profile& profile,
+  const Trajectory& trajectory,
+  const Spacetime& region,
+  DetectConflict::Implementation::Conflicts* output_conflicts = nullptr);
 
 } // namespace internal
 

--- a/rmf_traffic/src/rmf_traffic/Motion.cpp
+++ b/rmf_traffic/src/rmf_traffic/Motion.cpp
@@ -21,14 +21,16 @@ namespace rmf_traffic {
 
 //==============================================================================
 std::unique_ptr<Motion> Motion::compute_cubic_splines(
-    const Trajectory::const_iterator& input_begin,
-    const Trajectory::const_iterator& input_end)
+  const Trajectory::const_iterator& input_begin,
+  const Trajectory::const_iterator& input_end)
 {
   if (input_begin == input_end)
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[rmf_traffic::Motion::compute_cubic_spline] invalid waypoint range: "
-          "begin == end");
+      "[rmf_traffic::Motion::compute_cubic_spline] invalid waypoint range: "
+      "begin == end");
+    // *INDENT-ON*
   }
 
   using const_iterator = internal::WaypointList::const_iterator;
@@ -39,7 +41,7 @@ std::unique_ptr<Motion> Motion::compute_cubic_splines(
   {
     const auto& point = *begin;
     return std::make_unique<SinglePointMotion>(
-          point.data.time, point.data.position, point.data.velocity);
+      point.data.time, point.data.position, point.data.velocity);
   }
 
   std::vector<Spline> splines;
@@ -54,19 +56,19 @@ std::unique_ptr<Motion> Motion::compute_cubic_splines(
 
 //==============================================================================
 std::unique_ptr<Motion> Motion::compute_cubic_splines(
-    const Trajectory& trajectory)
+  const Trajectory& trajectory)
 {
   return compute_cubic_splines(trajectory.begin(), trajectory.end());
 }
 
 //==============================================================================
 SinglePointMotion::SinglePointMotion(
-    const Time t,
-    Eigen::Vector3d p,
-    Eigen::Vector3d v)
-  : _t(t),
-    _p(std::move(p)),
-    _v(std::move(v))
+  const Time t,
+  Eigen::Vector3d p,
+  Eigen::Vector3d v)
+: _t(t),
+  _p(std::move(p)),
+  _v(std::move(v))
 {
   // Do nothing
 }
@@ -103,7 +105,7 @@ Eigen::Vector3d SinglePointMotion::compute_acceleration(Time /*t*/) const
 
 //==============================================================================
 SplineMotion::SplineMotion(Spline spline)
-  : _spline(std::move(spline))
+: _spline(std::move(spline))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/MotionInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/MotionInternal.hpp
@@ -30,9 +30,9 @@ class SinglePointMotion : public Motion
 public:
 
   SinglePointMotion(
-      const Time t,
-      Eigen::Vector3d p,
-      Eigen::Vector3d v);
+    const Time t,
+    Eigen::Vector3d p,
+    Eigen::Vector3d v);
 
   Time start_time() const final;
   Time finish_time() const final;

--- a/rmf_traffic/src/rmf_traffic/Profile.cpp
+++ b/rmf_traffic/src/rmf_traffic/Profile.cpp
@@ -21,13 +21,13 @@ namespace rmf_traffic {
 
 //==============================================================================
 Profile::Profile(
-    geometry::ConstFinalConvexShapePtr footprint,
-    geometry::ConstFinalConvexShapePtr vicinity)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(footprint),
-               std::move(vicinity)
-             }))
+  geometry::ConstFinalConvexShapePtr footprint,
+  geometry::ConstFinalConvexShapePtr vicinity)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(footprint),
+        std::move(vicinity)
+      }))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/Region.cpp
+++ b/rmf_traffic/src/rmf_traffic/Region.cpp
@@ -49,7 +49,7 @@ public:
   {
     iterator result;
     result._pimpl = rmf_utils::make_impl<iterator::Implementation>(
-          iterator::Implementation{it});
+      iterator::Implementation{it});
     return result;
   }
 
@@ -57,30 +57,30 @@ public:
 
 //==============================================================================
 Region::Region(
-    std::string map,
-    Time lower_bound,
-    Time upper_bound,
-    std::vector<geometry::Space> spaces)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(map),
-               lower_bound,
-               upper_bound,
-               std::move(spaces)}))
+  std::string map,
+  Time lower_bound,
+  Time upper_bound,
+  std::vector<geometry::Space> spaces)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(map),
+        lower_bound,
+        upper_bound,
+        std::move(spaces)}))
 {
   // Do nothing
 }
 
 //==============================================================================
 Region::Region(
-    std::string map,
-    std::vector<Space> spaces)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(map),
-               rmf_utils::nullopt,
-               rmf_utils::nullopt,
-               std::move(spaces)}))
+  std::string map,
+  std::vector<Space> spaces)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(map),
+        rmf_utils::nullopt,
+        rmf_utils::nullopt,
+        std::move(spaces)}))
 {
   // Do nothing
 }
@@ -101,7 +101,7 @@ auto Region::set_map(std::string map) -> Region&
 //==============================================================================
 const Time* Region::get_lower_time_bound() const
 {
-  if(_pimpl->lower_bound)
+  if (_pimpl->lower_bound)
     return &(*_pimpl->lower_bound);
 
   return nullptr;
@@ -124,7 +124,7 @@ auto Region::remove_lower_time_bound() -> Region&
 //==============================================================================
 const Time* Region::get_upper_time_bound() const
 {
-  if(_pimpl->upper_bound)
+  if (_pimpl->upper_bound)
     return &(*_pimpl->upper_bound);
 
   return nullptr;
@@ -160,14 +160,14 @@ void Region::pop_back()
 auto Region::erase(iterator it) -> iterator
 {
   return Implementation::make_iterator(
-        _pimpl->spaces.erase(it._pimpl->iter));
+    _pimpl->spaces.erase(it._pimpl->iter));
 }
 
 //==============================================================================
 auto Region::erase(iterator first, iterator last) -> iterator
 {
   return Implementation::make_iterator(
-        _pimpl->spaces.erase(first._pimpl->iter, last._pimpl->iter));
+    _pimpl->spaces.erase(first._pimpl->iter, last._pimpl->iter));
 }
 
 //==============================================================================
@@ -180,7 +180,7 @@ auto Region::begin() -> iterator
 auto Region::begin() const -> const_iterator
 {
   return Implementation::make_iterator(
-        const_cast<Implementation::Spaces&>(_pimpl->spaces).begin());
+    const_cast<Implementation::Spaces&>(_pimpl->spaces).begin());
 }
 
 //==============================================================================
@@ -199,7 +199,7 @@ auto Region::end() -> iterator
 auto Region::end() const -> const_iterator
 {
   return Implementation::make_iterator(
-        const_cast<Implementation::Spaces&>(_pimpl->spaces).end());
+    const_cast<Implementation::Spaces&>(_pimpl->spaces).end());
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/Route.cpp
+++ b/rmf_traffic/src/rmf_traffic/Route.cpp
@@ -21,13 +21,13 @@ namespace rmf_traffic {
 
 //==============================================================================
 Route::Route(
-    std::string map,
-    Trajectory trajectory)
+  std::string map,
+  Trajectory trajectory)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{
-             std::move(map),
-             std::move(trajectory)
-           }))
+      Implementation{
+        std::move(map),
+        std::move(trajectory)
+      }))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/Spline.cpp
+++ b/rmf_traffic/src/rmf_traffic/Spline.cpp
@@ -25,10 +25,10 @@ namespace {
 Eigen::Matrix4d make_M_inv()
 {
   Eigen::Matrix4d M;
-  M.block<1,4>(0,0) <<  1.0/6.0, 2.0/3.0,  1.0/6.0,     0.0;
-  M.block<1,4>(1,0) << -1.0/2.0,     0.0,  1.0/2.0,     0.0;
-  M.block<1,4>(2,0) <<  1.0/2.0,    -1.0,  1.0/2.0,     0.0;
-  M.block<1,4>(3,0) << -1.0/6.0, 1.0/2.0, -1.0/2.0, 1.0/6.0;
+  M.block<1, 4>(0, 0) <<  1.0/6.0, 2.0/3.0, 1.0/6.0, 0.0;
+  M.block<1, 4>(1, 0) << -1.0/2.0, 0.0, 1.0/2.0, 0.0;
+  M.block<1, 4>(2, 0) <<  1.0/2.0, -1.0, 1.0/2.0, 0.0;
+  M.block<1, 4>(3, 0) << -1.0/6.0, 1.0/2.0, -1.0/2.0, 1.0/6.0;
 
   return M.inverse();
 }
@@ -42,19 +42,21 @@ double compute_delta_t(const Time& finish_time, const Time& start_time)
 
 //==============================================================================
 std::array<Eigen::Vector4d, 3> compute_coefficients(
-    const Eigen::Vector3d& x0,
-    const Eigen::Vector3d& x1,
-    const Eigen::Vector3d& v0,
-    const Eigen::Vector3d& v1)
+  const Eigen::Vector3d& x0,
+  const Eigen::Vector3d& x1,
+  const Eigen::Vector3d& v0,
+  const Eigen::Vector3d& v1)
 {
   std::array<Eigen::Vector4d, 3> coeffs;
-  for(int i=0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
+    // *INDENT-OFF*
     std::size_t si = static_cast<std::size_t>(i);
     coeffs[si][0] =                                x0[i]; // = d
     coeffs[si][1] =            v0[i];                     // = c
     coeffs[si][2] = -v1[i] - 2*v0[i] + 3*x1[i] - 3*x0[i]; // = b
     coeffs[si][3] =  v1[i] +   v0[i] - 2*x1[i] + 2*x0[i]; // = a
+    // *INDENT-ON*
   }
 
   return coeffs;
@@ -62,10 +64,10 @@ std::array<Eigen::Vector4d, 3> compute_coefficients(
 
 //==============================================================================
 Spline::Parameters compute_parameters(
-    const Trajectory::const_iterator& finish_it)
+  const Trajectory::const_iterator& finish_it)
 {
   const Trajectory::const_iterator start_it =
-      --Trajectory::const_iterator(finish_it);
+    --Trajectory::const_iterator(finish_it);
 
   const Trajectory::Waypoint& start = *start_it;
   const Trajectory::Waypoint& finish = *finish_it;
@@ -89,10 +91,10 @@ Spline::Parameters compute_parameters(
 
 //==============================================================================
 Spline::Parameters compute_parameters(
-    const internal::WaypointList::const_iterator& finish_it)
+  const internal::WaypointList::const_iterator& finish_it)
 {
   const internal::WaypointList::const_iterator start_it =
-      --internal::WaypointList::const_iterator(finish_it);
+    --internal::WaypointList::const_iterator(finish_it);
 
   const internal::WaypointElement::Data& start = start_it->data;
   const internal::WaypointElement::Data& finish = finish_it->data;
@@ -119,7 +121,7 @@ double compute_scaled_time(const Time& time, const Spline::Parameters& params)
 {
   using Sec64 = std::chrono::duration<double>;
   const double relative_time =
-      std::chrono::duration_cast<Sec64>(time - params.time_range[0]).count();
+    std::chrono::duration_cast<Sec64>(time - params.time_range[0]).count();
 
   const double scaled_time = relative_time / params.delta_t;
   assert(0.0 - 1.0e-8 <= scaled_time);
@@ -130,14 +132,14 @@ double compute_scaled_time(const Time& time, const Spline::Parameters& params)
 
 //==============================================================================
 Eigen::Vector3d compute_position(
-    const Spline::Parameters& params,
-    const double time)
+  const Spline::Parameters& params,
+  const double time)
 {
   Eigen::Vector3d result = Eigen::Vector3d::Zero();
-  for(int i=0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     const Eigen::Vector4d coeffs = params.coeffs[i];
-    for(int j=0; j < 4; ++j)
+    for (int j = 0; j < 4; ++j)
       result[i] += coeffs[j] * pow(time, j);
   }
 
@@ -146,15 +148,15 @@ Eigen::Vector3d compute_position(
 
 //==============================================================================
 Eigen::Vector3d compute_velocity(
-    const Spline::Parameters& params,
-    const double time)
+  const Spline::Parameters& params,
+  const double time)
 {
   Eigen::Vector3d result = Eigen::Vector3d::Zero();
-  for(int i=0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     const Eigen::Vector4d coeffs = params.coeffs[i];
     // Note: This is computing the derivative of the polynomial w.r.t. time
-    for(int j=1; j < 4; ++j)
+    for (int j = 1; j < 4; ++j)
       result[i] += j * coeffs[j] * pow(time, j-1);
   }
 
@@ -163,15 +165,15 @@ Eigen::Vector3d compute_velocity(
 
 //==============================================================================
 Eigen::Vector3d compute_acceleration(
-    const Spline::Parameters& params,
-    const double time)
+  const Spline::Parameters& params,
+  const double time)
 {
   Eigen::Vector3d result = Eigen::Vector3d::Zero();
-  for(int i=0; i < 3; ++i)
+  for (int i = 0; i < 3; ++i)
   {
     const Eigen::Vector4d coeffs = params.coeffs[i];
     // Note: This is computing the second derivative w.r.t. time
-    for(int j=2; j < 4; ++j)
+    for (int j = 2; j < 4; ++j)
       result[i] += j * (j-1) * coeffs[j] * pow(time, j-2);
   }
 
@@ -185,27 +187,27 @@ const Eigen::Matrix4d M_inv = make_M_inv();
 
 //==============================================================================
 Spline::Spline(const Trajectory::const_iterator& it)
-  : params(compute_parameters(it))
+: params(compute_parameters(it))
 {
   // Do nothing
 }
 
 //==============================================================================
 Spline::Spline(const internal::WaypointList::const_iterator& it)
-  : params(compute_parameters(it))
+: params(compute_parameters(it))
 {
   // Do nothing
 }
 
 //==============================================================================
 std::array<Eigen::Vector3d, 4> Spline::compute_knots(
-    const Time start_time, const Time finish_time) const
+  const Time start_time, const Time finish_time) const
 {
   assert(params.time_range[0] <= start_time);
   assert(finish_time <= params.time_range[1]);
 
   const double scaled_delta_t =
-      compute_delta_t(finish_time, start_time) / params.delta_t;
+    compute_delta_t(finish_time, start_time) / params.delta_t;
 
   const double scaled_start_time = compute_scaled_time(start_time, params);
   const double scaled_finish_time = compute_scaled_time(finish_time, params);
@@ -220,13 +222,13 @@ std::array<Eigen::Vector3d, 4> Spline::compute_knots(
     scaled_delta_t * rmf_traffic::compute_velocity(params, scaled_finish_time);
 
   const std::array<Eigen::Vector4d, 3> subspline_coeffs =
-      compute_coefficients(x0, x1, v0, v1);
+    compute_coefficients(x0, x1, v0, v1);
 
   std::array<Eigen::Vector3d, 4> result;
-  for(std::size_t i=0; i < 3; ++i)
+  for (std::size_t i = 0; i < 3; ++i)
   {
     const Eigen::Vector4d p = M_inv * subspline_coeffs[i];
-    for(int j=0; j < 4; ++j)
+    for (int j = 0; j < 4; ++j)
       result[j][i] = p[j];
   }
 
@@ -235,14 +237,14 @@ std::array<Eigen::Vector3d, 4> Spline::compute_knots(
 
 //==============================================================================
 fcl::SplineMotion Spline::to_fcl(
-    const Time start_time, const Time finish_time) const
+  const Time start_time, const Time finish_time) const
 {
   std::array<Eigen::Vector3d, 4> knots = compute_knots(start_time, finish_time);
 
   std::array<fcl::Vec3f, 4> Td;
   std::array<fcl::Vec3f, 4> Rd;
 
-  for(std::size_t i=0; i < 4; ++i)
+  for (std::size_t i = 0; i < 4; ++i)
   {
     const Eigen::Vector3d p = knots[i];
     Td[i] = fcl::Vec3f(p[0], p[1], 0.0);
@@ -250,8 +252,8 @@ fcl::SplineMotion Spline::to_fcl(
   }
 
   return fcl::SplineMotion(
-      Td[0], Td[1], Td[2], Td[3],
-      Rd[0], Rd[1], Rd[2], Rd[3]);
+    Td[0], Td[1], Td[2], Td[3],
+    Rd[0], Rd[1], Rd[2], Rd[3]);
 }
 
 //==============================================================================
@@ -270,7 +272,7 @@ Time Spline::finish_time() const
 Eigen::Vector3d Spline::compute_position(const Time at_time) const
 {
   return rmf_traffic::compute_position(
-        params, compute_scaled_time(at_time, params));
+    params, compute_scaled_time(at_time, params));
 }
 
 //==============================================================================
@@ -278,15 +280,15 @@ Eigen::Vector3d Spline::compute_velocity(const Time at_time) const
 {
   const double delta_t_inv = 1.0/params.delta_t;
   return delta_t_inv * rmf_traffic::compute_velocity(
-        params, compute_scaled_time(at_time, params));
+    params, compute_scaled_time(at_time, params));
 }
 
 //==============================================================================
 Eigen::Vector3d Spline::compute_acceleration(const Time at_time) const
 {
   const double delta_t_inv = 1.0/params.delta_t;
-  return pow(delta_t_inv, 2 ) * rmf_traffic::compute_acceleration(
-        params, compute_scaled_time(at_time, params));
+  return pow(delta_t_inv, 2) * rmf_traffic::compute_acceleration(
+    params, compute_scaled_time(at_time, params));
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/Spline.hpp
+++ b/rmf_traffic/src/rmf_traffic/Spline.hpp
@@ -48,7 +48,7 @@ public:
   /// Compute the knots for the motion of this spline from start_time to
   /// finish_time, scaled to a "time" range of [0, 1].
   std::array<Eigen::Vector3d, 4> compute_knots(
-      const Time start_time, const Time finish_time) const;
+    const Time start_time, const Time finish_time) const;
 
   fcl::SplineMotion to_fcl(const Time start_time, const Time finish_time) const;
 

--- a/rmf_traffic/src/rmf_traffic/StaticMotion.cpp
+++ b/rmf_traffic/src/rmf_traffic/StaticMotion.cpp
@@ -44,7 +44,7 @@ bool StaticMotion::integrate(double /*dt*/) const
 
 //==============================================================================
 fcl::FCL_REAL StaticMotion::computeMotionBound(
-    const fcl::BVMotionBoundVisitor&) const
+  const fcl::BVMotionBoundVisitor&) const
 {
   // TODO(MXG): Investigate the legitimacy of this implementation. Make sure
   // that this function truly should always return 0.
@@ -53,11 +53,15 @@ fcl::FCL_REAL StaticMotion::computeMotionBound(
 
 //==============================================================================
 fcl::FCL_REAL StaticMotion::computeMotionBound(
-    const fcl::TriangleMotionBoundVisitor&) const
+  const fcl::TriangleMotionBoundVisitor&) const
 {
-  std::cout << " ----- OH NO, WE'RE USING StaticMotion::computeMotionBound(TriangleMotionBoundVisitor)!! ----- "
+  std::cout <<
+    " ----- OH NO, WE'RE USING StaticMotion::computeMotionBound(TriangleMotionBoundVisitor)!! ----- "
             << std::endl;
-  throw std::runtime_error("unimplemented function: StaticMotion::computeMotionBound(TriangleMotionBoundVisitor)");
+  // *INDENT-OFF*
+  throw std::runtime_error(
+    "unimplemented function: StaticMotion::computeMotionBound(TriangleMotionBoundVisitor)");
+  // *INDENT-ON*
 }
 
 //==============================================================================
@@ -69,9 +73,13 @@ void StaticMotion::getCurrentTransform(fcl::Transform3f& tf) const
 //==============================================================================
 void StaticMotion::getTaylorModel(fcl::TMatrix3&, fcl::TVector3&) const
 {
-  std::cout << " ----- OH NO, WE'RE USING StaticMotion::getTaylorModel()!! ----- "
+  std::cout <<
+    " ----- OH NO, WE'RE USING StaticMotion::getTaylorModel()!! ----- "
             << std::endl;
-  throw std::runtime_error("unimplemented function: StaticMotion::getTaylorModel()");
+  // *INDENT-OFF*
+  throw std::runtime_error(
+    "unimplemented function: StaticMotion::getTaylorModel()");
+  // *INDENT-ON*
 }
 
 } // namespace internal

--- a/rmf_traffic/src/rmf_traffic/StaticMotion.hpp
+++ b/rmf_traffic/src/rmf_traffic/StaticMotion.hpp
@@ -37,10 +37,10 @@ public:
   bool integrate(double dt) const final;
 
   fcl::FCL_REAL computeMotionBound(
-      const fcl::BVMotionBoundVisitor&) const final;
+    const fcl::BVMotionBoundVisitor&) const final;
 
   fcl::FCL_REAL computeMotionBound(
-      const fcl::TriangleMotionBoundVisitor&) const final;
+    const fcl::TriangleMotionBoundVisitor&) const final;
 
   void getCurrentTransform(fcl::Transform3f& tf) const final;
 

--- a/rmf_traffic/src/rmf_traffic/Trajectory.cpp
+++ b/rmf_traffic/src/rmf_traffic/Trajectory.cpp
@@ -37,7 +37,7 @@ public:
 
   template<typename SegT>
   Trajectory::base_iterator<SegT> make_iterator(
-      internal::WaypointList::iterator it) const
+    internal::WaypointList::iterator it) const
   {
     Trajectory::base_iterator<SegT> result;
     result._pimpl->raw_iterator = it;
@@ -50,7 +50,7 @@ public:
   Trajectory::base_iterator<SegT> post_increment()
   {
     const Trajectory::base_iterator<SegT> old_it =
-        make_iterator<SegT>(raw_iterator);
+      make_iterator<SegT>(raw_iterator);
 
     ++raw_iterator;
 
@@ -61,7 +61,7 @@ public:
   Trajectory::base_iterator<SegT> post_decrement()
   {
     const Trajectory::base_iterator<SegT> old_it =
-        make_iterator<SegT>(raw_iterator);
+      make_iterator<SegT>(raw_iterator);
 
     --raw_iterator;
 
@@ -69,7 +69,7 @@ public:
   }
 
   static WaypointList::const_iterator raw(
-      const Trajectory::const_iterator& iterator)
+    const Trajectory::const_iterator& iterator)
   {
     return iterator._pimpl->raw_iterator;
   }
@@ -77,7 +77,7 @@ public:
 
 //==============================================================================
 WaypointList::const_iterator get_raw_iterator(
-    const Trajectory::const_iterator& iterator)
+  const Trajectory::const_iterator& iterator)
 {
   return TrajectoryIteratorImplementation::raw(iterator);
 }
@@ -121,7 +121,7 @@ public:
 
   template<typename SegT>
   base_iterator<SegT> make_iterator(
-      internal::WaypointList::iterator iterator) const
+    internal::WaypointList::iterator iterator) const
   {
     base_iterator<SegT> it;
     it._pimpl->raw_iterator = std::move(iterator);
@@ -130,7 +130,8 @@ public:
     return it;
   }
 
-  std::unique_ptr<Waypoint> make_segment(internal::WaypointList::iterator iterator)
+  std::unique_ptr<Waypoint> make_segment(
+    internal::WaypointList::iterator iterator)
   {
     std::unique_ptr<Waypoint> seg(new Waypoint);
     seg->_pimpl->myself = std::move(iterator);
@@ -158,7 +159,7 @@ public:
     // Now correct all the iterators to point to the freshly copied container
     internal::WaypointList::iterator sit = segments.begin();
     internal::OrderMap::iterator oit = ordering.begin();
-    for( ; sit != segments.end(); ++sit, ++oit)
+    for ( ; sit != segments.end(); ++sit, ++oit)
     {
       sit->myself = make_segment(sit);
       oit->second = sit;
@@ -170,7 +171,7 @@ public:
   InsertionResult insert(internal::WaypointElement::Data data)
   {
     const internal::OrderMap::iterator hint = ordering.lower_bound(data.time);
-    if(hint != ordering.end() && hint->first == data.time)
+    if (hint != ordering.end() && hint->first == data.time)
     {
       // We already have a Waypoint in the Trajectory that ends at this same
       // exact moment in time, so we will return the existing iterator along
@@ -180,10 +181,10 @@ public:
     }
 
     const internal::WaypointList::const_iterator list_destination =
-        (hint == ordering.end()) ? segments.end() : hint->second;
+      (hint == ordering.end()) ? segments.end() : hint->second;
 
     const internal::WaypointList::iterator result =
-        segments.emplace(list_destination, std::move(data));
+      segments.emplace(list_destination, std::move(data));
     result->myself = make_segment(result);
     assert(segments.size() > 0);
 
@@ -196,12 +197,12 @@ public:
   iterator find(Time time)
   {
     const auto it = ordering.lower_bound(time);
-    if(it == ordering.end())
+    if (it == ordering.end())
       return make_iterator<Waypoint>(segments.end());
 
     // If the time comes before the start of the Trajectory, then we return
     // the end() iterator
-    if(time < segments.begin()->data.time)
+    if (time < segments.begin()->data.time)
       return make_iterator<Waypoint>(segments.end());
 
     return make_iterator<Waypoint>(it->second);
@@ -225,12 +226,12 @@ public:
   iterator erase(iterator first, iterator last)
   {
     const auto seg_begin = first->_pimpl->myself;
-    const auto seg_end = last._pimpl->raw_iterator == segments.end()?
-          segments.end() : last->_pimpl->myself;
+    const auto seg_end = last._pimpl->raw_iterator == segments.end() ?
+      segments.end() : last->_pimpl->myself;
 
     const auto order_start = ordering.find(seg_begin->data.time);
-    const auto order_end = seg_end == segments.end()?
-          ordering.end() : ordering.find(seg_end->data.time);
+    const auto order_end = seg_end == segments.end() ?
+      ordering.end() : ordering.find(seg_end->data.time);
 
     ordering.erase(order_start, order_end);
     return make_iterator<Waypoint>(segments.erase(seg_begin, seg_end));
@@ -256,7 +257,7 @@ Eigen::Vector3d Trajectory::Waypoint::position() const
 
 //==============================================================================
 Trajectory::Waypoint& Trajectory::Waypoint::position(
-    Eigen::Vector3d new_position)
+  Eigen::Vector3d new_position)
 {
   _pimpl->data().position = std::move(new_position);
   return *this;
@@ -270,7 +271,7 @@ Eigen::Vector3d Trajectory::Waypoint::velocity() const
 
 //==============================================================================
 Trajectory::Waypoint& Trajectory::Waypoint::velocity(
-    Eigen::Vector3d new_velocity)
+  Eigen::Vector3d new_velocity)
 {
   _pimpl->data().velocity = std::move(new_velocity);
   return *this;
@@ -289,7 +290,7 @@ Trajectory::Waypoint& Trajectory::Waypoint::change_time(const Time new_time)
   internal::WaypointElement::Data& current_data = data_it->data;
   const Time current_time = current_data.time;
 
-  if(current_time == new_time)
+  if (current_time == new_time)
   {
     // Short-circuit, since nothing is changing. The erase and re-insertion
     // would be a waste of time in this case.
@@ -299,13 +300,13 @@ Trajectory::Waypoint& Trajectory::Waypoint::change_time(const Time new_time)
   internal::OrderMap& ordering = _pimpl->parent->ordering;
   internal::WaypointList& segments = _pimpl->parent->segments;
   const internal::OrderMap::const_iterator current_order_it =
-      ordering.find(current_time);
+    ordering.find(current_time);
   assert(current_order_it != ordering.end());
 
   const internal::OrderMap::const_iterator hint =
-      ordering.lower_bound(new_time);
+    ordering.lower_bound(new_time);
 
-  if(current_order_it == hint)
+  if (current_order_it == hint)
   {
     // The Waypoint is already in the correct location within the list, so it
     // does not need to be moved. We can just update its entry in the OrderMap.
@@ -314,11 +315,11 @@ Trajectory::Waypoint& Trajectory::Waypoint::change_time(const Time new_time)
     // hint because the hint iterator will be invalidated when we erase
     // current_order_it (because they are iterators to the same element).
     const internal::OrderMap::const_iterator new_hint =
-        ++internal::OrderMap::const_iterator(hint);
+      ++internal::OrderMap::const_iterator(hint);
     ordering.erase(current_order_it);
     ordering.emplace_hint(new_hint, new_time, std::move(data_it));
   }
-  else if(hint == ordering.end())
+  else if (hint == ordering.end())
   {
     // This Waypoint must be moved to the end of the list.
     segments.splice(segments.end(), segments, data_it);
@@ -330,14 +331,16 @@ Trajectory::Waypoint& Trajectory::Waypoint::change_time(const Time new_time)
     const internal::WaypointList::const_iterator destination = hint->second;
     assert(destination != segments.end());
 
-    if(destination->data.time == new_time)
+    if (destination->data.time == new_time)
     {
       // The new time conflicts with an existing time, so we will throw an
       // exception.
+      // *INDENT-OFF*
       throw std::invalid_argument(
-            "[Trajectory::Waypoint::change_time] Attempted to set time to "
-            + std::to_string(new_time.time_since_epoch().count())
-            + "ns, but a waypoint already exists at that timestamp.");
+        "[Trajectory::Waypoint::change_time] Attempted to set time to "
+        + std::to_string(new_time.time_since_epoch().count())
+        + "ns, but a waypoint already exists at that timestamp.");
+      // *INDENT-ON*
     }
 
     segments.splice(destination, segments, data_it);
@@ -358,27 +361,27 @@ void Trajectory::Waypoint::adjust_times(Duration delta_t)
   const internal::WaypointList::iterator begin_it = _pimpl->myself;
   const Time original_begin_time = begin_it->data.time;
 
-  if(delta_t.count() < 0 && begin_it != segments.begin())
+  if (delta_t.count() < 0 && begin_it != segments.begin())
   {
     // If delta_t is negative and this is not the first Waypoint in the
     // Trajectory, make sure the change in time does not make it dip beneath its
     // predecessor Waypoint.
     const internal::WaypointList::const_iterator predecessor_it =
-        --internal::WaypointList::iterator(begin_it);
+      --internal::WaypointList::iterator(begin_it);
     const auto new_time = begin_it->data.time + delta_t;
-    if(new_time <= predecessor_it->data.time)
+    if (new_time <= predecessor_it->data.time)
     {
       const auto tp = predecessor_it->data.time
-          .time_since_epoch().count();
+        .time_since_epoch().count();
       const auto tc = (new_time).time_since_epoch().count();
 
       const std::string error =
-          std::string("[Trajectory::Waypoint::adjust_times] ")
-          + "The given negative change in time: "
-          + std::to_string(delta_t.count()) + "ns caused the Waypoint's new "
-          + "time window [" + std::to_string(tc)
-          + "] to overlap with its precedessor's [" + std::to_string(tp)
-          + "]";
+        std::string("[Trajectory::Waypoint::adjust_times] ")
+        + "The given negative change in time: "
+        + std::to_string(delta_t.count()) + "ns caused the Waypoint's new "
+        + "time window [" + std::to_string(tc)
+        + "] to overlap with its precedessor's [" + std::to_string(tp)
+        + "]";
 
       throw std::invalid_argument(error);
     }
@@ -387,7 +390,8 @@ void Trajectory::Waypoint::adjust_times(Duration delta_t)
   // Adjust the times for the segments and collect their iterators
   std::vector<internal::WaypointList::iterator> list_iterators;
   list_iterators.reserve(segments.size());
-  for(internal::WaypointList::iterator it = begin_it; it != segments.end(); ++it)
+  for (internal::WaypointList::iterator it = begin_it; it != segments.end();
+    ++it)
   {
     it->data.time += delta_t;
     list_iterators.push_back(it);
@@ -395,7 +399,7 @@ void Trajectory::Waypoint::adjust_times(Duration delta_t)
 
   internal::OrderMap& ordering = _pimpl->parent->ordering;
   const internal::OrderMap::iterator order_it =
-      ordering.find(original_begin_time);
+    ordering.find(original_begin_time);
   assert(order_it != ordering.end());
 
   // Erase the existing ordering entries for all the modified Trajectory
@@ -404,7 +408,7 @@ void Trajectory::Waypoint::adjust_times(Duration delta_t)
 
   // Add new entries one at a time, supplying the emplacement operator with the
   // hint that it can always append the entry to the end of the map.
-  for(internal::WaypointList::iterator& it : list_iterators)
+  for (internal::WaypointList::iterator& it : list_iterators)
   {
     const Time new_time = it->data.time;
     ordering.emplace_hint(ordering.end(), new_time, std::move(it));
@@ -413,21 +417,21 @@ void Trajectory::Waypoint::adjust_times(Duration delta_t)
 
 //==============================================================================
 Trajectory::Waypoint::Waypoint()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
 
 //==============================================================================
 Trajectory::Trajectory()
-  : _pimpl(rmf_utils::make_unique_impl<Implementation>())
+: _pimpl(rmf_utils::make_unique_impl<Implementation>())
 {
   // Do nothing
 }
 
 //==============================================================================
 Trajectory::Trajectory(const Trajectory& other)
-  : _pimpl(rmf_utils::make_unique_impl<Implementation>(*other._pimpl))
+: _pimpl(rmf_utils::make_unique_impl<Implementation>(*other._pimpl))
 {
   // Do nothing
 }
@@ -441,15 +445,15 @@ Trajectory& Trajectory::operator=(const Trajectory& other)
 
 //==============================================================================
 Trajectory::InsertionResult Trajectory::insert(
-    Time time,
-    Eigen::Vector3d position,
-    Eigen::Vector3d velocity)
+  Time time,
+  Eigen::Vector3d position,
+  Eigen::Vector3d velocity)
 {
   return _pimpl->insert(
-        internal::WaypointElement::Data{
-          std::move(time),
-          std::move(position),
-          std::move(velocity)});
+    internal::WaypointElement::Data{
+      std::move(time),
+      std::move(position),
+      std::move(velocity)});
 }
 
 //==============================================================================
@@ -558,23 +562,23 @@ auto Trajectory::back() const -> const Waypoint&
 const Time* Trajectory::start_time() const
 {
   const auto& segments = _pimpl->segments;
-  return segments.size() == 0? nullptr : &segments.front().data.time;
+  return segments.size() == 0 ? nullptr : &segments.front().data.time;
 }
 
 //==============================================================================
 const Time* Trajectory::finish_time() const
 {
   const auto& segments = _pimpl->segments;
-  return segments.size() == 0? nullptr : &segments.back().data.time;
+  return segments.size() == 0 ? nullptr : &segments.back().data.time;
 }
 
 //==============================================================================
 Duration Trajectory::duration() const
 {
   const auto& segments = _pimpl->segments;
-  return segments.size() < 2?
-        Duration(0) :
-        segments.back().data.time - segments.front().data.time;
+  return segments.size() < 2 ?
+    Duration(0) :
+    segments.back().data.time - segments.front().data.time;
 }
 
 //==============================================================================
@@ -630,8 +634,8 @@ auto Trajectory::base_iterator<SegT>::operator--(int) -> base_iterator
 //==============================================================================
 #define DEFINE_BASIC_ITERATOR_OP(op) \
   template<typename SegT> \
-  bool Trajectory::base_iterator<SegT>::operator op ( \
-      const base_iterator& other) const \
+  bool Trajectory::base_iterator<SegT>::operator op( \
+    const base_iterator& other) const \
   { \
     return _pimpl->raw_iterator op other._pimpl->raw_iterator; \
   }
@@ -641,14 +645,14 @@ DEFINE_BASIC_ITERATOR_OP(!=)
 
 template<typename SegT>
 bool Trajectory::base_iterator<SegT>::operator<(
-    const base_iterator& other) const
+  const base_iterator& other) const
 {
   const bool this_is_end =
-      this->_pimpl->raw_iterator == _pimpl->parent->segments.end();
+    this->_pimpl->raw_iterator == _pimpl->parent->segments.end();
   const bool other_is_end =
-      other._pimpl->raw_iterator == _pimpl->parent->segments.end();
+    other._pimpl->raw_iterator == _pimpl->parent->segments.end();
 
-  if(this_is_end || other_is_end)
+  if (this_is_end || other_is_end)
   {
     // If the other is the end iterator but this iterator is not, then we return
     // true, because the end iterator is "larger" than any valid iterator.
@@ -660,20 +664,20 @@ bool Trajectory::base_iterator<SegT>::operator<(
 
   // If they are both valid iterators, then we can compare their times.
   return this->_pimpl->raw_iterator->data.time
-      < other._pimpl->raw_iterator->data.time;
+    < other._pimpl->raw_iterator->data.time;
 }
 
 //==============================================================================
 template<typename SegT>
 bool Trajectory::base_iterator<SegT>::operator>(
-    const base_iterator& other) const
+  const base_iterator& other) const
 {
   const bool this_is_end =
-      this->_pimpl->raw_iterator == _pimpl->parent->segments.end();
+    this->_pimpl->raw_iterator == _pimpl->parent->segments.end();
   const bool other_is_end =
-      other._pimpl->raw_iterator == _pimpl->parent->segments.end();
+    other._pimpl->raw_iterator == _pimpl->parent->segments.end();
 
-  if(this_is_end || other_is_end)
+  if (this_is_end || other_is_end)
   {
     // See the logic above for operator<, but in this case we want the opposite
     // conclusion.
@@ -682,13 +686,13 @@ bool Trajectory::base_iterator<SegT>::operator>(
 
   // If they are both valid iterators, then we can compare their times.
   return this->_pimpl->raw_iterator->data.time
-      > other._pimpl->raw_iterator->data.time;
+    > other._pimpl->raw_iterator->data.time;
 }
 
 //==============================================================================
 template<typename SegT>
 bool Trajectory::base_iterator<SegT>::operator<=(
-    const base_iterator& other) const
+  const base_iterator& other) const
 {
   return (*this == other) || (*this < other);
 }
@@ -696,7 +700,7 @@ bool Trajectory::base_iterator<SegT>::operator<=(
 //==============================================================================
 template<typename SegT>
 bool Trajectory::base_iterator<SegT>::operator>=(
-    const base_iterator& other) const
+  const base_iterator& other) const
 {
   return (*this == other) || (*this > other);
 }
@@ -711,7 +715,7 @@ Trajectory::base_iterator<SegT>::operator const_iterator() const
 //==============================================================================
 template<typename SegT>
 Trajectory::base_iterator<SegT>::base_iterator()
-  : _pimpl(rmf_utils::make_impl<internal::TrajectoryIteratorImplementation>())
+: _pimpl(rmf_utils::make_impl<internal::TrajectoryIteratorImplementation>())
 {
   // Do nothing
 }
@@ -722,7 +726,7 @@ template class Trajectory::base_iterator<const Trajectory::Waypoint>;
 
 //==============================================================================
 bool Trajectory::Debug::check_iterator_time_consistency(
-    const Trajectory& trajectory, const bool print_inconsistency)
+  const Trajectory& trajectory, const bool print_inconsistency)
 {
   assert(trajectory._pimpl);
 
@@ -733,7 +737,7 @@ bool Trajectory::Debug::check_iterator_time_consistency(
 
   internal::WaypointList::const_iterator s_it = segments.begin();
   internal::OrderMap::const_iterator o_it = ordering.begin();
-  for( ; s_it != segments.end() && o_it != ordering.end(); ++s_it, ++o_it)
+  for ( ; s_it != segments.end() && o_it != ordering.end(); ++s_it, ++o_it)
   {
     consistent &= s_it->data.time == o_it->first;
   }
@@ -741,15 +745,15 @@ bool Trajectory::Debug::check_iterator_time_consistency(
   consistent &= s_it == segments.end();
   consistent &= o_it == ordering.end();
 
-  if(print_inconsistency && !consistent)
+  if (print_inconsistency && !consistent)
   {
     std::size_t index = 0;
     s_it = segments.begin();
     o_it = ordering.begin();
     std::cout << "Trajectory time inconsistency detected: "
               << "( ordering | segments | difference )\n";
-    for( ; s_it != segments.end() && o_it != ordering.end();
-         ++s_it, ++o_it, ++index)
+    for ( ; s_it != segments.end() && o_it != ordering.end();
+      ++s_it, ++o_it, ++index)
     {
       const auto difference = o_it->first - s_it->data.time;
       std::cout << " -- [" << index << "] "
@@ -758,20 +762,20 @@ bool Trajectory::Debug::check_iterator_time_consistency(
                 << " | Difference: " << difference.count()/1e9 << "\n";
     }
 
-    if(s_it != segments.end())
+    if (s_it != segments.end())
     {
       std::cout << " -- more elements in segments\n";
-      for( ; s_it != segments.end(); ++s_it, ++index)
+      for ( ; s_it != segments.end(); ++s_it, ++index)
       {
         std::cout << "      -- [" << index << "] "
                   << s_it->data.time.time_since_epoch().count()/1e9
                   << "\n";
       }
     }
-    if(o_it != ordering.end())
+    if (o_it != ordering.end())
     {
       std::cout << " -- more elements in ordering:\n";
-      for( ; o_it != ordering.end(); ++o_it, ++index)
+      for ( ; o_it != ordering.end(); ++o_it, ++index)
       {
         std::cout << "     -- [" << index << "] "
                   << o_it->first.time_since_epoch().count()/1e9 << "\n";

--- a/rmf_traffic/src/rmf_traffic/TrajectoryInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/TrajectoryInternal.hpp
@@ -50,13 +50,13 @@ struct WaypointElement
   std::unique_ptr<Trajectory::Waypoint> myself;
 
   WaypointElement(Data input_data)
-    : data(std::move(input_data))
+  : data(std::move(input_data))
   {
     // Do nothing
   }
 
   WaypointElement(const WaypointElement& other)
-    : data(other.data)
+  : data(other.data)
   {
     // Do nothing
   }
@@ -73,7 +73,7 @@ struct WaypointElement
 
 //==============================================================================
 WaypointList::const_iterator get_raw_iterator(
-    const Trajectory::const_iterator& iterator);
+  const Trajectory::const_iterator& iterator);
 
 } // namespace internal
 } // namespace rmf_traffic

--- a/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
@@ -38,11 +38,11 @@ public:
   bool holding_point;
 
   template<typename... Args>
-  static Waypoint make(Args&&... args)
+  static Waypoint make(Args&& ... args)
   {
     Waypoint result;
     result._pimpl = rmf_utils::make_impl<Implementation>(
-          Implementation{std::forward<Args>(args)...});
+      Implementation{std::forward<Args>(args)...});
 
     return result;
   }
@@ -106,7 +106,7 @@ class AcceptableOrientationConstraint : public Graph::OrientationConstraint
 public:
 
   AcceptableOrientationConstraint(std::vector<double> acceptable)
-    : orientations(std::move(acceptable))
+  : orientations(std::move(acceptable))
   {
     // Do nothing
   }
@@ -114,21 +114,21 @@ public:
   std::vector<double> orientations;
 
   bool apply(Eigen::Vector3d& position,
-             const Eigen::Vector2d& /*course_vector*/) const final
+    const Eigen::Vector2d& /*course_vector*/) const final
   {
     assert(!orientations.empty());
     // This constraint can never be satisfied if there are no acceptable
     // orientations.
-    if(orientations.empty())
+    if (orientations.empty())
       return false;
 
     const double p = position[2];
     double closest = p;
     double best_diff = std::numeric_limits<double>::infinity();
-    for(const double theta : orientations)
+    for (const double theta : orientations)
     {
       const double diff = std::abs(rmf_utils::wrap_to_pi(theta - p));
-      if(diff < best_diff)
+      if (diff < best_diff)
       {
         closest = theta;
         best_diff = diff;
@@ -156,7 +156,7 @@ class DirectionConstraint : public Graph::OrientationConstraint
 public:
 
   static Eigen::Rotation2Dd compute_forward_offset(
-      const Eigen::Vector2d& forward)
+    const Eigen::Vector2d& forward)
   {
     return Eigen::Rotation2Dd(std::atan2(forward[1], forward[0]));
   }
@@ -164,11 +164,11 @@ public:
   static const Eigen::Rotation2Dd R_pi;
 
   DirectionConstraint(
-      Direction _direction,
-      const Eigen::Vector2d& _forward_vector)
-    : R_f(compute_forward_offset(_forward_vector)),
-      R_f_inv(R_f.inverse()),
-      direction(_direction)
+    Direction _direction,
+    const Eigen::Vector2d& _forward_vector)
+  : R_f(compute_forward_offset(_forward_vector)),
+    R_f_inv(R_f.inverse()),
+    direction(_direction)
   {
     // Do nothing
   }
@@ -178,20 +178,20 @@ public:
   Direction direction;
 
   Eigen::Rotation2Dd compute_R_final(
-      const Eigen::Vector2d& course_vector) const
+    const Eigen::Vector2d& course_vector) const
   {
     const Eigen::Rotation2Dd R_c(
-          std::atan2(course_vector[1], course_vector[0]));
+      std::atan2(course_vector[1], course_vector[0]));
 
-    if(Direction::Backward == direction)
+    if (Direction::Backward == direction)
       return R_pi * R_c * R_f_inv;
 
     return R_c * R_f_inv;
   }
 
   bool apply(
-      Eigen::Vector3d& position,
-      const Eigen::Vector2d& course_vector) const final
+    Eigen::Vector3d& position,
+    const Eigen::Vector2d& course_vector) const final
   {
     position[2] = rmf_utils::wrap_to_pi(compute_R_final(course_vector).angle());
     return true;
@@ -213,14 +213,14 @@ rmf_utils::clone_ptr<Graph::OrientationConstraint>
 Graph::OrientationConstraint::make(std::vector<double> acceptable_orientations)
 {
   return rmf_utils::make_clone<AcceptableOrientationConstraint>(
-        std::move(acceptable_orientations));
+    std::move(acceptable_orientations));
 }
 
 //==============================================================================
 rmf_utils::clone_ptr<Graph::OrientationConstraint>
 Graph::OrientationConstraint::make(
-    Direction direction,
-    const Eigen::Vector2d& forward)
+  Direction direction,
+  const Eigen::Vector2d& forward)
 {
   return rmf_utils::make_clone<DirectionConstraint>(direction, forward);
 }
@@ -237,13 +237,13 @@ public:
 
 //==============================================================================
 Graph::Lane::Door::Door(
-    std::string name,
-    Duration duration)
+  std::string name,
+  Duration duration)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{
-             std::move(name),
-             duration
-           }))
+      Implementation{
+        std::move(name),
+        duration
+      }))
 {
   // Do nothing
 }
@@ -287,15 +287,15 @@ public:
 
 //==============================================================================
 Graph::Lane::LiftDoor::LiftDoor(
-    std::string lift_name,
-    std::string floor_name,
-    Duration duration)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(lift_name),
-               std::move(floor_name),
-               duration
-             }))
+  std::string lift_name,
+  std::string floor_name,
+  Duration duration)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(lift_name),
+        std::move(floor_name),
+        duration
+      }))
 {
   // Do nothing
 }
@@ -354,15 +354,15 @@ public:
 
 //==============================================================================
 Graph::Lane::LiftMove::LiftMove(
-    std::string lift_name,
-    std::string destination_floor_name,
-    Duration duration)
+  std::string lift_name,
+  std::string destination_floor_name,
+  Duration duration)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{
-             std::move(lift_name),
-             std::move(destination_floor_name),
-             duration
-           }))
+      Implementation{
+        std::move(lift_name),
+        std::move(destination_floor_name),
+        duration
+      }))
 {
   // Do nothing
 }
@@ -418,13 +418,13 @@ public:
 
 //==============================================================================
 Graph::Lane::Dock::Dock(
-    std::string dock_name,
-    Duration duration)
+  std::string dock_name,
+  Duration duration)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{
-             std::move(dock_name),
-             duration
-           }))
+      Implementation{
+        std::move(dock_name),
+        duration
+      }))
 {
   // Do nothing
 }
@@ -551,32 +551,32 @@ public:
 
 //==============================================================================
 Graph::Lane::Node::Node(
-    std::size_t waypoint_index,
-    rmf_utils::clone_ptr<Event> event,
-    rmf_utils::clone_ptr<OrientationConstraint> orientation,
-    rmf_utils::clone_ptr<VelocityConstraint> velocity)
+  std::size_t waypoint_index,
+  rmf_utils::clone_ptr<Event> event,
+  rmf_utils::clone_ptr<OrientationConstraint> orientation,
+  rmf_utils::clone_ptr<VelocityConstraint> velocity)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               waypoint_index,
-               std::move(event),
-               std::move(orientation),
-               std::move(velocity)
-             }))
+      Implementation{
+        waypoint_index,
+        std::move(event),
+        std::move(orientation),
+        std::move(velocity)
+      }))
 {
   // Do nothing
 }
 
 //==============================================================================
 Graph::Lane::Node::Node(
-    std::size_t waypoint_index,
-    rmf_utils::clone_ptr<OrientationConstraint> orientation)
+  std::size_t waypoint_index,
+  rmf_utils::clone_ptr<OrientationConstraint> orientation)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{
-             waypoint_index,
-             nullptr,
-             std::move(orientation),
-             nullptr
-           }))
+      Implementation{
+        waypoint_index,
+        nullptr,
+        std::move(orientation),
+        nullptr
+      }))
 {
   // Do nothing
 }
@@ -622,11 +622,11 @@ public:
   std::size_t door_index;
 
   template<typename... Args>
-  static Lane make(Args&&... args)
+  static Lane make(Args&& ... args)
   {
     Lane lane;
     lane._pimpl = rmf_utils::make_impl<Implementation>(
-          Implementation{std::forward<Args>(args)...});
+      Implementation{std::forward<Args>(args)...});
 
     return lane;
   }
@@ -658,21 +658,21 @@ Graph::Lane::Lane()
 
 //==============================================================================
 Graph::Graph()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
 
 //==============================================================================
 auto Graph::add_waypoint(
-    std::string map_name,
-    Eigen::Vector2d location,
-    const bool is_holding_point) -> Waypoint&
+  std::string map_name,
+  Eigen::Vector2d location,
+  const bool is_holding_point) -> Waypoint&
 {
   _pimpl->waypoints.emplace_back(
-        Waypoint::Implementation::make(
-          _pimpl->waypoints.size(),
-          std::move(map_name), std::move(location), is_holding_point));
+    Waypoint::Implementation::make(
+      _pimpl->waypoints.size(),
+      std::move(map_name), std::move(location), is_holding_point));
 
   _pimpl->lanes_from.push_back({});
 
@@ -707,11 +707,11 @@ auto Graph::add_lane(Lane::Node entry, Lane::Node exit) -> Lane&
   _pimpl->lanes_from[entry.waypoint_index()].push_back(lane_id);
 
   _pimpl->lanes.emplace_back(
-        Lane::Implementation::make(
-          _pimpl->lanes.size(),
-          std::move(entry),
-          std::move(exit),
-          false, std::size_t()));
+    Lane::Implementation::make(
+      _pimpl->lanes.size(),
+      std::move(entry),
+      std::move(exit),
+      false, std::size_t()));
 
   return _pimpl->lanes.back();
 }

--- a/rmf_traffic/src/rmf_traffic/agv/Interpolate.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Interpolate.cpp
@@ -39,11 +39,11 @@ struct State
   Time t;
 
   State(double s_in, double v_in, double t_in, Time t_start)
-    : s(s_in),
-      v(v_in),
-      t(t_start +
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-          std::chrono::duration<double>(t_in)))
+  : s(s_in),
+    v(v_in),
+    t(t_start +
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(t_in)))
   {
     // Do nothing
   }
@@ -53,10 +53,10 @@ using States = std::vector<State>;
 
 //==============================================================================
 States compute_traversal(
-    const Time start_time,
-    const double s_f,
-    const double v_nom,
-    const double a_nom)
+  const Time start_time,
+  const double s_f,
+  const double v_nom,
+  const double a_nom)
 {
   States states;
   states.reserve(3);
@@ -75,7 +75,7 @@ States compute_traversal(
   // Only bother adding this waypoint if the constant velocity time period is
   // more than 1/100th of a second. Otherwise we'll just start decelerating
   // towards the goal right away.
-  if(t_d - t_a > 1e-2)
+  if (t_d - t_a > 1e-2)
   {
     const double s_d = v*(t_d - t_a) + s_a;
     states.emplace_back(s_d, v, t_d, start_time);
@@ -92,25 +92,25 @@ States compute_traversal(
 namespace internal {
 //==============================================================================
 void interpolate_translation(Trajectory& trajectory,
-    const double v_nom,
-    const double a_nom,
-    const Time start_time,
-    const Eigen::Vector3d& start,
-    const Eigen::Vector3d& finish,
-    const double threshold)
+  const double v_nom,
+  const double a_nom,
+  const Time start_time,
+  const Eigen::Vector3d& start,
+  const Eigen::Vector3d& finish,
+  const double threshold)
 {
   const double heading = start[2];
-  const Eigen::Vector2d start_p = start.block<2,1>(0,0);
-  const Eigen::Vector2d finish_p = finish.block<2,1>(0,0);
+  const Eigen::Vector2d start_p = start.block<2, 1>(0, 0);
+  const Eigen::Vector2d finish_p = finish.block<2, 1>(0, 0);
   const Eigen::Vector2d diff_p = finish_p - start_p;
   const double dist = diff_p.norm();
-  if(dist < threshold)
+  if (dist < threshold)
     return;
 
   const Eigen::Vector2d dir = diff_p/dist;
 
   States states = compute_traversal(start_time, dist, v_nom, a_nom);
-  for(const State& state : states)
+  for (const State& state : states)
   {
     const Eigen::Vector2d p_s = dir * state.s + start_p;
     const Eigen::Vector2d v_s = dir * state.v;
@@ -123,29 +123,29 @@ void interpolate_translation(Trajectory& trajectory,
 
 //==============================================================================
 void interpolate_rotation(
-    Trajectory& trajectory,
-    const double w_nom,
-    const double alpha_nom,
-    const Time start_time,
-    const Eigen::Vector3d& start,
-    const Eigen::Vector3d& finish,
-    const double threshold)
+  Trajectory& trajectory,
+  const double w_nom,
+  const double alpha_nom,
+  const Time start_time,
+  const Eigen::Vector3d& start,
+  const Eigen::Vector3d& finish,
+  const double threshold)
 {
   const double start_heading = start[2];
   const double finish_heading = finish[2];
   const double diff_heading =
-      rmf_utils::wrap_to_pi(finish_heading - start_heading);
+    rmf_utils::wrap_to_pi(finish_heading - start_heading);
 
   const double diff_heading_abs = std::abs(diff_heading);
-  if(diff_heading_abs < threshold)
+  if (diff_heading_abs < threshold)
     return;
 
-  const double dir = diff_heading < 0.0? -1.0 : 1.0;
+  const double dir = diff_heading < 0.0 ? -1.0 : 1.0;
 
   States states = compute_traversal(
-        start_time, diff_heading_abs, w_nom, alpha_nom);
+    start_time, diff_heading_abs, w_nom, alpha_nom);
 
-  for(const State& state : states)
+  for (const State& state : states)
   {
     const double s = rmf_utils::wrap_to_pi(start_heading + dir*state.s);
     const double w = dir*state.v;
@@ -163,20 +163,20 @@ class invalid_traits_error::Implementation
 public:
 
   static invalid_traits_error make_error(
-      const VehicleTraits& traits)
+    const VehicleTraits& traits)
   {
     std::vector<std::pair<std::string, double>> values;
-    for(const auto& pair :
-        {std::make_pair("linear velocity",
-                        traits.linear().get_nominal_velocity()),
-         std::make_pair("linear acceleration",
-                        traits.linear().get_nominal_acceleration()),
-         std::make_pair("rotational velocity",
-                        traits.rotational().get_nominal_velocity()),
-         std::make_pair("rotational acceleration",
-                        traits.rotational().get_nominal_acceleration())})
+    for (const auto& pair :
+      {std::make_pair("linear velocity",
+        traits.linear().get_nominal_velocity()),
+        std::make_pair("linear acceleration",
+        traits.linear().get_nominal_acceleration()),
+        std::make_pair("rotational velocity",
+        traits.rotational().get_nominal_velocity()),
+        std::make_pair("rotational acceleration",
+        traits.rotational().get_nominal_acceleration())})
     {
-      if(pair.second <= 0.0)
+      if (pair.second <= 0.0)
         values.push_back(pair);
     }
 
@@ -184,11 +184,11 @@ public:
 
     invalid_traits_error error;
     error._pimpl->_what =
-        "[invalid_traits_error] The following traits have invalid values:";
-    for(const auto& pair : values)
+      "[invalid_traits_error] The following traits have invalid values:";
+    for (const auto& pair : values)
     {
       error._pimpl->_what +=
-          "\n -- " + pair.first + ": " + std::to_string(pair.second);
+        "\n -- " + pair.first + ": " + std::to_string(pair.second);
     }
 
     return error;
@@ -205,22 +205,22 @@ const char* invalid_traits_error::what() const noexcept
 
 //==============================================================================
 invalid_traits_error::invalid_traits_error()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
 
 //==============================================================================
 Interpolate::Options::Options(
-    const bool always_stop,
-    const double translation_thresh,
-    const double rotation_thresh,
-    const double corner_angle_thresh)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             always_stop,
-             translation_thresh,
-             rotation_thresh,
-             corner_angle_thresh))
+  const bool always_stop,
+  const double translation_thresh,
+  const double rotation_thresh,
+  const double corner_angle_thresh)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      always_stop,
+      translation_thresh,
+      rotation_thresh,
+      corner_angle_thresh))
 {
   // Do nothing
 }
@@ -240,7 +240,7 @@ bool Interpolate::Options::always_stop() const
 
 //==============================================================================
 Interpolate::Options& Interpolate::Options::set_translation_threshold(
-    double dist)
+  double dist)
 {
   _pimpl->translation_thresh = dist;
   return *this;
@@ -267,7 +267,7 @@ double Interpolate::Options::get_rotation_threshold() const
 
 //==============================================================================
 Interpolate::Options& Interpolate::Options::set_corner_angle_threshold(
-    double angle)
+  double angle)
 {
   _pimpl->corner_angle_thresh = angle;
   return *this;
@@ -282,19 +282,19 @@ double Interpolate::Options::get_corner_angle_threshold() const
 //==============================================================================
 namespace internal {
 bool can_skip_interpolation(
-    const Eigen::Vector3d& last_position,
-    const Eigen::Vector3d& next_position,
-    const Eigen::Vector3d& future_position,
-    const Interpolate::Options::Implementation& options)
+  const Eigen::Vector3d& last_position,
+  const Eigen::Vector3d& next_position,
+  const Eigen::Vector3d& future_position,
+  const Interpolate::Options::Implementation& options)
 {
-  const Eigen::Vector2d next_p = next_position.block<2,1>(0,0);
-  const Eigen::Vector2d last_p = last_position.block<2,1>(0,0);
-  const Eigen::Vector2d future_p = future_position.block<2,1>(0,0);
+  const Eigen::Vector2d next_p = next_position.block<2, 1>(0, 0);
+  const Eigen::Vector2d last_p = last_position.block<2, 1>(0, 0);
+  const Eigen::Vector2d future_p = future_position.block<2, 1>(0, 0);
 
   // If the waypoints are very close together, then we can skip it
   bool can_skip =
-      (next_p - last_p).norm() < options.translation_thresh
-      || (future_p - next_p).norm() < options.translation_thresh;
+    (next_p - last_p).norm() < options.translation_thresh
+    || (future_p - next_p).norm() < options.translation_thresh;
 
   // Check if the corner is too sharp
   const Eigen::Vector2d d_next_p = next_p - last_p;
@@ -302,22 +302,22 @@ bool can_skip_interpolation(
   const double d_next_p_norm = d_next_p.norm();
   const double d_future_p_norm = d_future_p.norm();
 
-  if(d_next_p_norm > 1e-8 && d_future_p_norm > 1e-8)
+  if (d_next_p_norm > 1e-8 && d_future_p_norm > 1e-8)
   {
     const double dot_product = d_next_p.dot(d_future_p);
     const double angle = std::acos(
-          dot_product/(d_next_p_norm * d_future_p_norm));
+      dot_product/(d_next_p_norm * d_future_p_norm));
     // If the corner is smaller than the threshold, then we can skip it
-    if(angle < options.corner_angle_thresh)
+    if (angle < options.corner_angle_thresh)
       can_skip = true;
   }
 
   const double next_angle = next_position[2];
   const double last_angle = last_position[2];
   const double future_angle = future_position[2];
-  if(can_skip && (
-       std::abs(next_angle - last_angle) > options.rotation_thresh
-       || std::abs(future_angle - next_angle) > options.rotation_thresh))
+  if (can_skip && (
+      std::abs(next_angle - last_angle) > options.rotation_thresh
+      || std::abs(future_angle - next_angle) > options.rotation_thresh))
   {
     can_skip = false;
   }
@@ -329,23 +329,23 @@ bool can_skip_interpolation(
 
 //==============================================================================
 Trajectory Interpolate::positions(
-    const VehicleTraits& traits,
-    const Time start_time,
-    const std::vector<Eigen::Vector3d>& input_positions,
-    const Options& input_options)
+  const VehicleTraits& traits,
+  const Time start_time,
+  const std::vector<Eigen::Vector3d>& input_positions,
+  const Options& input_options)
 {
-  if(!traits.valid())
+  if (!traits.valid())
     throw invalid_traits_error::Implementation::make_error(traits);
 
   Trajectory trajectory;
 
-  if(input_positions.empty())
+  if (input_positions.empty())
     return trajectory;
 
   trajectory.insert(
-        start_time,
-        input_positions.front(),
-        Eigen::Vector3d::Zero());
+    start_time,
+    input_positions.front(),
+    Eigen::Vector3d::Zero());
   assert(trajectory.size() > 0);
 
   const double v = traits.linear().get_nominal_velocity();
@@ -356,16 +356,16 @@ Trajectory Interpolate::positions(
 
   const std::size_t N = input_positions.size();
   std::size_t last_stop_index = 0;
-  for(std::size_t i=1; i < N; ++i)
+  for (std::size_t i = 1; i < N; ++i)
   {
     const Eigen::Vector3d& last_position = input_positions[last_stop_index];
     const Eigen::Vector3d& next_position = input_positions[i];
 
-    if(!options.always_stop && i+1 < N)
+    if (!options.always_stop && i+1 < N)
     {
       const Eigen::Vector3d& future_position = input_positions[i+1];
-      if(internal::can_skip_interpolation(
-           last_position, next_position, future_position, options))
+      if (internal::can_skip_interpolation(
+          last_position, next_position, future_position, options))
       {
         continue;
       }
@@ -373,12 +373,12 @@ Trajectory Interpolate::positions(
 
     assert(trajectory.finish_time());
     internal::interpolate_translation(
-          trajectory, v, a, *trajectory.finish_time(), last_position,
-          next_position, options.translation_thresh);
+      trajectory, v, a, *trajectory.finish_time(), last_position,
+      next_position, options.translation_thresh);
 
     internal::interpolate_rotation(
-          trajectory, w, alpha, *trajectory.finish_time(), last_position,
-          next_position, options.rotation_thresh);
+      trajectory, w, alpha, *trajectory.finish_time(), last_position,
+      next_position, options.rotation_thresh);
 
     last_stop_index = i;
   }

--- a/rmf_traffic/src/rmf_traffic/agv/InterpolateInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/InterpolateInternal.hpp
@@ -29,20 +29,20 @@ class Interpolate::Options::Implementation
 public:
 
   Implementation(
-      const bool always_stop,
-      const double translation_thresh,
-      const double rotation_thresh,
-      const double corner_angle_thresh)
-    : always_stop(always_stop),
-      translation_thresh(translation_thresh),
-      rotation_thresh(rotation_thresh),
-      corner_angle_thresh(corner_angle_thresh)
+    const bool always_stop,
+    const double translation_thresh,
+    const double rotation_thresh,
+    const double corner_angle_thresh)
+  : always_stop(always_stop),
+    translation_thresh(translation_thresh),
+    rotation_thresh(rotation_thresh),
+    corner_angle_thresh(corner_angle_thresh)
   {
     // Do nothing
   }
 
   Implementation(const Options& options)
-    : Implementation(*options._pimpl)
+  : Implementation(*options._pimpl)
   {
     // Do nothing
   }
@@ -63,30 +63,30 @@ namespace internal {
 
 //==============================================================================
 bool can_skip_interpolation(
-    const Eigen::Vector3d& last_position,
-    const Eigen::Vector3d& next_position,
-    const Eigen::Vector3d& future_position,
-    const Interpolate::Options::Implementation& options);
+  const Eigen::Vector3d& last_position,
+  const Eigen::Vector3d& next_position,
+  const Eigen::Vector3d& future_position,
+  const Interpolate::Options::Implementation& options);
 
 //==============================================================================
 void interpolate_translation(
-    Trajectory& trajectory,
-    const double v_nom,
-    const double a_nom,
-    const Time start_time,
-    const Eigen::Vector3d& start,
-    const Eigen::Vector3d& finish,
-    const double threshold);
+  Trajectory& trajectory,
+  const double v_nom,
+  const double a_nom,
+  const Time start_time,
+  const Eigen::Vector3d& start,
+  const Eigen::Vector3d& finish,
+  const double threshold);
 
 //==============================================================================
 void interpolate_rotation(
-    Trajectory& trajectory,
-    const double w_nom,
-    const double alpha_nom,
-    const Time start_time,
-    const Eigen::Vector3d& start,
-    const Eigen::Vector3d& finish,
-    const double threshold);
+  Trajectory& trajectory,
+  const double w_nom,
+  const double alpha_nom,
+  const Time start_time,
+  const Eigen::Vector3d& start,
+  const Eigen::Vector3d& finish,
+  const double threshold);
 
 } // namespace internal
 } // namespace agv

--- a/rmf_traffic/src/rmf_traffic/agv/Negotiator.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Negotiator.cpp
@@ -31,7 +31,7 @@ public:
 
 //==============================================================================
 SimpleNegotiator::Options::Options(Duration min_hold_time)
-  : _pimpl(rmf_utils::make_impl<Implementation>(Implementation{min_hold_time}))
+: _pimpl(rmf_utils::make_impl<Implementation>(Implementation{min_hold_time}))
 {
   // Do nothing
 }
@@ -60,14 +60,14 @@ public:
   Planner planner;
 
   Implementation(
-      Planner::Start start_,
-      Planner::Goal goal_,
-      Planner::Configuration configuration_,
-      Planner::Options options_)
-    : start(std::move(start_)),
-      goal(std::move(goal_)),
-      options(std::move(options_)),
-      planner(std::move(configuration_), options)
+    Planner::Start start_,
+    Planner::Goal goal_,
+    Planner::Configuration configuration_,
+    Planner::Options options_)
+  : start(std::move(start_)),
+    goal(std::move(goal_)),
+    options(std::move(options_)),
+    planner(std::move(configuration_), options)
   {
     // Do nothing
   }
@@ -76,32 +76,32 @@ public:
 
 //==============================================================================
 SimpleNegotiator::SimpleNegotiator(
-    Planner::Start start,
-    Planner::Goal goal,
-    Planner::Configuration planner_configuration,
-    const Options& options)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             std::move(start),
-             std::move(goal),
-             std::move(planner_configuration),
-             Planner::Options(nullptr, options.minimum_holding_time())))
+  Planner::Start start,
+  Planner::Goal goal,
+  Planner::Configuration planner_configuration,
+  const Options& options)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      std::move(start),
+      std::move(goal),
+      std::move(planner_configuration),
+      Planner::Options(nullptr, options.minimum_holding_time())))
 {
   // Do nothing
 }
 
 //==============================================================================
 void SimpleNegotiator::respond(
-    std::shared_ptr<const schedule::Negotiation::Table> table,
-    const Responder& responder,
-    const bool* interrupt_flag)
+  std::shared_ptr<const schedule::Negotiation::Table> table,
+  const Responder& responder,
+  const bool* interrupt_flag)
 {
   const auto& profile =
-      _pimpl->planner.get_configuration().vehicle_traits().profile();
+    _pimpl->planner.get_configuration().vehicle_traits().profile();
 
   auto options = _pimpl->options;
 
   options.validator(
-        rmf_utils::make_clone<NegotiatingRouteValidator>(*table, profile));
+    rmf_utils::make_clone<NegotiatingRouteValidator>(*table, profile));
 
   options.interrupt_flag(interrupt_flag);
 

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -41,15 +41,15 @@ public:
 
 //==============================================================================
 Planner::Configuration::Configuration(
-    Graph graph,
-    VehicleTraits traits,
-    Interpolate::Options interpolation)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(graph),
-               std::move(traits),
-               std::move(interpolation)
-             }))
+  Graph graph,
+  VehicleTraits traits,
+  Interpolate::Options interpolation)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(graph),
+        std::move(traits),
+        std::move(interpolation)
+      }))
 {
   // Do nothing
 }
@@ -126,15 +126,15 @@ public:
 
 //==============================================================================
 Planner::Options::Options(
-    rmf_utils::clone_ptr<RouteValidator> validator,
-    const Duration min_hold_time,
-    const bool* interrupt_flag)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(validator),
-               min_hold_time,
-               interrupt_flag
-             }))
+  rmf_utils::clone_ptr<RouteValidator> validator,
+  const Duration min_hold_time,
+  const bool* interrupt_flag)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(validator),
+        min_hold_time,
+        interrupt_flag
+      }))
 {
   // Do nothing
 }
@@ -195,19 +195,19 @@ public:
 
 //==============================================================================
 Planner::Start::Start(
-    const Time initial_time,
-    const std::size_t initial_waypoint,
-    const double initial_orientation,
-    rmf_utils::optional<Eigen::Vector2d> initial_location,
-    rmf_utils::optional<std::size_t> initial_lane)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               initial_time,
-               initial_waypoint,
-               initial_orientation,
-               std::move(initial_location),
-               std::move(initial_lane)
-             }))
+  const Time initial_time,
+  const std::size_t initial_waypoint,
+  const double initial_orientation,
+  rmf_utils::optional<Eigen::Vector2d> initial_location,
+  rmf_utils::optional<std::size_t> initial_lane)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        initial_time,
+        initial_waypoint,
+        initial_orientation,
+        std::move(initial_location),
+        std::move(initial_lane)
+      }))
 {
   // Do nothing
 }
@@ -259,7 +259,7 @@ const rmf_utils::optional<Eigen::Vector2d>& Planner::Start::location() const
 
 //==============================================================================
 auto Planner::Start::location(
-    rmf_utils::optional<Eigen::Vector2d> initial_location) -> Start&
+  rmf_utils::optional<Eigen::Vector2d> initial_location) -> Start&
 {
   _pimpl->location = std::move(initial_location);
   return *this;
@@ -273,7 +273,7 @@ const rmf_utils::optional<std::size_t>& Planner::Start::lane() const
 
 //==============================================================================
 auto Planner::Start::lane(
-    rmf_utils::optional<std::size_t> initial_lane) -> Start&
+  rmf_utils::optional<std::size_t> initial_lane) -> Start&
 {
   _pimpl->lane = initial_lane;
   return *this;
@@ -292,24 +292,24 @@ public:
 
 //==============================================================================
 Planner::Goal::Goal(const std::size_t waypoint)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               waypoint,
-               rmf_utils::nullopt
-             }))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        waypoint,
+        rmf_utils::nullopt
+      }))
 {
   // Do nothing
 }
 
 //==============================================================================
 Planner::Goal::Goal(
-    const std::size_t waypoint,
-    const double goal_orientation)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               waypoint,
-               goal_orientation
-             }))
+  const std::size_t waypoint,
+  const double goal_orientation)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        waypoint,
+        goal_orientation
+      }))
 {
   // Do nothing
 }
@@ -344,7 +344,7 @@ auto Planner::Goal::any_orientation() -> Goal&
 //==============================================================================
 const double* Planner::Goal::orientation() const
 {
-  if(_pimpl->orientation)
+  if (_pimpl->orientation)
     return &(*_pimpl->orientation);
 
   return nullptr;
@@ -374,20 +374,20 @@ public:
 
 
   static rmf_utils::optional<Plan> generate(
-      internal::planning::CacheManager cache_mgr,
-      const std::vector<Planner::Start>& starts,
-      Planner::Goal goal,
-      Planner::Options options)
+    internal::planning::CacheManager cache_mgr,
+    const std::vector<Planner::Start>& starts,
+    Planner::Goal goal,
+    Planner::Options options)
   {
     auto result = cache_mgr.get().plan(
-        {starts}, std::move(goal), std::move(options));
+      {starts}, std::move(goal), std::move(options));
 
     if (!result)
       return rmf_utils::nullopt;
 
     Plan plan;
     plan._pimpl = rmf_utils::make_impl<Implementation>(
-          Implementation{std::move(*result), std::move(cache_mgr)});
+      Implementation{std::move(*result), std::move(cache_mgr)});
 
     return std::move(plan);
   }
@@ -396,14 +396,14 @@ public:
 
 //==============================================================================
 Planner::Planner(
-    Configuration config,
-    Options default_options)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               internal::planning::make_cache(config),
-               std::move(default_options),
-               config
-             }))
+  Configuration config,
+  Options default_options)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        internal::planning::make_cache(config),
+        std::move(default_options),
+        config
+      }))
 {
   // Do nothing
 }
@@ -437,46 +437,46 @@ auto Planner::get_default_options() const -> const Options&
 rmf_utils::optional<Plan> Planner::plan(const Start& start, Goal goal) const
 {
   return Plan::Implementation::generate(
-        _pimpl->cache_mgr,
-        {start},
-        std::move(goal),
-        _pimpl->default_options);
+    _pimpl->cache_mgr,
+    {start},
+    std::move(goal),
+    _pimpl->default_options);
 }
 
 //==============================================================================
 rmf_utils::optional<Plan> Planner::plan(
-    const Start& start,
-    Goal goal,
-    Options options) const
+  const Start& start,
+  Goal goal,
+  Options options) const
 {
   return Plan::Implementation::generate(
-        _pimpl->cache_mgr,
-        {start},
-        std::move(goal),
-        std::move(options));
+    _pimpl->cache_mgr,
+    {start},
+    std::move(goal),
+    std::move(options));
 }
 
 //==============================================================================
 rmf_utils::optional<Plan> Planner::plan(const StartSet& starts, Goal goal) const
 {
   return Plan::Implementation::generate(
-        _pimpl->cache_mgr,
-        starts,
-        std::move(goal),
-        _pimpl->default_options);
+    _pimpl->cache_mgr,
+    starts,
+    std::move(goal),
+    _pimpl->default_options);
 }
 
 //==============================================================================
 rmf_utils::optional<Plan> Planner::plan(
-    const StartSet& starts,
-    Goal goal,
-    Options options) const
+  const StartSet& starts,
+  Goal goal,
+  Options options) const
 {
   return Plan::Implementation::generate(
-        _pimpl->cache_mgr,
-        starts,
-        std::move(goal),
-        std::move(options));
+    _pimpl->cache_mgr,
+    starts,
+    std::move(goal),
+    std::move(options));
 }
 
 //==============================================================================
@@ -525,44 +525,44 @@ const std::vector<Plan::Waypoint>& Plan::get_waypoints() const
 rmf_utils::optional<Plan> Plan::replan(const Start& new_start) const
 {
   return Plan::Implementation::generate(
-        _pimpl->cache_mgr,
-        {new_start},
-        _pimpl->result.goal,
-        _pimpl->result.options);
+    _pimpl->cache_mgr,
+    {new_start},
+    _pimpl->result.goal,
+    _pimpl->result.options);
 }
 
 //==============================================================================
 rmf_utils::optional<Plan> Plan::replan(
-    const Planner::Start& new_start,
-    Planner::Options new_options) const
+  const Planner::Start& new_start,
+  Planner::Options new_options) const
 {
   return Plan::Implementation::generate(
-        _pimpl->cache_mgr,
-        {new_start},
-        _pimpl->result.goal,
-        std::move(new_options));
+    _pimpl->cache_mgr,
+    {new_start},
+    _pimpl->result.goal,
+    std::move(new_options));
 }
 
 //==============================================================================
 rmf_utils::optional<Plan> Plan::replan(const StartSet& new_starts) const
 {
   return Plan::Implementation::generate(
-        _pimpl->cache_mgr,
-        new_starts,
-        _pimpl->result.goal,
-        _pimpl->result.options);
+    _pimpl->cache_mgr,
+    new_starts,
+    _pimpl->result.goal,
+    _pimpl->result.options);
 }
 
 //==============================================================================
 rmf_utils::optional<Plan> Plan::replan(
-    const StartSet& new_starts,
-    Options new_options) const
+  const StartSet& new_starts,
+  Options new_options) const
 {
   return Plan::Implementation::generate(
-        _pimpl->cache_mgr,
-        new_starts,
-        _pimpl->result.goal,
-        std::move(new_options));
+    _pimpl->cache_mgr,
+    new_starts,
+    _pimpl->result.goal,
+    std::move(new_options));
 }
 
 //==============================================================================
@@ -592,18 +592,18 @@ const Planner::Configuration& Plan::get_configuration() const
 //==============================================================================
 
 std::vector<Plan::Start> compute_plan_starts(
-    const rmf_traffic::agv::Graph& graph,
-    const Eigen::Vector3d pose,
-    const rmf_traffic::Time start_time,
-    const double max_merge_waypoint_distance,
-    const double max_merge_lane_distance,
-    const double min_lane_length)
+  const rmf_traffic::agv::Graph& graph,
+  const Eigen::Vector3d pose,
+  const rmf_traffic::Time start_time,
+  const double max_merge_waypoint_distance,
+  const double max_merge_lane_distance,
+  const double min_lane_length)
 {
   const Eigen::Vector2d p_location = {pose[0], pose[1]};
   const double start_yaw = pose[2];
 
   // If there are waypoints which are very close, take that as the only Start
-  for (std::size_t i=0; i < graph.num_waypoints() ; ++i)
+  for (std::size_t i = 0; i < graph.num_waypoints(); ++i)
   {
     const auto& wp = graph.get_waypoint(i);
     const Eigen::Vector2d wp_location = wp.get_location();
@@ -619,14 +619,14 @@ std::vector<Plan::Start> compute_plan_starts(
   std::vector<Plan::Start> starts;
   std::unordered_set<std::size_t> raw_starts;
 
-  for (std::size_t i=0; i < graph.num_lanes(); ++i)
+  for (std::size_t i = 0; i < graph.num_lanes(); ++i)
   {
     const auto& lane = graph.get_lane(i);
-    const Eigen::Vector2d p0 = 
-        graph.get_waypoint(lane.entry().waypoint_index()).get_location();
+    const Eigen::Vector2d p0 =
+      graph.get_waypoint(lane.entry().waypoint_index()).get_location();
     const Eigen::Vector2d p1 =
-        graph.get_waypoint(lane.exit().waypoint_index()).get_location();
-    
+      graph.get_waypoint(lane.exit().waypoint_index()).get_location();
+
     const double lane_length = (p1 - p0).norm();
 
     // This "lane" is effectively a single point, so we'll skip it
@@ -649,8 +649,8 @@ std::vector<Plan::Start> compute_plan_starts(
           continue;
 
         starts.emplace_back(
-            Plan::Start(
-                start_time, entry_waypoint_index, start_yaw, p_location));
+          Plan::Start(
+            start_time, entry_waypoint_index, start_yaw, p_location));
       }
     }
     // If it's larger than the lane length, then its closest point on the lane
@@ -666,8 +666,8 @@ std::vector<Plan::Start> compute_plan_starts(
           continue;
 
         starts.emplace_back(
-            Plan::Start(
-                start_time, exit_waypoint_index, start_yaw, p_location));
+          Plan::Start(
+            start_time, exit_waypoint_index, start_yaw, p_location));
       }
     }
     // If its between the entry and the exit waypoints, then we should
@@ -680,8 +680,8 @@ std::vector<Plan::Start> compute_plan_starts(
       if (lane_dist < max_merge_lane_distance)
       {
         starts.emplace_back(
-            Plan::Start(
-                start_time, exit_waypoint_index, start_yaw, p_location, i));
+          Plan::Start(
+            start_time, exit_waypoint_index, start_yaw, p_location, i));
       }
     }
   }

--- a/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
@@ -35,23 +35,23 @@ public:
 
 //==============================================================================
 ScheduleRouteValidator::ScheduleRouteValidator(
-    const schedule::Viewer& viewer,
-    schedule::ParticipantId participant_id,
-    Profile profile)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               &viewer,
-               participant_id,
-               std::move(profile),
-               rmf_traffic::schedule::query_all()
-             }))
+  const schedule::Viewer& viewer,
+  schedule::ParticipantId participant_id,
+  Profile profile)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        &viewer,
+        participant_id,
+        std::move(profile),
+        rmf_traffic::schedule::query_all()
+      }))
 {
   _pimpl->query.spacetime().query_timespan({});
 }
 
 //==============================================================================
 ScheduleRouteValidator& ScheduleRouteValidator::schedule_viewer(
-    const schedule::Viewer& viewer)
+  const schedule::Viewer& viewer)
 {
   _pimpl->viewer = &viewer;
   return *this;
@@ -65,7 +65,7 @@ const schedule::Viewer& ScheduleRouteValidator::schedule_viewer() const
 
 //==============================================================================
 ScheduleRouteValidator& ScheduleRouteValidator::participant(
-    const schedule::ParticipantId p)
+  const schedule::ParticipantId p)
 {
   _pimpl->participant = p;
   return *this;
@@ -84,10 +84,10 @@ bool ScheduleRouteValidator::valid(const Route& route) const
   _pimpl->query.spacetime().timespan()->add_map(route.map());
 
   _pimpl->query.spacetime().timespan()->set_lower_time_bound(
-        *route.trajectory().start_time());
+    *route.trajectory().start_time());
 
   _pimpl->query.spacetime().timespan()->set_upper_time_bound(
-        *route.trajectory().finish_time());
+    *route.trajectory().finish_time());
 
   const auto view = _pimpl->viewer->query(_pimpl->query);
   for (const auto& v : view)
@@ -96,10 +96,10 @@ bool ScheduleRouteValidator::valid(const Route& route) const
       continue;
 
     if (rmf_traffic::DetectConflict::between(
-          _pimpl->profile,
-          route.trajectory(),
-          v.description.profile(),
-          v.route.trajectory()))
+        _pimpl->profile,
+        route.trajectory(),
+        v.description.profile(),
+        v.route.trajectory()))
       return false;
   }
 
@@ -125,14 +125,14 @@ public:
 
 //==============================================================================
 NegotiatingRouteValidator::NegotiatingRouteValidator(
-    const schedule::Negotiation::Table& table,
-    Profile profile)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               &table,
-               std::move(profile),
-               schedule::query_all()
-             }))
+  const schedule::Negotiation::Table& table,
+  Profile profile)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        &table,
+        std::move(profile),
+        schedule::query_all()
+      }))
 {
   _pimpl->query.spacetime().query_timespan({});
 }
@@ -144,19 +144,19 @@ bool NegotiatingRouteValidator::valid(const Route& route) const
   _pimpl->query.spacetime().timespan()->add_map(route.map());
 
   _pimpl->query.spacetime().timespan()->set_lower_time_bound(
-        *route.trajectory().start_time());
+    *route.trajectory().start_time());
 
   _pimpl->query.spacetime().timespan()->set_upper_time_bound(
-        *route.trajectory().finish_time());
+    *route.trajectory().finish_time());
 
   const auto view = _pimpl->table->query(_pimpl->query.spacetime());
   for (const auto& v : view)
   {
     if (rmf_traffic::DetectConflict::between(
-          _pimpl->profile,
-          route.trajectory(),
-          v.description.profile(),
-          v.route.trajectory()))
+        _pimpl->profile,
+        route.trajectory(),
+        v.description.profile(),
+        v.route.trajectory()))
     {
       return false;
     }

--- a/rmf_traffic/src/rmf_traffic/agv/VehicleTraits.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/VehicleTraits.cpp
@@ -45,15 +45,15 @@ public:
   Holonomic _holonomic;
 
   Implementation(
-      Limits linear,
-      Limits rotation,
-      Profile profile,
-      Differential differential)
-    : _linear(std::move(linear)),
-      _rotation(std::move(rotation)),
-      _profile(std::move(profile)),
-      _steering_mode(Steering::Differential),
-      _differential(differential)
+    Limits linear,
+    Limits rotation,
+    Profile profile,
+    Differential differential)
+  : _linear(std::move(linear)),
+    _rotation(std::move(rotation)),
+    _profile(std::move(profile)),
+    _steering_mode(Steering::Differential),
+    _differential(differential)
   {
     // Do nothing
   }
@@ -61,8 +61,8 @@ public:
 
 //==============================================================================
 VehicleTraits::Limits::Limits(const double velocity, const double acceleration)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{velocity, acceleration}))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{velocity, acceleration}))
 {
   // Do nothing
 }
@@ -112,9 +112,9 @@ public:
 
 //==============================================================================
 VehicleTraits::Differential::Differential(
-    Eigen::Vector2d forward,
-    const bool reversible)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
+  Eigen::Vector2d forward,
+  const bool reversible)
+: _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{std::move(forward), reversible}))
 {
   // Do nothing
@@ -162,15 +162,15 @@ VehicleTraits::Holonomic::Holonomic()
 
 //==============================================================================
 VehicleTraits::VehicleTraits(
-    Limits linear,
-    Limits rotational,
-    Profile profile,
-    Differential steering)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             std::move(linear),
-             std::move(rotational),
-             std::move(profile),
-             std::move(steering)))
+  Limits linear,
+  Limits rotational,
+  Profile profile,
+  Differential steering)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      std::move(linear),
+      std::move(rotational),
+      std::move(profile),
+      std::move(steering)))
 {
   // Do nothing
 }
@@ -228,7 +228,7 @@ auto VehicleTraits::set_differential(Differential parameters) -> Differential&
 //==============================================================================
 auto VehicleTraits::get_differential() -> Differential*
 {
-  if(_pimpl->_steering_mode == Steering::Differential)
+  if (_pimpl->_steering_mode == Steering::Differential)
     return &_pimpl->_differential;
 
   return nullptr;
@@ -237,7 +237,7 @@ auto VehicleTraits::get_differential() -> Differential*
 //==============================================================================
 auto VehicleTraits::get_differential() const -> const Differential*
 {
-  if(_pimpl->_steering_mode == Steering::Differential)
+  if (_pimpl->_steering_mode == Steering::Differential)
     return &_pimpl->_differential;
 
   return nullptr;
@@ -254,7 +254,7 @@ auto VehicleTraits::set_holonomic(Holonomic parameters) -> Holonomic&
 //==============================================================================
 auto VehicleTraits::get_holonomic() -> Holonomic*
 {
-  if(_pimpl->_steering_mode == Steering::Holonomic)
+  if (_pimpl->_steering_mode == Steering::Holonomic)
     return &_pimpl->_holonomic;
 
   return nullptr;
@@ -263,7 +263,7 @@ auto VehicleTraits::get_holonomic() -> Holonomic*
 //==============================================================================
 auto VehicleTraits::get_holonomic() const -> const Holonomic*
 {
-  if(_pimpl->_steering_mode == Steering::Holonomic)
+  if (_pimpl->_steering_mode == Steering::Holonomic)
     return &_pimpl->_holonomic;
 
   return nullptr;
@@ -272,13 +272,14 @@ auto VehicleTraits::get_holonomic() const -> const Holonomic*
 //==============================================================================
 bool VehicleTraits::valid() const
 {
-  const bool steering_valid = [&]() -> bool
-  {
-    if(_pimpl->_steering_mode == Steering::Differential)
-      return get_differential()->valid();
+  const bool steering_valid =
+    [&]() -> bool
+    {
+      if (_pimpl->_steering_mode == Steering::Differential)
+        return get_differential()->valid();
 
-    return true;
-  }();
+      return true;
+    } ();
 
   return linear().valid() && rotational().valid() && steering_valid;
 }

--- a/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_Planner.hpp
@@ -37,11 +37,11 @@ public:
   Graph::Lane::EventPtr event;
 
   template<typename... Args>
-  static Waypoint make(Args&&... args)
+  static Waypoint make(Args&& ... args)
   {
     Waypoint wp;
     wp._pimpl = rmf_utils::make_impl<Implementation>(
-          Implementation{std::forward<Args>(args)...});
+      Implementation{std::forward<Args>(args)...});
 
     return wp;
   }

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
@@ -46,7 +46,7 @@ struct Compare
     // TODO(MXG): Micro-optimization: consider saving the sum of these values
     // in the Node instead of needing to re-add them for every comparison.
     return b->remaining_cost_estimate + b->current_cost
-         < a->remaining_cost_estimate + a->current_cost;
+      < a->remaining_cost_estimate + a->current_cost;
   }
 };
 
@@ -78,7 +78,7 @@ Cache& Cache::operator=(Cache&&)
 
 //==============================================================================
 CacheHandle::CacheHandle(CachePtr original)
-  : _original(std::move(original))
+: _original(std::move(original))
 {
   std::unique_lock<std::mutex> lock(_original->mutex);
   _copy = _original->clone();
@@ -86,9 +86,9 @@ CacheHandle::CacheHandle(CachePtr original)
 
 //==============================================================================
 rmf_utils::optional<Result> CacheHandle::plan(
-    const std::vector<agv::Planner::Start>& starts,
-    agv::Planner::Goal goal,
-    agv::Planner::Options options)
+  const std::vector<agv::Planner::Start>& starts,
+  agv::Planner::Goal goal,
+  agv::Planner::Options options)
 {
   return _copy->plan(starts, std::move(goal), std::move(options));
 }
@@ -104,7 +104,7 @@ CacheHandle::~CacheHandle()
 
 //==============================================================================
 CacheManager::CacheManager(CachePtr cache)
-  : _cache(std::move(cache))
+: _cache(std::move(cache))
 {
   // Do nothing
 }
@@ -123,14 +123,14 @@ const agv::Planner::Configuration& CacheManager::get_configuration() const
 
 //==============================================================================
 template<
-    class Expander,
-    class Context = typename Expander::Context,
-    class InitialNodeArgs = typename Expander::InitialNodeArgs,
-    class NodePtr = typename Expander::NodePtr>
+  class Expander,
+  class Context = typename Expander::Context,
+  class InitialNodeArgs = typename Expander::InitialNodeArgs,
+  class NodePtr = typename Expander::NodePtr>
 NodePtr search(
-    Context&& context,
-    InitialNodeArgs&& initial_node_args,
-    const bool* interrupt_flag)
+  Context&& context,
+  InitialNodeArgs&& initial_node_args,
+  const bool* interrupt_flag)
 {
   using SearchQueue = typename Expander::SearchQueue;
 
@@ -139,12 +139,12 @@ NodePtr search(
   SearchQueue queue;
   expander.make_initial_nodes(initial_node_args, queue);
 
-  while(!queue.empty() && !(interrupt_flag && *interrupt_flag))
+  while (!queue.empty() && !(interrupt_flag && *interrupt_flag))
   {
     NodePtr top = queue.top();
     queue.pop();
 
-    if(expander.is_finished(top))
+    if (expander.is_finished(top))
       return top;
 
     expander.expand(top, queue);
@@ -175,9 +175,9 @@ std::vector<Route> reconstruct_routes(const NodePtr& finish_node)
   {
     RouteData& last_route = routes.back();
     const RouteData& next_route = (*it)->route_from_parent;
-    if(next_route.map == last_route.map)
+    if (next_route.map == last_route.map)
     {
-      for(const auto& waypoint : next_route.trajectory)
+      for (const auto& waypoint : next_route.trajectory)
         last_route.trajectory.insert(waypoint);
     }
     else
@@ -197,12 +197,12 @@ std::vector<Route> reconstruct_routes(const NodePtr& finish_node)
 //==============================================================================
 template<typename NodePtr>
 std::vector<agv::Plan::Waypoint> reconstruct_waypoints(
-    const NodePtr& finish_node,
-    const agv::Graph::Implementation& graph)
+  const NodePtr& finish_node,
+  const agv::Graph::Implementation& graph)
 {
   NodePtr node = finish_node;
   std::vector<NodePtr> node_sequence;
-  while(node)
+  while (node)
   {
     node_sequence.push_back(node);
     node = node->parent;
@@ -212,15 +212,15 @@ std::vector<agv::Plan::Waypoint> reconstruct_waypoints(
   for (auto it = node_sequence.rbegin(); it != node_sequence.rend(); ++it)
   {
     const auto& n = *it;
-    const Eigen::Vector2d p = n->waypoint?
-          graph.waypoints[*n->waypoint].get_location() :
-          n->route_from_parent.trajectory.back().position()
-            .template block<2,1>(0,0);
+    const Eigen::Vector2d p = n->waypoint ?
+      graph.waypoints[*n->waypoint].get_location() :
+      n->route_from_parent.trajectory.back().position()
+      .template block<2, 1>(0, 0);
     const Time time{*n->route_from_parent.trajectory.finish_time()};
     waypoints.emplace_back(
-          agv::Plan::Waypoint::Implementation::make(
-            Eigen::Vector3d{p[0], p[1], n->orientation}, time,
-            n->waypoint, n->event));
+      agv::Plan::Waypoint::Implementation::make(
+        Eigen::Vector3d{p[0], p[1], n->orientation}, time,
+        n->waypoint, n->event));
   }
 
   return waypoints;
@@ -260,7 +260,7 @@ struct EuclideanExpander
   };
 
   using SearchQueue =
-      std::priority_queue<NodePtr, std::vector<NodePtr>, Compare<NodePtr>>;
+    std::priority_queue<NodePtr, std::vector<NodePtr>, Compare<NodePtr>>;
 
   struct InitialNodeArgs
   {
@@ -288,16 +288,16 @@ struct EuclideanExpander
   void make_initial_nodes(const InitialNodeArgs& args, SearchQueue& queue)
   {
     const Eigen::Vector2d location =
-        context.graph.waypoints[args.waypoint].get_location();
+      context.graph.waypoints[args.waypoint].get_location();
 
     queue.emplace(std::make_shared<Node>(
-          Node{
-            args.waypoint,
-            estimate_remaining_cost(location),
-            0.0,
-            location,
-            nullptr
-          }));
+        Node{
+          args.waypoint,
+          estimate_remaining_cost(location),
+          0.0,
+          location,
+          nullptr
+        }));
   }
 
   bool is_finished(const NodePtr& node)
@@ -308,24 +308,24 @@ struct EuclideanExpander
   static double lane_event_cost(const agv::Graph::Lane& lane)
   {
     double cost = 0.0;
-    if(const auto* event = lane.entry().event())
+    if (const auto* event = lane.entry().event())
       cost += time::to_seconds(event->duration());
 
-    if(const auto* event = lane.exit().event())
+    if (const auto* event = lane.exit().event())
       cost += time::to_seconds(event->duration());
 
     return cost;
   }
 
   void expand_lane(
-      const NodePtr& parent_node,
-      const std::size_t lane_index,
-      SearchQueue& queue)
+    const NodePtr& parent_node,
+    const std::size_t lane_index,
+    SearchQueue& queue)
   {
     const agv::Graph::Lane& lane = context.graph.lanes[lane_index];
     assert(lane.entry().waypoint_index() == parent_node->waypoint);
     const std::size_t exit_waypoint_index = lane.exit().waypoint_index();
-    if(expanded.count(exit_waypoint_index) > 0)
+    if (expanded.count(exit_waypoint_index) > 0)
     {
       // This waypoint has already been expanded from, so there's no point in
       // expanding towards it again.
@@ -334,21 +334,21 @@ struct EuclideanExpander
 
     const Eigen::Vector2d p_start = parent_node->location;
     const Eigen::Vector2d p_exit =
-        context.graph.waypoints[exit_waypoint_index].get_location();
+      context.graph.waypoints[exit_waypoint_index].get_location();
 
     const double cost =
-        parent_node->current_cost
-        + lane_event_cost(lane)
-        + (p_exit - p_start).norm();
+      parent_node->current_cost
+      + lane_event_cost(lane)
+      + (p_exit - p_start).norm();
 
     queue.push(std::make_shared<Node>(
-                 Node{
-                   exit_waypoint_index,
-                   estimate_remaining_cost(p_exit),
-                   cost,
-                   p_exit,
-                   parent_node
-                 }));
+        Node{
+          exit_waypoint_index,
+          estimate_remaining_cost(p_exit),
+          cost,
+          p_exit,
+          parent_node
+        }));
   }
 
   void expand(const NodePtr& parent_node, SearchQueue& queue)
@@ -357,9 +357,9 @@ struct EuclideanExpander
     expanded.insert(parent_waypoint);
 
     const std::vector<std::size_t>& lanes =
-        context.graph.lanes_from[parent_waypoint];
+      context.graph.lanes_from[parent_waypoint];
 
-    for(const std::size_t l : lanes)
+    for (const std::size_t l : lanes)
       expand_lane(parent_node, l, queue);
   }
 
@@ -378,11 +378,11 @@ Eigen::Vector3d to_3d(const Eigen::Vector2d& p, const double w)
 //==============================================================================
 template<typename NodePtrT>
 double compute_current_cost(
-    const NodePtrT& parent,
-    const Trajectory& trajectory_from_parent)
+  const NodePtrT& parent,
+  const Trajectory& trajectory_from_parent)
 {
   return parent->current_cost + time::to_seconds(
-        trajectory_from_parent.duration());
+    trajectory_from_parent.duration());
 }
 
 //==============================================================================
@@ -391,7 +391,7 @@ class DifferentialDriveConstraint
 public:
 
   static Eigen::Rotation2Dd compute_forward_offset(
-      const Eigen::Vector2d& forward)
+    const Eigen::Vector2d& forward)
   {
     return Eigen::Rotation2Dd(std::atan2(forward[1], forward[0]));
   }
@@ -399,8 +399,8 @@ public:
   static const Eigen::Rotation2Dd R_pi;
 
   DifferentialDriveConstraint(
-      const Eigen::Vector2d& forward,
-      const bool reversible)
+    const Eigen::Vector2d& forward,
+    const bool reversible)
   : R_f_inv(compute_forward_offset(forward).inverse()),
     reversible(reversible)
   {
@@ -408,18 +408,18 @@ public:
   }
 
   std::vector<double> get_orientations(
-      const Eigen::Vector2d& course_vector)
+    const Eigen::Vector2d& course_vector)
   {
     std::vector<double> orientations;
     orientations.reserve(2);
 
     const Eigen::Rotation2Dd R_c(
-          std::atan2(course_vector[1], course_vector[0]));
+      std::atan2(course_vector[1], course_vector[0]));
     const Eigen::Rotation2Dd R_h = R_c * R_f_inv;
 
     orientations.push_back(rmf_utils::wrap_to_pi(R_h.angle()));
 
-    if(reversible)
+    if (reversible)
       orientations.push_back(rmf_utils::wrap_to_pi((R_pi * R_h).angle()));
 
     return orientations;
@@ -432,7 +432,7 @@ public:
 
 //==============================================================================
 const Eigen::Rotation2Dd DifferentialDriveConstraint::R_pi =
-    Eigen::Rotation2Dd(M_PI);
+  Eigen::Rotation2Dd(M_PI);
 
 //==============================================================================
 struct DifferentialDriveExpander
@@ -453,7 +453,7 @@ struct DifferentialDriveExpander
   };
 
   using SearchQueue =
-      std::priority_queue<NodePtr, std::vector<NodePtr>, Compare<NodePtr>>;
+    std::priority_queue<NodePtr, std::vector<NodePtr>, Compare<NodePtr>>;
 
   class LaneEventExecutor : public agv::Graph::Lane::Executor
   {
@@ -506,24 +506,24 @@ struct DifferentialDriveExpander
       assert(_event);
       const auto duration = _event->duration();
       return expander->make_delay(
-            *_parent->waypoint,
-            _parent,
-            duration,
-            std::move(_event));
+        *_parent->waypoint,
+        _parent,
+        duration,
+        std::move(_event));
     }
 
     LaneEventExecutor& add_if_valid(
-        DifferentialDriveExpander* expander,
-        SearchQueue& queue)
+      DifferentialDriveExpander* expander,
+      SearchQueue& queue)
     {
       assert(_event);
       const auto duration = _event->duration();
       expander->expand_delay(
-            *_parent->waypoint,
-            _parent,
-            duration,
-            queue,
-            std::move(_event));
+        *_parent->waypoint,
+        _parent,
+        duration,
+        queue,
+        std::move(_event));
       return *this;
     }
 
@@ -544,20 +544,20 @@ struct DifferentialDriveExpander
   public:
 
     double estimate_remaining_cost(
-        const Context& context,
-        const std::size_t waypoint)
+      const Context& context,
+      const std::size_t waypoint)
     {
       auto estimate_it = known_costs.insert(
-          {waypoint, std::numeric_limits<double>::infinity()});
+        {waypoint, std::numeric_limits<double>::infinity()});
 
-      if(estimate_it.second)
+      if (estimate_it.second)
       {
         // The pair was inserted, which implies that the cost estimate for this
         // waypoint has never been found before, and we should compute it now.
         const EuclideanExpander::NodePtr solution = search<EuclideanExpander>(
-              EuclideanExpander::Context{context.graph, context.final_waypoint},
-              EuclideanExpander::InitialNodeArgs{waypoint},
-              nullptr);
+          EuclideanExpander::Context{context.graph, context.final_waypoint},
+          EuclideanExpander::InitialNodeArgs{waypoint},
+          nullptr);
 
         // TODO(MXG): Instead of asserting that the goal exists, we should
         // probably take this opportunity to shortcircuit the planner and return
@@ -569,7 +569,7 @@ struct DifferentialDriveExpander
         // Note: this constructs positions in reverse, but that's okay because
         // the Interpolate::positions function will produce a trajectory with the
         // same duration whether it is interpolating forward or backwards.
-        while(euclidean_node)
+        while (euclidean_node)
         {
           const Eigen::Vector2d p = euclidean_node->location;
           positions.push_back({p[0], p[1], 0.0});
@@ -580,7 +580,7 @@ struct DifferentialDriveExpander
         // about the Trajectory's start/end time being correct; we only care
         // about the difference between the two.
         const rmf_traffic::Trajectory estimate = agv::Interpolate::positions(
-              context.traits, context.initial_time, positions);
+          context.traits, context.initial_time, positions);
 
         const double cost_esimate = time::to_seconds(estimate.duration());
         estimate_it.first->second = cost_esimate;
@@ -596,7 +596,7 @@ struct DifferentialDriveExpander
 
     void update(const Heuristic& other)
     {
-      for(const auto& wp_costs : other.known_costs)
+      for (const auto& wp_costs : other.known_costs)
         known_costs.insert(wp_costs);
     }
 
@@ -632,58 +632,58 @@ struct DifferentialDriveExpander
   void make_initial_nodes(const InitialNodeArgs& args, SearchQueue& queue)
   {
     const std::size_t N_starts = args.starts.size();
-    for (std::size_t start_index=0; start_index < N_starts; ++start_index)
+    for (std::size_t start_index = 0; start_index < N_starts; ++start_index)
     {
       const auto& start = args.starts[start_index];
 
       const std::size_t initial_waypoint = start.waypoint();
 
       const double cost_estimate =
-          _context.heuristic.estimate_remaining_cost(
-            _context, initial_waypoint);
+        _context.heuristic.estimate_remaining_cost(
+        _context, initial_waypoint);
 
       const double initial_orientation = start.orientation();
       const std::string& map_name =
-          _context.graph.waypoints[initial_waypoint].get_map_name();
+        _context.graph.waypoints[initial_waypoint].get_map_name();
 
       _query.spacetime().timespan()->add_map(map_name);
 
       const auto initial_time = start.time();
 
       const Eigen::Vector2d wp_location =
-          _context.graph.waypoints[initial_waypoint].get_location();
+        _context.graph.waypoints[initial_waypoint].get_location();
 
       const auto& initial_location = start.location();
       if (initial_location)
       {
         const Eigen::Vector3d initial_position =
-            to_3d(*initial_location, initial_orientation);
+          to_3d(*initial_location, initial_orientation);
 
         RouteData initial_route;
         initial_route.map = map_name;
         Trajectory& initial_trajectory = initial_route.trajectory;
         initial_trajectory.insert(
-              initial_time,
-              initial_position,
-              Eigen::Vector3d::Zero());
+          initial_time,
+          initial_position,
+          Eigen::Vector3d::Zero());
 
         const auto initial_node = std::make_shared<Node>(
-              Node{
-                std::numeric_limits<double>::infinity(),
-                0.0,
-                rmf_utils::nullopt,
-                initial_orientation,
-                initial_route,
-                nullptr,
-                nullptr,
-                start_index
-              });
+          Node{
+            std::numeric_limits<double>::infinity(),
+            0.0,
+            rmf_utils::nullopt,
+            initial_orientation,
+            initial_route,
+            nullptr,
+            nullptr,
+            start_index
+          });
 
         const Eigen::Vector2d course =
-            (wp_location - *initial_location).normalized();
+          (wp_location - *initial_location).normalized();
 
         const std::vector<double> orientations =
-            _differential_constraint.get_orientations(course);
+          _differential_constraint.get_orientations(course);
 
         const auto initial_lane = start.lane();
 
@@ -695,15 +695,18 @@ struct DifferentialDriveExpander
             const auto lane_exit = lane.exit().waypoint_index();
             if (lane_exit != initial_waypoint)
             {
+              // *INDENT-OFF*
               throw std::invalid_argument(
-                    "[rmf_traffic::agv::Planner] Disagreement between initial "
-                    "waypoint index [" + std::to_string(initial_waypoint)
-                    + "] and the initial lane exit ["
-                    + std::to_string(lane_exit) + "]");
+                "[rmf_traffic::agv::Planner] Disagreement between initial "
+                "waypoint index [" + std::to_string(
+                  initial_waypoint)
+                + "] and the initial lane exit ["
+                + std::to_string(lane_exit) + "]");
+              // *INDENT-ON*
             }
 
             if (!is_orientation_okay(
-                  *initial_location, orientation, course, lane))
+                *initial_location, orientation, course, lane))
             {
               // We cannot approach the initial_waypoint with this orientation,
               // so we cannot use this orientation to start.
@@ -713,10 +716,10 @@ struct DifferentialDriveExpander
 
           auto rotated_initial_node = initial_node;
           if (std::abs(rmf_utils::wrap_to_pi(orientation - initial_orientation))
-              >= _context.interpolate.rotation_thresh)
+            >= _context.interpolate.rotation_thresh)
           {
             const Eigen::Vector3d rotated_position =
-                to_3d(*initial_location, orientation);
+              to_3d(*initial_location, orientation);
 
             RouteData rotation_route = initial_route;
             Trajectory& rotation_trajectory = rotation_route.trajectory;
@@ -726,13 +729,13 @@ struct DifferentialDriveExpander
             // we use interpolate_rotation
 
             agv::internal::interpolate_rotation(
-                  rotation_trajectory,
-                  rotational.get_nominal_velocity(),
-                  rotational.get_nominal_acceleration(),
-                  initial_time,
-                  initial_position,
-                  rotated_position,
-                  _context.interpolate.rotation_thresh);
+              rotation_trajectory,
+              rotational.get_nominal_velocity(),
+              rotational.get_nominal_acceleration(),
+              initial_time,
+              initial_position,
+              rotated_position,
+              _context.interpolate.rotation_thresh);
 
             if (rotation_trajectory.size() != 1 && !is_valid(rotation_route))
             {
@@ -742,34 +745,34 @@ struct DifferentialDriveExpander
             }
 
             const double rotation_cost =
-                rmf_traffic::time::to_seconds(rotation_trajectory.duration());
+              rmf_traffic::time::to_seconds(rotation_trajectory.duration());
 
             rotated_initial_node = std::make_shared<Node>(
-                  Node{
-                    std::numeric_limits<double>::infinity(),
-                    rotation_cost,
-                    rmf_utils::nullopt,
-                    orientation,
-                    std::move(rotation_route),
-                    nullptr,
-                    initial_node
-                  });
+              Node{
+                std::numeric_limits<double>::infinity(),
+                rotation_cost,
+                rmf_utils::nullopt,
+                orientation,
+                std::move(rotation_route),
+                nullptr,
+                initial_node
+              });
           }
 
           RouteData approach_route;
           approach_route.map = map_name;
           Trajectory& approach_trajectory = approach_route.trajectory;
           approach_trajectory.insert(
-                rotated_initial_node->route_from_parent.trajectory.back());
+            rotated_initial_node->route_from_parent.trajectory.back());
 
           agv::internal::interpolate_translation(
-                approach_trajectory,
-                _context.traits.linear().get_nominal_velocity(),
-                _context.traits.linear().get_nominal_acceleration(),
-                *approach_trajectory.start_time(),
-                to_3d(*initial_location, orientation),
-                to_3d(wp_location, orientation),
-                _context.interpolate.translation_thresh);
+            approach_trajectory,
+            _context.traits.linear().get_nominal_velocity(),
+            _context.traits.linear().get_nominal_acceleration(),
+            *approach_trajectory.start_time(),
+            to_3d(*initial_location, orientation),
+            to_3d(wp_location, orientation),
+            _context.interpolate.translation_thresh);
 
           if (approach_trajectory.size() != 1 && !is_valid(approach_route))
           {
@@ -779,19 +782,19 @@ struct DifferentialDriveExpander
           }
 
           const double current_cost =
-              rmf_traffic::time::to_seconds(approach_trajectory.duration())
-              + rotated_initial_node->current_cost;
+            rmf_traffic::time::to_seconds(approach_trajectory.duration())
+            + rotated_initial_node->current_cost;
 
           queue.push(std::make_shared<Node>(
-                       Node{
-                         cost_estimate,
-                         current_cost,
-                         initial_waypoint,
-                         orientation,
-                         std::move(approach_route),
-                         nullptr,
-                         rotated_initial_node
-                       }));
+              Node{
+                cost_estimate,
+                current_cost,
+                initial_waypoint,
+                orientation,
+                std::move(approach_route),
+                nullptr,
+                rotated_initial_node
+              }));
         }
       }
       else
@@ -800,34 +803,34 @@ struct DifferentialDriveExpander
         initial_route.map = map_name;
         Trajectory& initial_trajectory = initial_route.trajectory;
         initial_trajectory.insert(
-              initial_time,
-              to_3d(wp_location, initial_orientation),
-              Eigen::Vector3d::Zero());
+          initial_time,
+          to_3d(wp_location, initial_orientation),
+          Eigen::Vector3d::Zero());
 
         queue.push(std::make_shared<Node>(
-                     Node{
-                       cost_estimate,
-                       0.0,
-                       initial_waypoint,
-                       initial_orientation,
-                       std::move(initial_route),
-                       nullptr,
-                       nullptr,
-                       start_index
-                     }));
+            Node{
+              cost_estimate,
+              0.0,
+              initial_waypoint,
+              initial_orientation,
+              std::move(initial_route),
+              nullptr,
+              nullptr,
+              start_index
+            }));
       }
     }
   }
 
   bool is_finished(const NodePtr& node) const
   {
-    if(*node->waypoint != _context.final_waypoint)
+    if (*node->waypoint != _context.final_waypoint)
       return false;
 
-    if(_context.final_orientation)
+    if (_context.final_orientation)
     {
-      if(std::abs(node->orientation - *_context.final_orientation)
-         > _context.interpolate.rotation_thresh)
+      if (std::abs(node->orientation - *_context.final_orientation)
+        > _context.interpolate.rotation_thresh)
         return false;
     }
 
@@ -843,15 +846,15 @@ struct DifferentialDriveExpander
   }
 
   NodePtr expand_rotation(
-      const NodePtr& parent_node,
-      const double target_orientation)
+    const NodePtr& parent_node,
+    const double target_orientation)
   {
     const std::size_t waypoint = *parent_node->waypoint;
     RouteData route;
     route.map = _context.graph.waypoints[waypoint].get_map_name();
     Trajectory& trajectory = route.trajectory;
     const Trajectory::Waypoint& last =
-        parent_node->route_from_parent.trajectory.back();
+      parent_node->route_from_parent.trajectory.back();
 
     const Eigen::Vector3d& p = last.position();
     trajectory.insert(last);
@@ -860,50 +863,51 @@ struct DifferentialDriveExpander
     // context to reduce the dereferencing cost here.
     const auto& rotational = _context.traits.rotational();
     agv::internal::interpolate_rotation(
-          trajectory,
-          rotational.get_nominal_velocity(),
-          rotational.get_nominal_acceleration(),
-          last.time(),
-          p,
-          Eigen::Vector3d(p[0], p[1], target_orientation),
-          _context.interpolate.rotation_thresh);
+      trajectory,
+      rotational.get_nominal_velocity(),
+      rotational.get_nominal_acceleration(),
+      last.time(),
+      p,
+      Eigen::Vector3d(p[0], p[1], target_orientation),
+      _context.interpolate.rotation_thresh);
 
-    if(is_valid(route))
+    if (is_valid(route))
     {
       return std::make_shared<Node>(
-            Node{
-              _context.heuristic.estimate_remaining_cost(_context, waypoint),
-              compute_current_cost(parent_node, trajectory),
-              waypoint,
-              target_orientation,
-              std::move(route),
-              nullptr,
-              parent_node
-            });
+        Node{
+          _context.heuristic.estimate_remaining_cost(_context, waypoint),
+          compute_current_cost(parent_node, trajectory),
+          waypoint,
+          target_orientation,
+          std::move(route),
+          nullptr,
+          parent_node
+        });
     }
 
     return nullptr;
   }
 
   bool is_orientation_okay(
-      const Eigen::Vector2d& initial_p,
-      const double orientation,
-      const Eigen::Vector2d& course,
-      const agv::Graph::Lane& lane) const
+    const Eigen::Vector2d& initial_p,
+    const double orientation,
+    const Eigen::Vector2d& course,
+    const agv::Graph::Lane& lane) const
   {
-    for(const auto* constraint : {
+    for (const auto* constraint : {
         lane.entry().orientation_constraint(),
-        lane.exit().orientation_constraint()})
+        lane.exit().orientation_constraint()
+      })
     {
-      if(!constraint)
+      if (!constraint)
         continue;
 
       Eigen::Vector3d position{initial_p[0], initial_p[1], orientation};
-      if(!constraint->apply(position, course))
+      if (!constraint->apply(position, course))
         return false;
 
-      if(std::abs(rmf_utils::wrap_to_pi(orientation - position[2]))
-         > _context.interpolate.rotation_thresh)
+      if (std::abs(rmf_utils::wrap_to_pi(orientation - position[2]))
+        > _context.interpolate.rotation_thresh)
         return false;
     }
 
@@ -911,33 +915,34 @@ struct DifferentialDriveExpander
   }
 
   std::vector<NodePtr> expand_rotations(
-      const NodePtr& parent_node,
-      const std::size_t lane_index)
+    const NodePtr& parent_node,
+    const std::size_t lane_index)
   {
     const agv::Graph::Lane& lane = _context.graph.lanes[lane_index];
 
     const agv::Graph::Waypoint& initial_waypoint =
-        _context.graph.waypoints[lane.entry().waypoint_index()];
+      _context.graph.waypoints[lane.entry().waypoint_index()];
     const Eigen::Vector2d& initial_p = initial_waypoint.get_location();
 
     const agv::Graph::Waypoint& next_waypoint =
-        _context.graph.waypoints[lane.exit().waypoint_index()];
+      _context.graph.waypoints[lane.exit().waypoint_index()];
     const Eigen::Vector2d& next_p = next_waypoint.get_location();
 
     const Eigen::Vector2d course = (next_p - initial_p).normalized();
 
     const std::vector<double> orientations =
-        _differential_constraint.get_orientations(course);
+      _differential_constraint.get_orientations(course);
 
     std::vector<NodePtr> rotations;
     rotations.reserve(orientations.size());
-    for(const double orientation : orientations)
+    for (const double orientation : orientations)
     {
-      if(!is_orientation_okay(initial_p, orientation, course, lane))
+      if (!is_orientation_okay(initial_p, orientation, course, lane))
         continue;
 
-      if(std::abs(rmf_utils::wrap_to_pi(orientation - parent_node->orientation))
-         < _context.interpolate.rotation_thresh)
+      if (std::abs(rmf_utils::wrap_to_pi(orientation -
+        parent_node->orientation))
+        < _context.interpolate.rotation_thresh)
       {
         // No rotation is needed to reach this orientation
         rotations.push_back(parent_node);
@@ -945,7 +950,7 @@ struct DifferentialDriveExpander
       else
       {
         const NodePtr rotation = expand_rotation(parent_node, orientation);
-        if(rotation)
+        if (rotation)
           rotations.push_back(rotation);
       }
     }
@@ -954,46 +959,46 @@ struct DifferentialDriveExpander
   }
 
   NodePtr make_if_valid(
-      const std::size_t waypoint,
-      const double orientation,
-      const NodePtr& parent_node,
-      RouteData route,
-      agv::Graph::Lane::EventPtr event = nullptr)
+    const std::size_t waypoint,
+    const double orientation,
+    const NodePtr& parent_node,
+    RouteData route,
+    agv::Graph::Lane::EventPtr event = nullptr)
   {
     assert(route.trajectory.size() > 1);
-    if(is_valid(route))
+    if (is_valid(route))
     {
       return std::make_shared<Node>(
-            Node{
-              _context.heuristic.estimate_remaining_cost(_context, waypoint),
-              compute_current_cost(parent_node, route.trajectory),
-              waypoint,
-              orientation,
-              std::move(route),
-              std::move(event),
-              parent_node
-            });
+        Node{
+          _context.heuristic.estimate_remaining_cost(_context, waypoint),
+          compute_current_cost(parent_node, route.trajectory),
+          waypoint,
+          orientation,
+          std::move(route),
+          std::move(event),
+          parent_node
+        });
     }
 
     return nullptr;
   }
 
   bool add_if_valid(
-      const std::size_t waypoint,
-      const double orientation,
-      const NodePtr& parent_node,
-      RouteData route,
-      SearchQueue& queue,
-      agv::Graph::Lane::EventPtr event = nullptr)
+    const std::size_t waypoint,
+    const double orientation,
+    const NodePtr& parent_node,
+    RouteData route,
+    SearchQueue& queue,
+    agv::Graph::Lane::EventPtr event = nullptr)
   {
     const auto node = make_if_valid(
-          waypoint,
-          orientation,
-          parent_node,
-          std::move(route),
-          std::move(event));
+      waypoint,
+      orientation,
+      parent_node,
+      std::move(route),
+      std::move(event));
 
-    if(node)
+    if (node)
     {
       // TODO(MXG): Consider short-circuiting the rest of the search and
       // returning the solution if this Node solves the search problem. It could
@@ -1011,22 +1016,22 @@ struct DifferentialDriveExpander
   };
 
   void expand_down_lane(
-      NodePtr initial_parent,
-      const std::size_t initial_lane_index,
-      SearchQueue& queue)
+    NodePtr initial_parent,
+    const std::size_t initial_lane_index,
+    SearchQueue& queue)
   {
     const std::size_t initial_waypoint = *initial_parent->waypoint;
     assert(_context.graph.lanes[initial_lane_index].entry().waypoint_index()
-           == initial_waypoint);
+      == initial_waypoint);
     const Eigen::Vector2d initial_p =
-        _context.graph.waypoints[initial_waypoint].get_location();
+      _context.graph.waypoints[initial_waypoint].get_location();
     const double orientation = initial_parent->orientation;
 
     const auto& initial_lane = _context.graph.lanes[initial_lane_index];
     if (const auto* entry_event = initial_lane.entry().event())
     {
       initial_parent = entry_event->execute(
-            _executor.update(initial_parent)).get(this);
+        _executor.update(initial_parent)).get(this);
 
       if (!initial_parent)
       {
@@ -1036,10 +1041,10 @@ struct DifferentialDriveExpander
     }
 
     const std::string map_name =
-        _context.graph.waypoints[initial_waypoint].get_map_name();
+      _context.graph.waypoints[initial_waypoint].get_map_name();
 
     const Trajectory::Waypoint& initial_wp =
-        initial_parent->route_from_parent.trajectory.back();
+      initial_parent->route_from_parent.trajectory.back();
 
     const Time initial_time = initial_wp.time();
     const Eigen::Vector3d initial_position = initial_wp.position();
@@ -1055,7 +1060,7 @@ struct DifferentialDriveExpander
       const agv::Graph::Lane& lane = _context.graph.lanes[top.lane];
       const std::size_t exit_waypoint_index = lane.exit().waypoint_index();
       const agv::Graph::Waypoint& exit_waypoint =
-          _context.graph.waypoints[exit_waypoint_index];
+        _context.graph.waypoints[exit_waypoint_index];
 
       const Eigen::Vector2d& next_p = exit_waypoint.get_location();
       const Eigen::Vector3d next_position{next_p[0], next_p[1], orientation};
@@ -1067,33 +1072,33 @@ struct DifferentialDriveExpander
       Trajectory& trajectory = route.trajectory;
       trajectory.insert(initial_wp);
       agv::internal::interpolate_translation(
-            trajectory,
-            _context.traits.linear().get_nominal_velocity(),
-            _context.traits.linear().get_nominal_acceleration(),
-            initial_time,
-            initial_position,
-            next_position,
-            _context.interpolate.translation_thresh);
+        trajectory,
+        _context.traits.linear().get_nominal_velocity(),
+        _context.traits.linear().get_nominal_acceleration(),
+        initial_time,
+        initial_position,
+        next_position,
+        _context.interpolate.translation_thresh);
 
       if (const auto* event = lane.exit().event())
       {
-        if(!is_valid(route))
+        if (!is_valid(route))
           continue;
 
         auto parent_to_event = std::make_shared<Node>(
-              Node{
-                _context.heuristic.estimate_remaining_cost(
-                    _context, exit_waypoint_index),
-                compute_current_cost(initial_parent, trajectory),
-                exit_waypoint_index,
-                orientation,
-                std::move(route),
-                nullptr,
-                initial_parent
-              });
+          Node{
+            _context.heuristic.estimate_remaining_cost(
+              _context, exit_waypoint_index),
+            compute_current_cost(initial_parent, trajectory),
+            exit_waypoint_index,
+            orientation,
+            std::move(route),
+            nullptr,
+            initial_parent
+          });
 
         event->execute(_executor.update(parent_to_event))
-            .add_if_valid(this, queue);
+        .add_if_valid(this, queue);
 
         continue;
       }
@@ -1101,7 +1106,7 @@ struct DifferentialDriveExpander
       // we may need to copy the trajectory later when we expand further down
       // other lanes.
       else if (!add_if_valid(exit_waypoint_index, orientation, initial_parent,
-                        route, queue))
+        route, queue))
       {
         // This lane was not successfully added, so we should not try to expand
         // this any further.
@@ -1111,20 +1116,20 @@ struct DifferentialDriveExpander
       // If this lane was successfully added, we can try to find more lanes to
       // continue down, as a single expansion from the original parent.
       const std::vector<std::size_t>& lanes =
-          _context.graph.lanes_from[exit_waypoint_index];
+        _context.graph.lanes_from[exit_waypoint_index];
 
       for (const std::size_t l : lanes)
       {
         const agv::Graph::Lane& future_lane = _context.graph.lanes[l];
 
         const Eigen::Vector2d future_p =
-            _context.graph.waypoints[future_lane.exit().waypoint_index()]
-            .get_location();
+          _context.graph.waypoints[future_lane.exit().waypoint_index()]
+          .get_location();
 
         const Eigen::Vector2d course = future_p - initial_p;
 
         const bool check_orientation =
-            is_orientation_okay(initial_p, orientation, course, future_lane);
+          is_orientation_okay(initial_p, orientation, course, future_lane);
 
         if (!check_orientation)
         {
@@ -1144,9 +1149,9 @@ struct DifferentialDriveExpander
           future_p[0], future_p[1], orientation
         };
 
-        if(!agv::internal::can_skip_interpolation(
-             initial_position, next_position,
-             future_position, _context.interpolate))
+        if (!agv::internal::can_skip_interpolation(
+            initial_position, next_position,
+            future_position, _context.interpolate))
         {
           continue;
         }
@@ -1157,9 +1162,9 @@ struct DifferentialDriveExpander
   }
 
   void expand_lane(
-      const NodePtr& initial_parent,
-      const std::size_t initial_lane_index,
-      SearchQueue& queue)
+    const NodePtr& initial_parent,
+    const std::size_t initial_lane_index,
+    SearchQueue& queue)
   {
     const auto rotations = expand_rotations(initial_parent, initial_lane_index);
     for (const auto& parent : rotations)
@@ -1167,13 +1172,13 @@ struct DifferentialDriveExpander
   }
 
   NodePtr make_delay(
-      const std::size_t waypoint,
-      const NodePtr& parent_node,
-      const Duration delay,
-      agv::Graph::Lane::EventPtr event = nullptr)
+    const std::size_t waypoint,
+    const NodePtr& parent_node,
+    const Duration delay,
+    agv::Graph::Lane::EventPtr event = nullptr)
   {
     const Trajectory& parent_trajectory =
-        parent_node->route_from_parent.trajectory;
+      parent_node->route_from_parent.trajectory;
     const auto& initial_segment = parent_trajectory.back();
 
     RouteData route;
@@ -1185,34 +1190,34 @@ struct DifferentialDriveExpander
     trajectory.insert(initial_segment);
 
     trajectory.insert(
-          initial_time + delay,
-          initial_pos,
-          Eigen::Vector3d::Zero());
+      initial_time + delay,
+      initial_pos,
+      Eigen::Vector3d::Zero());
     assert(trajectory.size() == 2);
 
     return make_if_valid(
-          waypoint, initial_pos[2], parent_node,
-          std::move(route), std::move(event));
+      waypoint, initial_pos[2], parent_node,
+      std::move(route), std::move(event));
   }
 
   void expand_delay(
-      const std::size_t waypoint,
-      const NodePtr& parent_node,
-      const Duration delay,
-      SearchQueue& queue,
-      agv::Graph::Lane::EventPtr event = nullptr)
+    const std::size_t waypoint,
+    const NodePtr& parent_node,
+    const Duration delay,
+    SearchQueue& queue,
+    agv::Graph::Lane::EventPtr event = nullptr)
   {
     const auto node = make_delay(
-          waypoint, parent_node, delay, std::move(event));
+      waypoint, parent_node, delay, std::move(event));
 
-    if(node)
+    if (node)
       queue.push(node);
   }
 
   void expand_holding(
-      const std::size_t waypoint,
-      const NodePtr& parent_node,
-      SearchQueue& queue)
+    const std::size_t waypoint,
+    const NodePtr& parent_node,
+    SearchQueue& queue)
   {
     expand_delay(waypoint, parent_node, _context.holding_time, queue);
   }
@@ -1220,9 +1225,9 @@ struct DifferentialDriveExpander
   void expand(const NodePtr& parent_node, SearchQueue& queue)
   {
     const std::size_t parent_waypoint = *parent_node->waypoint;
-    if(parent_waypoint == _context.final_waypoint)
+    if (parent_waypoint == _context.final_waypoint)
     {
-      if(!_context.final_orientation)
+      if (!_context.final_orientation)
       {
         // We have already arrived at the solution, because the user does not
         // care about the final orientation.
@@ -1236,10 +1241,10 @@ struct DifferentialDriveExpander
       }
 
       const double final_orientation =
-          rmf_utils::wrap_to_pi(*_context.final_orientation);
+        rmf_utils::wrap_to_pi(*_context.final_orientation);
       const auto final_node =
-          expand_rotation(parent_node, final_orientation);
-      if(final_node)
+        expand_rotation(parent_node, final_orientation);
+      if (final_node)
       {
         queue.push(final_node);
         return;
@@ -1254,7 +1259,7 @@ struct DifferentialDriveExpander
     }
 
     const std::vector<std::size_t>& lanes =
-        _context.graph.lanes_from[parent_waypoint];
+      _context.graph.lanes_from[parent_waypoint];
 
     for (const std::size_t l : lanes)
       expand_lane(parent_node, l, queue);
@@ -1287,7 +1292,7 @@ public:
     _traits(_config.vehicle_traits()),
     _profile(_traits.profile()),
     _interpolate(agv::Interpolate::Options::Implementation::get(
-                   _config.interpolation()))
+        _config.interpolation()))
   {
     // Do nothing
   }
@@ -1301,45 +1306,45 @@ public:
   {
     const auto& newer = static_cast<const DifferentialDriveCache&>(newer_cache);
 
-    for(const auto& h : newer._heuristics)
+    for (const auto& h : newer._heuristics)
     {
 
       auto& heuristic = _heuristics.insert(
-            std::make_pair(h.first, Heuristic{})).first->second;
+        std::make_pair(h.first, Heuristic{})).first->second;
 
       heuristic.update(h.second);
     }
   }
 
   rmf_utils::optional<Result> plan(
-      const std::vector<agv::Planner::Start>& starts,
-      agv::Planner::Goal goal,
-      agv::Planner::Options options) final
+    const std::vector<agv::Planner::Start>& starts,
+    agv::Planner::Goal goal,
+    agv::Planner::Options options) final
   {
     if (starts.empty())
       return rmf_utils::nullopt;
 
     const std::size_t goal_waypoint = goal.waypoint();
     Heuristic& h = _heuristics.insert(
-          std::make_pair(goal_waypoint, Heuristic{})).first->second;
+      std::make_pair(goal_waypoint, Heuristic{})).first->second;
     const bool* const interrupt_flag = options.interrupt_flag();
 
     const NodePtr solution = search<DifferentialDriveExpander>(
-          DifferentialDriveExpander::Context{
-            _graph,
-            _traits,
-            _profile,
-            options.minimum_holding_time(),
-            _interpolate,
-            options.validator().get(),
-            goal_waypoint,
-            goal.orientation(),
-            starts.front().time(),
-            interrupt_flag,
-            h
-          },
-          DifferentialDriveExpander::InitialNodeArgs{starts},
-          interrupt_flag);
+      DifferentialDriveExpander::Context{
+        _graph,
+        _traits,
+        _profile,
+        options.minimum_holding_time(),
+        _interpolate,
+        options.validator().get(),
+        goal_waypoint,
+        goal.orientation(),
+        starts.front().time(),
+        interrupt_flag,
+        h
+      },
+      DifferentialDriveExpander::InitialNodeArgs{starts},
+      interrupt_flag);
 
     if (!solution)
       return rmf_utils::nullopt;
@@ -1349,11 +1354,11 @@ public:
     auto start_index = find_start_index(solution);
 
     return Result{
-        std::move(routes),
-        std::move(waypoints),
-        starts[start_index],
-        std::move(goal),
-        std::move(options)
+      std::move(routes),
+      std::move(waypoints),
+      starts[start_index],
+      std::move(goal),
+      std::move(options)
     };
   }
 
@@ -1381,15 +1386,17 @@ private:
 //==============================================================================
 CacheManager make_cache(agv::Planner::Configuration config)
 {
-  if(config.vehicle_traits().get_differential())
+  if (config.vehicle_traits().get_differential())
   {
     return CacheManager(std::make_shared<DifferentialDriveCache>(
-                          std::move(config)));
+          std::move(config)));
   }
 
+  // *INDENT-OFF*
   throw std::runtime_error(
-        "[rmf_traffic::agv::Planner] Planning utilities are currently only "
-        "implemented for AGVs that use a differential drive.");
+    "[rmf_traffic::agv::Planner] Planning utilities are currently only "
+    "implemented for AGVs that use a differential drive.");
+  // *INDENT-ON*
 }
 
 } // namespace planning

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.hpp
@@ -62,11 +62,11 @@ public:
   virtual void update(const Cache& other) = 0;
 
   virtual rmf_utils::optional<Result> plan(
-      const std::vector<agv::Planner::Start>& starts,
-      agv::Planner::Goal goal,
-      agv::Planner::Options options) = 0;
+    const std::vector<agv::Planner::Start>& starts,
+    agv::Planner::Goal goal,
+    agv::Planner::Options options) = 0;
 
-  virtual const agv::Planner::Configuration& get_configuration() const =0;
+  virtual const agv::Planner::Configuration& get_configuration() const = 0;
 
   virtual ~Cache() = default;
 };
@@ -85,9 +85,9 @@ public:
   CacheHandle(CacheHandle&&) = default;
 
   rmf_utils::optional<Result> plan(
-      const std::vector<agv::Planner::Start>& starts,
-      agv::Planner::Goal goal,
-      agv::Planner::Options options);
+    const std::vector<agv::Planner::Start>& starts,
+    agv::Planner::Goal goal,
+    agv::Planner::Options options);
 
   ~CacheHandle();
 

--- a/rmf_traffic/src/rmf_traffic/debug_Trajectory.hpp
+++ b/rmf_traffic/src/rmf_traffic/debug_Trajectory.hpp
@@ -27,7 +27,7 @@ class Trajectory::Debug
 public:
 
   static bool check_iterator_time_consistency(
-      const Trajectory& trajectory, bool print_inconsistency);
+    const Trajectory& trajectory, bool print_inconsistency);
 };
 
 

--- a/rmf_traffic/src/rmf_traffic/detail/internal_bidirectional_iterator.hpp
+++ b/rmf_traffic/src/rmf_traffic/detail/internal_bidirectional_iterator.hpp
@@ -74,7 +74,7 @@ auto bidirectional_iterator<E, I, F>::operator--(int) -> bidirectional_iterator
 //==============================================================================
 template<typename E, typename I, typename F>
 bool bidirectional_iterator<E, I, F>::operator==(
-    const bidirectional_iterator& other) const
+  const bidirectional_iterator& other) const
 {
   return _pimpl->iter == other._pimpl->iter;
 }
@@ -82,7 +82,7 @@ bool bidirectional_iterator<E, I, F>::operator==(
 //==============================================================================
 template<typename E, typename I, typename F>
 bool bidirectional_iterator<E, I, F>::operator!=(
-    const bidirectional_iterator& other) const
+  const bidirectional_iterator& other) const
 {
   return _pimpl->iter != other._pimpl->iter;
 }
@@ -97,8 +97,8 @@ bidirectional_iterator<E, I, F>::bidirectional_iterator()
 //==============================================================================
 template<typename E, typename I, typename F>
 bidirectional_iterator<E, I, F>::bidirectional_iterator(I impl)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{std::move(impl)}))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{std::move(impl)}))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/detail/internal_forward_iterator.hpp
+++ b/rmf_traffic/src/rmf_traffic/detail/internal_forward_iterator.hpp
@@ -57,7 +57,7 @@ auto forward_iterator<E, I, F>::operator++(int) -> forward_iterator
 //==============================================================================
 template<typename E, typename I, typename F>
 bool forward_iterator<E, I, F>::operator==(
-    const forward_iterator& other) const
+  const forward_iterator& other) const
 {
   return _pimpl->iter == other._pimpl->iter;
 }
@@ -65,7 +65,7 @@ bool forward_iterator<E, I, F>::operator==(
 //==============================================================================
 template<typename E, typename I, typename F>
 bool forward_iterator<E, I, F>::operator!=(
-    const forward_iterator& other) const
+  const forward_iterator& other) const
 {
   return _pimpl->iter != other._pimpl->iter;
 }
@@ -80,8 +80,8 @@ forward_iterator<E, I, F>::forward_iterator()
 //==============================================================================
 template<typename E, typename I, typename F>
 forward_iterator<E, I, F>::forward_iterator(I impl)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{std::move(impl)}))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{std::move(impl)}))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/geometry/Box.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Box.cpp
@@ -30,8 +30,8 @@ class BoxInternal : public Shape::Internal
 public:
 
   BoxInternal(double x, double y)
-    : _x(x),
-      _y(y)
+  : _x(x),
+    _y(y)
   {
     // Do nothing
   }
@@ -49,15 +49,15 @@ public:
 
 //==============================================================================
 Box::Box(double x_length, double y_length)
-  : ConvexShape(std::make_unique<BoxInternal>(x_length, y_length))
+: ConvexShape(std::make_unique<BoxInternal>(x_length, y_length))
 {
   // Do nothing
 }
 
 //==============================================================================
 Box::Box(const Box& other)
-  : ConvexShape(std::make_unique<BoxInternal>(
-                  static_cast<const BoxInternal&>(*other._get_internal())))
+: ConvexShape(std::make_unique<BoxInternal>(
+      static_cast<const BoxInternal&>(*other._get_internal())))
 {
   // Do nothing
 }
@@ -66,7 +66,7 @@ Box::Box(const Box& other)
 Box& Box::operator=(const Box& other)
 {
   static_cast<BoxInternal&>(*_get_internal()) =
-      static_cast<const BoxInternal&>(*other._get_internal());
+    static_cast<const BoxInternal&>(*other._get_internal());
 
   return *this;
 }
@@ -99,22 +99,22 @@ double Box::get_y_length() const
 FinalShape Box::finalize() const
 {
   double characteristic_length = 0.5 * std::sqrt(
-      this->get_x_length() * this->get_x_length()
-      + this->get_y_length() * this->get_y_length());
+    this->get_x_length() * this->get_x_length()
+    + this->get_y_length() * this->get_y_length());
   return FinalShape::Implementation::make_final_shape(
-        rmf_utils::make_derived_impl<const Shape, const Box>(*this),
-        _get_internal()->make_fcl(), characteristic_length);
+    rmf_utils::make_derived_impl<const Shape, const Box>(*this),
+    _get_internal()->make_fcl(), characteristic_length);
 }
 
 //==============================================================================
 FinalConvexShape Box::finalize_convex() const
 {
   double characteristic_length = 0.5 * std::sqrt(
-      this->get_x_length() * this->get_x_length()
-      + this->get_y_length() * this->get_y_length());
+    this->get_x_length() * this->get_x_length()
+    + this->get_y_length() * this->get_y_length());
   return FinalConvexShape::Implementation::make_final_shape(
-        rmf_utils::make_derived_impl<const Shape, const Box>(*this),
-        _get_internal()->make_fcl(), characteristic_length);
+    rmf_utils::make_derived_impl<const Shape, const Box>(*this),
+    _get_internal()->make_fcl(), characteristic_length);
 }
 
 } // namespace geometry

--- a/rmf_traffic/src/rmf_traffic/geometry/Circle.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Circle.cpp
@@ -30,7 +30,7 @@ class CircleInternal : public Shape::Internal
 public:
 
   CircleInternal(double radius)
-    : _radius(radius)
+  : _radius(radius)
   {
     // Do nothing
   }
@@ -45,15 +45,15 @@ public:
 
 //==============================================================================
 Circle::Circle(double radius)
-  : ConvexShape(std::make_unique<CircleInternal>(radius))
+: ConvexShape(std::make_unique<CircleInternal>(radius))
 {
   // Do nothing
 }
 
 //==============================================================================
 Circle::Circle(const Circle& other)
-  : ConvexShape(std::make_unique<CircleInternal>(
-                  static_cast<const CircleInternal&>(*other._get_internal())))
+: ConvexShape(std::make_unique<CircleInternal>(
+      static_cast<const CircleInternal&>(*other._get_internal())))
 {
   // Do nothing
 }
@@ -62,7 +62,7 @@ Circle::Circle(const Circle& other)
 Circle& Circle::operator=(const Circle& other)
 {
   static_cast<CircleInternal&>(*_get_internal()) =
-      static_cast<const CircleInternal&>(*other._get_internal());
+    static_cast<const CircleInternal&>(*other._get_internal());
 
   return *this;
 }
@@ -83,16 +83,16 @@ double Circle::get_radius() const
 FinalShape Circle::finalize() const
 {
   return FinalShape::Implementation::make_final_shape(
-        rmf_utils::make_derived_impl<const Shape, const Circle>(*this),
-        _get_internal()->make_fcl(), this->get_radius());
+    rmf_utils::make_derived_impl<const Shape, const Circle>(*this),
+    _get_internal()->make_fcl(), this->get_radius());
 }
 
 //==============================================================================
 FinalConvexShape Circle::finalize_convex() const
 {
   return FinalConvexShape::Implementation::make_final_shape(
-        rmf_utils::make_derived_impl<const Shape, const Circle>(*this),
-        _get_internal()->make_fcl(), this->get_radius());
+    rmf_utils::make_derived_impl<const Shape, const Circle>(*this),
+    _get_internal()->make_fcl(), this->get_radius());
 }
 
 } // namespace geometry

--- a/rmf_traffic/src/rmf_traffic/geometry/ConvexShape.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/ConvexShape.cpp
@@ -24,7 +24,7 @@ namespace geometry {
 
 //==============================================================================
 ConvexShape::ConvexShape(std::unique_ptr<Shape::Internal> internal)
-  : Shape(std::move(internal))
+: Shape(std::move(internal))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/geometry/Shape.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Shape.cpp
@@ -36,7 +36,7 @@ const Shape::Internal* Shape::_get_internal() const
 
 //==============================================================================
 Shape::Shape(std::unique_ptr<Internal> internal)
-  : _internal(std::move(internal))
+: _internal(std::move(internal))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/geometry/ShapeInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/ShapeInternal.hpp
@@ -61,15 +61,15 @@ public:
   }
 
   static FinalShape make_final_shape(
-      rmf_utils::impl_ptr<const Shape> shape,
-      CollisionGeometries collisions,
-      double characteristic_length)
+    rmf_utils::impl_ptr<const Shape> shape,
+    CollisionGeometries collisions,
+    double characteristic_length)
   {
     FinalShape result;
     result._pimpl = rmf_utils::make_impl<Implementation>(
-          Implementation{std::move(shape),
-          std::move(collisions),
-          std::move(characteristic_length)});
+      Implementation{std::move(shape),
+        std::move(collisions),
+        std::move(characteristic_length)});
     return result;
   }
 
@@ -86,15 +86,15 @@ public:
   }
 
   static FinalConvexShape make_final_shape(
-      rmf_utils::impl_ptr<const Shape> shape,
-      CollisionGeometries collisions,
-      double characteristic_length)
+    rmf_utils::impl_ptr<const Shape> shape,
+    CollisionGeometries collisions,
+    double characteristic_length)
   {
     FinalConvexShape result;
     result._pimpl = rmf_utils::make_impl<FinalShape::Implementation>(
-          FinalShape::Implementation{std::move(shape),
-          std::move(collisions),
-          characteristic_length});
+      FinalShape::Implementation{std::move(shape),
+        std::move(collisions),
+        characteristic_length});
     return result;
   }
 };

--- a/rmf_traffic/src/rmf_traffic/geometry/SimplePolygon.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/SimplePolygon.cpp
@@ -39,29 +39,29 @@ std::string eigen_to_string(const T& obj)
 
 //==============================================================================
 std::string generate_self_intersection_polygon_message(
-    const SimplePolygon::Intersections& intersections)
+  const SimplePolygon::Intersections& intersections)
 {
   std::string output = "[rmf_traffic::Polygon] Invalid polygon "
-      "requested: " + std::to_string(intersections.size())
-      + " pair(s) of edges intersect. See the following pairs where waypoint A "
-      "intersects waypoint B:"
-      + "\n * (index A0) <vertex A0> -> (index A1) <vertex A1>"
-      + "\n   (index B0) <vertex B0> -> (index B1) <vertex B1>\n";
+    "requested: " + std::to_string(intersections.size())
+    + " pair(s) of edges intersect. See the following pairs where waypoint A "
+    "intersects waypoint B:"
+    + "\n * (index A0) <vertex A0> -> (index A1) <vertex A1>"
+    + "\n   (index B0) <vertex B0> -> (index B1) <vertex B1>\n";
 
-  for(const SimplePolygon::IntersectingPair& pair : intersections)
+  for (const SimplePolygon::IntersectingPair& pair : intersections)
   {
-    for(std::size_t i=0; i < 2; ++i)
+    for (std::size_t i = 0; i < 2; ++i)
     {
-      if(i==0)
+      if (i == 0)
         output += " * ";
       else
         output += "   ";
 
       output += "(" +
-          std::to_string(pair[i].indices[0]) + ") <" +
-          eigen_to_string(pair[i].points[0]) + "> | (" +
-          std::to_string(pair[i].indices[1]) + ") <" +
-          eigen_to_string(pair[i].points[1]) + ">\n";
+        std::to_string(pair[i].indices[0]) + ") <" +
+        eigen_to_string(pair[i].points[0]) + "> | (" +
+        std::to_string(pair[i].indices[1]) + ") <" +
+        eigen_to_string(pair[i].points[1]) + ">\n";
     }
   }
 
@@ -70,18 +70,18 @@ std::string generate_self_intersection_polygon_message(
 
 //==============================================================================
 std::string generate_insufficient_vertices_polygon_message(
-    const std::size_t num_vertices)
+  const std::size_t num_vertices)
 {
   return "[rmf_traffic::Polygon] Invalid polygon requested: "
-      + std::to_string(num_vertices) + " vertices specified, but at least 3 "
-      + "vertices are required for a polygon.";
+    + std::to_string(num_vertices) + " vertices specified, but at least 3 "
+    + "vertices are required for a polygon.";
 }
 
 //==============================================================================
 bool compute_intersection(
-    const SimplePolygon::EdgeInfo& edge_a,
-    const SimplePolygon::EdgeInfo& edge_b,
-    Eigen::Vector2d* intersection_point = nullptr)
+  const SimplePolygon::EdgeInfo& edge_a,
+  const SimplePolygon::EdgeInfo& edge_b,
+  Eigen::Vector2d* intersection_point = nullptr)
 {
   // Using as a reference: http://www.cs.swan.ac.uk/~cssimon/line_intersection.html
 
@@ -91,28 +91,28 @@ bool compute_intersection(
   const Eigen::Vector2d p_b1 = edge_b.points[1];
 
   Eigen::Matrix2d M;
-  M.block<2,1>(0,0) =   p_b1 - p_b0;
-  M.block<2,1>(0,1) = -(p_a1 - p_a0);
+  M.block<2, 1>(0, 0) = p_b1 - p_b0;
+  M.block<2, 1>(0, 1) = -(p_a1 - p_a0);
 
   const Eigen::Vector2d c = p_a0 - p_b0;
 
   // Before trying to solve the system, let's check if the edges are very
   // close to being parallel and quit early if they are.
-  if(std::abs(M.determinant()) < 1e-8)
+  if (std::abs(M.determinant()) < 1e-8)
     return false;
 
   const Eigen::Vector2d t = M.colPivHouseholderQr().solve(c);
-  for(int i=0; i < 2; ++i)
+  for (int i = 0; i < 2; ++i)
   {
     // If the "time" value is outside the range of [0.0, 1.0] then it is outside
     // the line waypoint that it's associated to, so we can disregard the alleged
     // intersection.
     const double t_i = t[i];
-    if(t_i < 0.0 || 1.0 < t_i)
+    if (t_i < 0.0 || 1.0 < t_i)
       return false;
   }
 
-  if(intersection_point)
+  if (intersection_point)
     *intersection_point = p_a0 + t[0]*(p_a1 - p_a0);
 
   return true;
@@ -131,28 +131,28 @@ using Subpolygon = std::vector<AliasVertex>;
 
 //==============================================================================
 bool is_polygon_ear(
-    const Subpolygon& polygon,
-    const Triangle& triangle)
+  const Subpolygon& polygon,
+  const Triangle& triangle)
 {
   using EdgeInfo = SimplePolygon::EdgeInfo;
 
   const std::size_t a0 = triangle[0];
   const std::size_t a1 = triangle[2]; // yes, [2] is intended
   const EdgeInfo edge_a =
-      EdgeInfo{{a0, a1}, {polygon[a0].point, polygon[a1].point}};
+    EdgeInfo{{a0, a1}, {polygon[a0].point, polygon[a1].point}};
 
-  for(std::size_t b0=0; b0 < polygon.size(); ++b0)
+  for (std::size_t b0 = 0; b0 < polygon.size(); ++b0)
   {
-    const std::size_t b1 = (b0 == polygon.size()-1)? 0 : b0+1;
+    const std::size_t b1 = (b0 == polygon.size()-1) ? 0 : b0+1;
 
     // Ignore any edges that are in contact with the edge we care about.
-    if(b0 == a0 || b0 == a1 || b1 == a0 || b1 == a1)
+    if (b0 == a0 || b0 == a1 || b1 == a0 || b1 == a1)
       continue;
 
     const EdgeInfo edge_b =
-        EdgeInfo{{b0, b1}, {polygon[b0].point, polygon[b1].point}};
+      EdgeInfo{{b0, b1}, {polygon[b0].point, polygon[b1].point}};
 
-    if(compute_intersection(edge_a, edge_b))
+    if (compute_intersection(edge_a, edge_b))
       return false;
   }
 
@@ -161,8 +161,8 @@ bool is_polygon_ear(
 
 //==============================================================================
 std::size_t find_deepest_reflex_point(
-    const Subpolygon& polygon,
-    const Triangle& triangle)
+  const Subpolygon& polygon,
+  const Triangle& triangle)
 {
   // Reference: https://en.wikipedia.org/wiki/Barycentric_coordinate_system#Barycentric_coordinates_on_triangles
   // Simpler form: https://stackoverflow.com/a/2049712
@@ -171,12 +171,13 @@ std::size_t find_deepest_reflex_point(
   const Eigen::Vector2d p_preceding = polygon[triangle[0]].point;
   const Eigen::Vector2d p_successive = polygon[triangle[2]].point;
 
-  const Eigen::Matrix2d M_inv = [&]() {
-    Eigen::Matrix2d output;
-    output.block<2,1>(0,0) = p_preceding - p_pivot;
-    output.block<2,1>(0,0) = p_successive - p_pivot;
-    return output.inverse();
-  }();
+  const Eigen::Matrix2d M_inv = [&]()
+    {
+      Eigen::Matrix2d output;
+      output.block<2, 1>(0, 0) = p_preceding - p_pivot;
+      output.block<2, 1>(0, 0) = p_successive - p_pivot;
+      return output.inverse();
+    } ();
 
   const Eigen::Vector2d diagonal = (p_successive - p_preceding).normalized();
 
@@ -184,10 +185,10 @@ std::size_t find_deepest_reflex_point(
   // would be absurd.
   std::size_t deepest_index = static_cast<std::size_t>(-1);
   double deepest_value = -std::numeric_limits<double>::infinity();
-  for(std::size_t i=0; i < polygon.size(); ++i)
+  for (std::size_t i = 0; i < polygon.size(); ++i)
   {
     // Skip any indices that are part of the triangle
-    if(i == triangle[0] || i == triangle[1] || i == triangle[2])
+    if (i == triangle[0] || i == triangle[1] || i == triangle[2])
       continue;
 
     const Eigen::Vector2d p = polygon[i].point;
@@ -195,7 +196,7 @@ std::size_t find_deepest_reflex_point(
     // Check if the point is inside the triangle, and skip to the next index
     // if it is not.
     const Eigen::Vector2d s = M_inv * (p - p_pivot);
-    if(s[0] + s[1] > 1.0 || s[0] < 0.0 || s[1] < 0.0)
+    if (s[0] + s[1] > 1.0 || s[0] < 0.0 || s[1] < 0.0)
       continue;
 
     // If the point is inside the triangle, then compute its depth (distance
@@ -204,7 +205,7 @@ std::size_t find_deepest_reflex_point(
     const double depth = (p_rel - diagonal.dot(p_rel) * diagonal).norm();
 
     // Compare the depth to the others, and find the deepest
-    if(depth > deepest_value)
+    if (depth > deepest_value)
     {
       deepest_index = i;
       deepest_value = depth;
@@ -216,8 +217,8 @@ std::size_t find_deepest_reflex_point(
 
 //==============================================================================
 std::array<Subpolygon, 2> split_subpolygon(
-    const Subpolygon& original,
-    const std::array<std::size_t, 2>& edge)
+  const Subpolygon& original,
+  const std::array<std::size_t, 2>& edge)
 {
   std::array<Subpolygon, 2> output;
 
@@ -225,10 +226,10 @@ std::array<Subpolygon, 2> split_subpolygon(
   const std::size_t split_end = std::max(edge[0], edge[1]);
 
   Subpolygon& output_0 = output[0];
-  for(std::size_t i=0; i < original.size(); ++i)
+  for (std::size_t i = 0; i < original.size(); ++i)
   {
     output_0.push_back(original[i]);
-    if(i == split_start)
+    if (i == split_start)
     {
       // When we reach the split, just jump the value of i to the index that
       // comes before the endpoint of the split. Then on the next iteration of
@@ -238,7 +239,7 @@ std::array<Subpolygon, 2> split_subpolygon(
   }
 
   Subpolygon& output_1 = output[1];
-  for(std::size_t i = split_start; i <= split_end; ++i)
+  for (std::size_t i = split_start; i <= split_end; ++i)
     output_1.push_back(original[i]);
 
   return output;
@@ -246,52 +247,53 @@ std::array<Subpolygon, 2> split_subpolygon(
 
 //==============================================================================
 Triangle get_original_indices(
-    const Subpolygon& polygon,
-    const Triangle& triangle)
+  const Subpolygon& polygon,
+  const Triangle& triangle)
 {
   return Triangle{
-      polygon[triangle[0]].original_index,
-      polygon[triangle[1]].original_index,
-      polygon[triangle[2]].original_index
+    polygon[triangle[0]].original_index,
+    polygon[triangle[1]].original_index,
+    polygon[triangle[2]].original_index
   };
 }
 
 //==============================================================================
 std::vector<Triangle> decompose_polygon(
-    const std::vector<Eigen::Vector2d>& polygon)
+  const std::vector<Eigen::Vector2d>& polygon)
 {
   std::vector<Subpolygon> subpolygon_queue;
 
   // Creat the initial sub-polygon to analyze
-  subpolygon_queue.emplace_back([&polygon]() -> Subpolygon
-  {
-    Subpolygon sp;
-    for(std::size_t i=0; i < polygon.size(); ++i)
-      sp.emplace_back(AliasVertex{i, polygon[i]});
-
-    if( (sp.back().point - sp.front().point).norm() < 1e-8 )
+  subpolygon_queue.emplace_back(
+    [&polygon]() -> Subpolygon
     {
-      // If the first and last point are very very close, we will effective snap
-      // them together by deleting the last one.
-      sp.pop_back();
-    }
+      Subpolygon sp;
+      for (std::size_t i = 0; i < polygon.size(); ++i)
+        sp.emplace_back(AliasVertex{i, polygon[i]});
 
-    return sp;
-  }());
+      if ( (sp.back().point - sp.front().point).norm() < 1e-8)
+      {
+        // If the first and last point are very very close, we will effective snap
+        // them together by deleting the last one.
+        sp.pop_back();
+      }
+
+      return sp;
+    } ());
 
   std::vector<Triangle> triangles;
-  while(!subpolygon_queue.empty())
+  while (!subpolygon_queue.empty())
   {
     Subpolygon next_polygon = subpolygon_queue.back();
     subpolygon_queue.pop_back();
 
     const std::size_t N = next_polygon.size();
-    if(N == 3)
+    if (N == 3)
     {
       triangles.push_back(get_original_indices(next_polygon, {0, 1, 2}));
       continue;
     }
-    else if(N < 3)
+    else if (N < 3)
     {
       std::cerr << "[rmf_traffic::geometry::decompose_polygon] "
                 << "A subpolygon has an incorrect number of vertices: " << N
@@ -302,7 +304,7 @@ std::vector<Triangle> decompose_polygon(
 
     const std::size_t pivot_point = N-2;
     const Triangle next_triangle = {pivot_point-1, pivot_point, pivot_point+1};
-    if(is_polygon_ear(next_polygon, next_triangle))
+    if (is_polygon_ear(next_polygon, next_triangle))
     {
       // If the triangle is an ear (not intersected by any other lines of the
       // polygon), then we can just snip it off.
@@ -324,12 +326,12 @@ std::vector<Triangle> decompose_polygon(
     // computation of is_polygon_ear(~) and using that to narrow down which
     // vertices to look at when computing the deepest reflext point.
     const std::size_t reflex_point =
-        find_deepest_reflex_point(next_polygon, next_triangle);
+      find_deepest_reflex_point(next_polygon, next_triangle);
 
     const auto new_subpolygons = split_subpolygon(
-          next_polygon, {pivot_point, reflex_point});
+      next_polygon, {pivot_point, reflex_point});
 
-    for(auto&& new_subpolygon : new_subpolygons)
+    for (auto&& new_subpolygon : new_subpolygons)
       subpolygon_queue.emplace_back(std::move(new_subpolygon));
   }
 
@@ -356,13 +358,13 @@ bool is_polygon_convex(const std::vector<Eigen::Vector2d>& polygon)
   const bool must_be_ccw = cross_product_2D(e0, e1) > 0.0;
 
   Eigen::Vector2d e_previous = e1;
-  for(std::size_t i=2; i < polygon.size(); ++i)
+  for (std::size_t i = 2; i < polygon.size(); ++i)
   {
-    const std::size_t i_next = i+1==polygon.size()? 0 : i+1;
+    const std::size_t i_next = i+1 == polygon.size() ? 0 : i+1;
     const Eigen::Vector2d ei = polygon[i_next] - polygon[i];
 
     const bool is_ccw = cross_product_2D(e_previous, ei) > 0.0;
-    if(is_ccw != must_be_ccw)
+    if (is_ccw != must_be_ccw)
       return false;
 
     e_previous = ei;
@@ -377,21 +379,21 @@ class ConvexWrapper : public fcl::Convex
 public:
 
   ConvexWrapper(std::unique_ptr<fcl::Vec3f[]> points_, int num_points_)
-    : fcl::Convex(nullptr, nullptr, 0, points_.get(), num_points_, nullptr),
-      point_storage(std::move(points_))
+  : fcl::Convex(nullptr, nullptr, 0, points_.get(), num_points_, nullptr),
+    point_storage(std::move(points_))
   {
     // Do nothing
   }
 
   static std::shared_ptr<fcl::Convex> make(
-      const std::vector<Eigen::Vector2d>& points)
+    const std::vector<Eigen::Vector2d>& points)
   {
     // Create an array with double the points, because we need to place the
     // points at both ground level and ceiling level.
     std::unique_ptr<fcl::Vec3f[]> fcl_points =
-        std::make_unique<fcl::Vec3f[]>(2*points.size());
+      std::make_unique<fcl::Vec3f[]>(2*points.size());
 
-    for(std::size_t i=0; i < points.size(); ++i)
+    for (std::size_t i = 0; i < points.size(); ++i)
     {
       const Eigen::Vector2d& p = points[i];
       fcl_points[2*i] = fcl::Vec3f(p[0], p[1], 0.0);
@@ -399,7 +401,7 @@ public:
     }
 
     return std::make_shared<ConvexWrapper>(
-          std::move(fcl_points), 2*points.size());
+      std::move(fcl_points), 2*points.size());
   }
 
   std::unique_ptr<fcl::Vec3f[]> point_storage;
@@ -408,14 +410,14 @@ public:
 
 //==============================================================================
 std::shared_ptr<fcl::Convex> make_convex(
-    const std::vector<Eigen::Vector2d>& polygon)
+  const std::vector<Eigen::Vector2d>& polygon)
 {
   return ConvexWrapper::make(polygon);
 }
 
 //==============================================================================
 std::vector<std::shared_ptr<fcl::Convex>> make_triangulation(
-    const std::vector<Eigen::Vector2d>& polygon)
+  const std::vector<Eigen::Vector2d>& polygon)
 {
   const std::vector<Triangle> triangles = decompose_polygon(polygon);
 
@@ -423,10 +425,10 @@ std::vector<std::shared_ptr<fcl::Convex>> make_triangulation(
 
   std::vector<Eigen::Vector2d> points;
   points.reserve(3);
-  for(const Triangle& triangle : triangles)
+  for (const Triangle& triangle : triangles)
   {
     points.clear();
-    for(const std::size_t index : triangle)
+    for (const std::size_t index : triangle)
       points.push_back(polygon[index]);
 
     triangulation.push_back(ConvexWrapper::make(points));
@@ -439,20 +441,20 @@ std::vector<std::shared_ptr<fcl::Convex>> make_triangulation(
 
 //==============================================================================
 InvalidSimplePolygonException::InvalidSimplePolygonException(
-    SimplePolygon::Intersections intersections,
-    const std::size_t num_vertices)
-  : intersecting_pairs(std::move(intersections)),
-    num_vertices(num_vertices),
-    _what(generate_self_intersection_polygon_message(intersecting_pairs))
+  SimplePolygon::Intersections intersections,
+  const std::size_t num_vertices)
+: intersecting_pairs(std::move(intersections)),
+  num_vertices(num_vertices),
+  _what(generate_self_intersection_polygon_message(intersecting_pairs))
 {
   // Do nothing
 }
 
 //==============================================================================
 InvalidSimplePolygonException::InvalidSimplePolygonException(
-    const std::size_t num_vertices)
-  : num_vertices(num_vertices),
-    _what(generate_insufficient_vertices_polygon_message(num_vertices))
+  const std::size_t num_vertices)
+: num_vertices(num_vertices),
+  _what(generate_insufficient_vertices_polygon_message(num_vertices))
 {
   // Do nothing
 }
@@ -473,25 +475,25 @@ public:
   using Intersections = SimplePolygon::Intersections;
 
   SimplePolygonInternal(std::vector<Eigen::Vector2d> points)
-    : _points(points)
+  : _points(points)
   {
     // Do nothing
   }
 
   bool check_self_intersections(Intersections* intersections) const
   {
-    if(intersections)
+    if (intersections)
       intersections->clear();
 
-    for(std::size_t a0=0; a0 < _points.size()-1; ++a0)
+    for (std::size_t a0 = 0; a0 < _points.size()-1; ++a0)
     {
       const std::size_t a1 = a0+1;
       const EdgeInfo edge_a = EdgeInfo{{a0, a1}, {_points[a0], _points[a1]}};
 
-      for(std::size_t b0=a0+2; b0 < _points.size(); ++b0)
+      for (std::size_t b0 = a0+2; b0 < _points.size(); ++b0)
       {
-        const std::size_t b1 = (b0 == _points.size()-1)? 0 : b0+1;
-        if(b1 == a0 || b1 == a1)
+        const std::size_t b1 = (b0 == _points.size()-1) ? 0 : b0+1;
+        if (b1 == a0 || b1 == a1)
         {
           // Skip this edge if it's in contact with edge A
           continue;
@@ -499,9 +501,9 @@ public:
 
         const EdgeInfo edge_b = EdgeInfo{{b0, b1}, {_points[b0], _points[b1]}};
 
-        if(compute_intersection(edge_a, edge_b))
+        if (compute_intersection(edge_a, edge_b))
         {
-          if(intersections)
+          if (intersections)
           {
             // If we have a non-null intersections argument, then the user is
             // asking to receive all intersections.
@@ -521,7 +523,7 @@ public:
     // If we had to collect all the intersections, then return false if the
     // collection of intersections is empty. Return true if there were any
     // intersections computed.
-    if(intersections)
+    if (intersections)
       return !intersections->empty();
 
     // If we did not collect the intersections, then return false here because
@@ -531,12 +533,15 @@ public:
 
   void except_on_invalid_polygon() const
   {
-    if(_points.size() < 3)
+    if (_points.size() < 3)
       throw InvalidSimplePolygonException(_points.size());
 
     Intersections intersections;
-    if(check_self_intersections(&intersections))
-      throw InvalidSimplePolygonException(std::move(intersections), _points.size());
+    // *INDENT-OFF*
+    if (check_self_intersections(&intersections))
+      throw InvalidSimplePolygonException(std::move(intersections),
+        _points.size());
+    // *INDENT-ON*
   }
 
   CollisionGeometries make_fcl() const final
@@ -544,7 +549,7 @@ public:
     except_on_invalid_polygon();
 
     CollisionGeometries shapes;
-    if(is_polygon_convex(_points))
+    if (is_polygon_convex(_points))
     {
       shapes.push_back(make_convex(_points));
     }
@@ -552,7 +557,7 @@ public:
     {
       const auto triangles = make_triangulation(_points);
       shapes.reserve(triangles.size());
-      for(auto&& triangle : triangles)
+      for (auto&& triangle : triangles)
         shapes.push_back(std::move(triangle));
     }
 
@@ -564,15 +569,15 @@ public:
 
 //==============================================================================
 SimplePolygon::SimplePolygon(std::vector<Eigen::Vector2d> points)
-  : Shape(std::make_unique<SimplePolygonInternal>(std::move(points)))
+: Shape(std::make_unique<SimplePolygonInternal>(std::move(points)))
 {
   // Do nothing
 }
 
 //==============================================================================
 SimplePolygon::SimplePolygon(const SimplePolygon& other)
-  : Shape(std::make_unique<SimplePolygonInternal>(
-            static_cast<const SimplePolygonInternal&>(*other._get_internal())))
+: Shape(std::make_unique<SimplePolygonInternal>(
+      static_cast<const SimplePolygonInternal&>(*other._get_internal())))
 {
   // Do nothing
 }
@@ -581,7 +586,7 @@ SimplePolygon::SimplePolygon(const SimplePolygon& other)
 SimplePolygon& SimplePolygon::operator=(const SimplePolygon& other)
 {
   static_cast<SimplePolygonInternal&>(*_get_internal()) =
-      static_cast<const SimplePolygonInternal&>(*other._get_internal());
+    static_cast<const SimplePolygonInternal&>(*other._get_internal());
 
   return *this;
 }
@@ -591,7 +596,7 @@ auto SimplePolygon::get_self_intersections() const -> Intersections
 {
   Intersections intersections;
   static_cast<const SimplePolygonInternal*>(_get_internal())
-      ->check_self_intersections(&intersections);
+  ->check_self_intersections(&intersections);
   return intersections;
 }
 
@@ -599,7 +604,7 @@ auto SimplePolygon::get_self_intersections() const -> Intersections
 bool SimplePolygon::has_self_intersections() const
 {
   return static_cast<const SimplePolygonInternal*>(_get_internal())
-      ->check_self_intersections(nullptr);
+    ->check_self_intersections(nullptr);
 }
 
 //==============================================================================
@@ -612,21 +617,21 @@ std::vector<Eigen::Vector2d> SimplePolygon::get_points() const
 std::size_t SimplePolygon::get_num_points() const
 {
   return static_cast<const SimplePolygonInternal*>(
-        _get_internal())->_points.size();
+    _get_internal())->_points.size();
 }
 
 //==============================================================================
 Eigen::Vector2d& SimplePolygon::get_point(const std::size_t index)
 {
   return static_cast<SimplePolygonInternal*>(
-        _get_internal())->_points.at(index);
+    _get_internal())->_points.at(index);
 }
 
 //==============================================================================
 const Eigen::Vector2d& SimplePolygon::get_point(const std::size_t index) const
 {
   return static_cast<const SimplePolygonInternal*>(
-        _get_internal())->_points.at(index);
+    _get_internal())->_points.at(index);
 }
 
 //==============================================================================
@@ -645,8 +650,8 @@ void SimplePolygon::add_point(const Eigen::Vector2d& p)
 
 //==============================================================================
 void SimplePolygon::insert_point(
-    const std::size_t index,
-    const Eigen::Vector2d& p)
+  const std::size_t index,
+  const Eigen::Vector2d& p)
 {
   auto& points = static_cast<SimplePolygonInternal*>(_get_internal())->_points;
   points.insert(points.begin()+index, p);
@@ -663,8 +668,8 @@ FinalShape SimplePolygon::finalize() const
       characteristic_length = distance;
   }
   return FinalShape::Implementation::make_final_shape(
-        rmf_utils::make_derived_impl<const Shape, const SimplePolygon>(*this),
-        _get_internal()->make_fcl(), characteristic_length);
+    rmf_utils::make_derived_impl<const Shape, const SimplePolygon>(*this),
+    _get_internal()->make_fcl(), characteristic_length);
 }
 
 } // namespace geometry

--- a/rmf_traffic/src/rmf_traffic/geometry/Space.cpp
+++ b/rmf_traffic/src/rmf_traffic/geometry/Space.cpp
@@ -32,14 +32,14 @@ public:
 
 //==============================================================================
 Space::Space(ConstFinalShapePtr shape, Eigen::Isometry2d tf)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{std::move(shape), std::move(tf)}))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{std::move(shape), std::move(tf)}))
 {
   // Do nothing
 }
 
 //==============================================================================
-const ConstFinalShapePtr &Space::get_shape() const
+const ConstFinalShapePtr& Space::get_shape() const
 {
   return _pimpl->shape;
 }

--- a/rmf_traffic/src/rmf_traffic/invalid_trajectory_error.hpp
+++ b/rmf_traffic/src/rmf_traffic/invalid_trajectory_error.hpp
@@ -30,27 +30,27 @@ public:
   std::string what;
 
   static invalid_trajectory_error make_segment_num_error(
-      std::size_t num_segments)
+    std::size_t num_segments)
   {
     invalid_trajectory_error error;
     error._pimpl->what = std::string()
-        + "[rmf_traffic::invalid_trajectory_error] Attempted to check a "
-        + "conflict with a Trajectory that has [" + std::to_string(num_segments)
-        + "] segments. This is not supported. Trajectories must have at least "
-        + "2 segments to check them for conflicts.";
+      + "[rmf_traffic::invalid_trajectory_error] Attempted to check a "
+      + "conflict with a Trajectory that has [" + std::to_string(num_segments)
+      + "] segments. This is not supported. Trajectories must have at least "
+      + "2 segments to check them for conflicts.";
     return error;
   }
 
   static invalid_trajectory_error make_missing_shape_error(
-      const Time time)
+    const Time time)
   {
     invalid_trajectory_error error;
     error._pimpl->what = std::string()
-        + "[rmf_traffic::invalid_trajectory_error] Attempting to check a "
-        + "conflict with a Trajectory that has no shape specified for the "
-        + "profile of its waypoint at time ["
-        + std::to_string(time.time_since_epoch().count())
-        + "ns]. This is not supported.";
+      + "[rmf_traffic::invalid_trajectory_error] Attempting to check a "
+      + "conflict with a Trajectory that has no shape specified for the "
+      + "profile of its waypoint at time ["
+      + std::to_string(time.time_since_epoch().count())
+      + "ns]. This is not supported.";
 
     return error;
   }

--- a/rmf_traffic/src/rmf_traffic/schedule/Change.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Change.cpp
@@ -24,9 +24,9 @@ namespace schedule {
 
 //==============================================================================
 rmf_utils::optional<Trajectory> apply_delay(
-    const Trajectory& old_trajectory,
-    Time from,
-    Duration delay)
+  const Trajectory& old_trajectory,
+  Time from,
+  Duration delay)
 {
   if (*old_trajectory.finish_time() < from)
     return rmf_utils::nullopt;
@@ -57,7 +57,7 @@ public:
 //==============================================================================
 Change::Add::Add(std::vector<Item> additions)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{std::move(additions)}))
+      Implementation{std::move(additions)}))
 {
   // Do nothing
 }
@@ -121,10 +121,10 @@ public:
 
 //==============================================================================
 Change::RegisterParticipant::RegisterParticipant(
-    ParticipantId id,
-    ParticipantDescription description)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{id, description}))
+  ParticipantId id,
+  ParticipantDescription description)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{id, description}))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/schedule/ChangeInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/ChangeInternal.hpp
@@ -37,9 +37,9 @@ public:
 
 //==============================================================================
 rmf_utils::optional<Trajectory> apply_delay(
-    const Trajectory& old_trajectory,
-    Time from,
-    Duration delay);
+  const Trajectory& old_trajectory,
+  Time from,
+  Duration delay);
 
 } // namespace schedule
 } // namespace rmf_traffic

--- a/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
@@ -42,8 +42,8 @@ Writer::Input deep_copy_input(Writer::Input input)
   for (const auto& item : input)
   {
     auto copy_item = Writer::Item{
-        item.id,
-        std::make_shared<Route>(*item.route)};
+      item.id,
+      std::make_shared<Route>(*item.route)};
 
     copy.emplace_back(std::move(copy_item));
   }
@@ -120,7 +120,7 @@ public:
     Version original_version;
   };
   using ParticipantUnregistrationVersion =
-      std::map<Version, RemoveParticipantInfo>;
+    std::map<Version, RemoveParticipantInfo>;
   ParticipantUnregistrationVersion remove_participant_version;
 
   using ParticipantRegistrationTime = std::map<Time, Version>;
@@ -138,8 +138,8 @@ public:
 
   using StagedChanges =
     std::unordered_map<
-      ParticipantId,
-      std::map<ItineraryVersion, Change>>;
+    ParticipantId,
+    std::map<ItineraryVersion, Change>>;
   StagedChanges staged_changes;
 
   std::unordered_set<ParticipantId> participant_ids;
@@ -166,8 +166,8 @@ public:
   /// that vector can be used to efficiently populate the route information,
   /// saving us the cost of a second map lookup later on.
   std::vector<RouteEntryPtr*> check_route_ids(
-      ParticipantState& state,
-      const Input& input)
+    ParticipantState& state,
+    const Input& input)
   {
     // NOTE(MXG): We store references to the values of the route entries,
     // because iterators to a std::unordered_map can be invalidated by
@@ -190,9 +190,11 @@ public:
       // this itinerary change.
       if (insertion.first->second)
       {
+        // *INDENT-OFF*
         throw std::runtime_error(
-              "[Database::set] New route ID [" + std::to_string(item.id)
-              + "] collides with one already in the database");
+          "[Database::set] New route ID [" + std::to_string(item.id)
+          + "] collides with one already in the database");
+        // *INDENT-ON*
       }
 
       entries.push_back(&insertion.first->second);
@@ -205,14 +207,14 @@ public:
   /// assumes that the items have already been fully validated and that there
   /// would be no negative side-effects to entering them.
   void insert_items(
-      ParticipantId participant,
-      ParticipantState& state,
-      const std::vector<RouteEntryPtr*>& entries,
-      const Input& input)
+    ParticipantId participant,
+    ParticipantState& state,
+    const std::vector<RouteEntryPtr*>& entries,
+    const Input& input)
   {
     assert(entries.size() == input.size());
 
-    for (std::size_t i=0; i < input.size(); ++i)
+    for (std::size_t i = 0; i < input.size(); ++i)
     {
       const auto& item = input[i];
       const RouteId route_id = item.id;
@@ -220,26 +222,26 @@ public:
 
       RouteEntryPtr& entry = *entries[i];
       entry = std::make_unique<RouteEntry>(
-            RouteEntry{
-              item.route,
-              participant,
-              route_id,
-              state.description,
-              nullptr,
-              schedule_version,
-              nullptr,
-              nullptr
-            });
+        RouteEntry{
+          item.route,
+          participant,
+          route_id,
+          state.description,
+          nullptr,
+          schedule_version,
+          nullptr,
+          nullptr
+        });
 
       timeline.insert(*entry);
     }
   }
 
   void apply_delay(
-      ParticipantId participant,
-      ParticipantState& state,
-      Time from,
-      Duration delay)
+    ParticipantId participant,
+    ParticipantState& state,
+    Time from,
+    Duration delay)
   {
     ParticipantStorage& storage = state.storage;
     for (const RouteId id : state.active_routes)
@@ -254,28 +256,28 @@ public:
         continue;
 
       auto new_route = std::make_shared<Route>(
-            entry->route->map(), std::move(*delayed));
+        entry->route->map(), std::move(*delayed));
 
       auto transition = std::make_unique<Transition>(
-            Transition{
-              Change::Delay::Implementation{from, delay},
-              std::move(entry)
-            });
+        Transition{
+          Change::Delay::Implementation{from, delay},
+          std::move(entry)
+        });
 
       // NOTE(MXG): The previous contents of entry have been moved into the
       // predecessor field of transition, so we are free to refill entry with
       // the newly created data.
       entry = std::make_unique<RouteEntry>(
-            RouteEntry{
-              std::move(new_route),
-              participant,
-              id,
-              state.description,
-              nullptr,
-              schedule_version,
-              std::move(transition),
-              nullptr
-            });
+        RouteEntry{
+          std::move(new_route),
+          participant,
+          id,
+          state.description,
+          nullptr,
+          schedule_version,
+          std::move(transition),
+          nullptr
+        });
 
       entry->transition->predecessor->successor = entry.get();
       timeline.insert(*entry);
@@ -283,9 +285,9 @@ public:
   }
 
   void erase_routes(
-      ParticipantId participant,
-      ParticipantState& state,
-      const std::unordered_set<RouteId>& routes)
+    ParticipantId participant,
+    ParticipantState& state,
+    const std::unordered_set<RouteId>& routes)
   {
     ParticipantStorage& storage = state.storage;
     for (const RouteId id : routes)
@@ -294,22 +296,22 @@ public:
       auto& entry = storage.at(id);
 
       auto transition = std::make_unique<Transition>(
-            Transition{
-              rmf_utils::nullopt,
-              std::move(entry)
-            });
+        Transition{
+          rmf_utils::nullopt,
+          std::move(entry)
+        });
 
       entry = std::make_unique<RouteEntry>(
-            RouteEntry{
-              nullptr,
-              participant,
-              id,
-              state.description,
-              nullptr,
-              schedule_version,
-              std::move(transition),
-              nullptr
-            });
+        RouteEntry{
+          nullptr,
+          participant,
+          id,
+          state.description,
+          nullptr,
+          schedule_version,
+          std::move(transition),
+          nullptr
+        });
 
       entry->transition->predecessor->successor = entry.get();
       timeline.insert(*entry);
@@ -337,10 +339,12 @@ public:
 
     } while (_next_participant_id != initial_suggestion);
 
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::Implementation::get_next_participant_id] There are no "
-          "remaining Participant ID values available. This should never happen."
-          " Please report this as a serious bug.");
+      "[Database::Implementation::get_next_participant_id] There are no "
+      "remaining Participant ID values available. This should never happen."
+      " Please report this as a serious bug.");
+    // *INDENT-ON*
   }
 
 private:
@@ -349,7 +353,7 @@ private:
 
 //==============================================================================
 std::size_t Database::Debug::current_entry_history_count(
-    const Database& database)
+  const Database& database)
 {
   std::size_t count = 0;
   for (const auto& p : database._pimpl->states)
@@ -360,15 +364,15 @@ std::size_t Database::Debug::current_entry_history_count(
 
 //==============================================================================
 std::size_t Database::Debug::current_removed_participant_count(
-    const Database& database)
+  const Database& database)
 {
   return database._pimpl->remove_participant_version.size();
 }
 
 //==============================================================================
 rmf_utils::optional<Writer::Input> Database::Debug::get_itinerary(
-    const Database& database,
-    const ParticipantId participant)
+  const Database& database,
+  const ParticipantId participant)
 {
   const auto state_it = database._pimpl->states.find(participant);
   if (state_it == database._pimpl->states.end())
@@ -387,18 +391,20 @@ rmf_utils::optional<Writer::Input> Database::Debug::get_itinerary(
 //==============================================================================
 
 void Database::set(
-    ParticipantId participant,
-    const Input& input,
-    ItineraryVersion version)
+  ParticipantId participant,
+  const Input& input,
+  ItineraryVersion version)
 {
   auto itinerary = deep_copy_input(input);
 
   const auto p_it = _pimpl->states.find(participant);
   if (p_it == _pimpl->states.end())
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::set] No participant with ID ["
-          + std::to_string(participant) + "]");
+      "[Database::set] No participant with ID ["
+      + std::to_string(participant) + "]");
+    // *INDENT-ON*
   }
 
   Implementation::ParticipantState& state = p_it->second;
@@ -412,12 +418,12 @@ void Database::set(
 
   if (auto ticket = state.tracker->check(version, true))
   {
-    ticket->set([=](){ this->set(participant, itinerary, version); });
+    ticket->set([=]() { this->set(participant, itinerary, version); });
     return;
   }
 
   std::vector<Implementation::RouteEntryPtr*> entries =
-      _pimpl->check_route_ids(state, itinerary);
+    _pimpl->check_route_ids(state, itinerary);
 
   //======== All validation is complete ===========
   ++_pimpl->schedule_version;
@@ -434,18 +440,20 @@ void Database::set(
 
 //==============================================================================
 void Database::extend(
-    ParticipantId participant,
-    const Input& input,
-    ItineraryVersion version)
+  ParticipantId participant,
+  const Input& input,
+  ItineraryVersion version)
 {
   auto routes = deep_copy_input(input);
 
   const auto p_it = _pimpl->states.find(participant);
   if (p_it == _pimpl->states.end())
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::extend] No participant with ID ["
-          + std::to_string(participant) + "]");
+      "[Database::extend] No participant with ID ["
+      + std::to_string(participant) + "]");
+    // *INDENT-ON*
   }
 
   Implementation::ParticipantState& state = p_it->second;
@@ -463,12 +471,12 @@ void Database::extend(
   {
     // If we got a ticket from the inconsistency tracker, then pass along a
     // callback to call this
-    ticket->set([=](){ this->extend(participant, routes, version); });
+    ticket->set([=]() { this->extend(participant, routes, version); });
     return;
   }
 
   std::vector<Implementation::RouteEntryPtr*> entries =
-      _pimpl->check_route_ids(state, routes);
+    _pimpl->check_route_ids(state, routes);
 
   //======== All validation is complete ===========
   ++_pimpl->schedule_version;
@@ -478,17 +486,19 @@ void Database::extend(
 
 //==============================================================================
 void Database::delay(
-    ParticipantId participant,
-    Time from,
-    Duration delay,
-    ItineraryVersion version)
+  ParticipantId participant,
+  Time from,
+  Duration delay,
+  ItineraryVersion version)
 {
   const auto p_it = _pimpl->states.find(participant);
   if (p_it == _pimpl->states.end())
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::delay] No participant with ID ["
-          + std::to_string(participant) + "]");
+      "[Database::delay] No participant with ID ["
+      + std::to_string(participant) + "]");
+    // *INDENT-ON*
   }
 
   Implementation::ParticipantState& state = p_it->second;
@@ -503,7 +513,7 @@ void Database::delay(
 
   if (auto ticket = state.tracker->check(version))
   {
-    ticket->set([=](){ this->delay(participant, from, delay, version); });
+    ticket->set([=]() { this->delay(participant, from, delay, version); });
     return;
   }
 
@@ -514,15 +524,17 @@ void Database::delay(
 
 //==============================================================================
 void Database::erase(
-    ParticipantId participant,
-    ItineraryVersion version)
+  ParticipantId participant,
+  ItineraryVersion version)
 {
   const auto p_it = _pimpl->states.find(participant);
   if (p_it == _pimpl->states.end())
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::erase] No participant with ID ["
-          + std::to_string(participant) + "]");
+      "[Database::erase] No participant with ID ["
+      + std::to_string(participant) + "]");
+    // *INDENT-ON*
   }
 
   Implementation::ParticipantState& state = p_it->second;
@@ -537,7 +549,7 @@ void Database::erase(
 
   if (auto ticket = state.tracker->check(version))
   {
-    ticket->set([=](){ this->erase(participant, version); });
+    ticket->set([=]() { this->erase(participant, version); });
     return;
   }
 
@@ -549,16 +561,18 @@ void Database::erase(
 
 //==============================================================================
 void Database::erase(
-    ParticipantId participant,
-    const std::vector<RouteId>& routes,
-    ItineraryVersion version)
+  ParticipantId participant,
+  const std::vector<RouteId>& routes,
+  ItineraryVersion version)
 {
   const auto p_it = _pimpl->states.find(participant);
   if (p_it == _pimpl->states.end())
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::erase] No participant with ID ["
-          + std::to_string(participant) + "]");
+      "[Database::erase] No participant with ID ["
+      + std::to_string(participant) + "]");
+    // *INDENT-ON*
   }
 
   Implementation::ParticipantState& state = p_it->second;
@@ -573,7 +587,7 @@ void Database::erase(
 
   if (auto ticket = state.tracker->check(version))
   {
-    ticket->set([=](){ this->erase(participant, routes, version); });
+    ticket->set([=]() { this->erase(participant, routes, version); });
     return;
   }
 
@@ -583,9 +597,11 @@ void Database::erase(
   {
     if (state.active_routes.count(id) == 0)
     {
+      // *INDENT-OFF*
       throw std::runtime_error(
-            "[Database::erase] The route with ID [" + std::to_string(id)
-            + "] is not active!");
+        "[Database::erase] The route with ID [" + std::to_string(id)
+        + "] is not active!");
+      // *INDENT-ON*
     }
 
     route_set.insert(id);
@@ -600,24 +616,24 @@ void Database::erase(
 
 //==============================================================================
 ParticipantId Database::register_participant(
-    ParticipantDescription description)
+  ParticipantDescription description)
 {
   const ParticipantId id = _pimpl->get_next_participant_id();
   auto tracker = Inconsistencies::Implementation::register_participant(
-        _pimpl->inconsistencies, id);
+    _pimpl->inconsistencies, id);
 
   const Version version = ++_pimpl->schedule_version;
 
   _pimpl->states.insert(
-        std::make_pair(
-          id,
-          Implementation::ParticipantState{
-            {},
-            std::move(tracker),
-            {},
-            std::make_shared<ParticipantDescription>(std::move(description)),
-            version
-          }));
+    std::make_pair(
+      id,
+      Implementation::ParticipantState{
+        {},
+        std::move(tracker),
+        {},
+        std::make_shared<ParticipantDescription>(std::move(description)),
+        version
+      }));
 
   _pimpl->add_participant_version[version] = id;
   return id;
@@ -625,27 +641,31 @@ ParticipantId Database::register_participant(
 
 //==============================================================================
 void Database::unregister_participant(
-    ParticipantId participant)
+  ParticipantId participant)
 {
   const auto id_it = _pimpl->participant_ids.find(participant);
   const auto state_it = _pimpl->states.find(participant);
 
   if (id_it == _pimpl->participant_ids.end()
-      && state_it == _pimpl->states.end())
+    && state_it == _pimpl->states.end())
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::unregister_participant] Requested unregistering an "
-          "inactive participant ID [" + std::to_string(participant) + "]");
+      "[Database::unregister_participant] Requested unregistering an "
+      "inactive participant ID [" + std::to_string(participant) + "]");
+    // *INDENT-ON*
   }
   else if (id_it == _pimpl->participant_ids.end()
-           || state_it == _pimpl->states.end())
+    || state_it == _pimpl->states.end())
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::unregister_participant] Inconsistency in participant "
-          "registration ["
-          + std::to_string(id_it == _pimpl->participant_ids.end()) + ":"
-          + std::to_string(state_it == _pimpl->states.end())
-          + "]. Please report this as a serious bug!");
+      "[Database::unregister_participant] Inconsistency in participant "
+      "registration ["
+      + std::to_string(id_it == _pimpl->participant_ids.end()) + ":"
+      + std::to_string(state_it == _pimpl->states.end())
+      + "]. Please report this as a serious bug!");
+    // *INDENT-ON*
   }
 
   _pimpl->inconsistencies._pimpl->unregister_participant(participant);
@@ -666,7 +686,7 @@ namespace {
 
 //==============================================================================
 const Database::Implementation::RouteEntry* get_most_recent(
-    const Database::Implementation::RouteEntry* from)
+  const Database::Implementation::RouteEntry* from)
 {
   assert(from);
   while (from->successor)
@@ -692,7 +712,7 @@ struct ParticipantChanges
 
 //==============================================================================
 class PatchRelevanceInspector
-    : public TimelineInspector<Database::Implementation::RouteEntry>
+  : public TimelineInspector<Database::Implementation::RouteEntry>
 {
 public:
 
@@ -718,8 +738,8 @@ public:
     }
 
     while (from->successor
-           && rmf_utils::modular(from->successor->schedule_version)
-                .less_than_or_equal(_after))
+      && rmf_utils::modular(from->successor->schedule_version)
+      .less_than_or_equal(_after))
     {
       from = from->successor;
     }
@@ -728,8 +748,8 @@ public:
   }
 
   void inspect(
-      const RouteEntry* entry,
-      const std::function<bool(const RouteEntry&)>& relevant) final
+    const RouteEntry* entry,
+    const std::function<bool(const RouteEntry&)>& relevant) final
   {
     const RouteEntry* const last = get_last_known_ancestor(entry);
     const RouteEntry* const newest = get_most_recent(entry);
@@ -755,12 +775,12 @@ public:
           assert(transition->delay);
           const auto& delay = *transition->delay;
           const auto insertion = p_changes.delays.insert(
-                std::make_pair(
-                  traverse->schedule_version,
-                  Delay{
-                    delay.from,
-                    delay.duration
-                  }));
+            std::make_pair(
+              traverse->schedule_version,
+              Delay{
+                delay.from,
+                delay.duration
+              }));
 #ifndef NDEBUG
           // When compiling in debug mode, if we see a duplicate insertion,
           // let's make sure that the previously entered data matches what we
@@ -793,10 +813,10 @@ public:
       {
         // The newest version of this route is relevant to the mirror
         changes[newest->participant].additions.emplace_back(
-              Change::Add::Item{
-                newest->route_id,
-                newest->route
-              });
+          Change::Add::Item{
+            newest->route_id,
+            newest->route
+          });
       }
       else
       {
@@ -811,7 +831,7 @@ private:
 
 //==============================================================================
 class FirstPatchRelevanceInspector
-    : public TimelineInspector<Database::Implementation::RouteEntry>
+  : public TimelineInspector<Database::Implementation::RouteEntry>
 {
 public:
 
@@ -820,24 +840,24 @@ public:
   std::unordered_map<ParticipantId, ParticipantChanges> changes;
 
   void inspect(
-      const RouteEntry* entry,
-      const std::function<bool(const RouteEntry&)>& relevant) final
+    const RouteEntry* entry,
+    const std::function<bool(const RouteEntry&)>& relevant) final
   {
     const RouteEntry* const newest = get_most_recent(entry);
     if (newest->route && relevant(*newest))
     {
       changes[newest->participant].additions.emplace_back(
-            Change::Add::Item{
-              newest->route_id,
-              newest->route
-            });
+        Change::Add::Item{
+          newest->route_id,
+          newest->route
+        });
     }
   }
 };
 
 //==============================================================================
 class ViewRelevanceInspector
-    : public TimelineInspector<Database::Implementation::RouteEntry>
+  : public TimelineInspector<Database::Implementation::RouteEntry>
 {
 public:
 
@@ -847,26 +867,26 @@ public:
   std::vector<Storage> routes;
 
   void inspect(
-      const RouteEntry* entry,
-      const std::function<bool(const RouteEntry&)>& relevant) final
+    const RouteEntry* entry,
+    const std::function<bool(const RouteEntry&)>& relevant) final
   {
     entry = get_most_recent(entry);
     if (entry->route && relevant(*entry))
     {
       routes.emplace_back(
-            Storage{
-              entry->participant,
-              entry->route_id,
-              entry->route,
-              entry->description
-            });
+        Storage{
+          entry->participant,
+          entry->route_id,
+          entry->route,
+          entry->description
+        });
     }
   }
 };
 
 //==============================================================================
 class ViewerAfterRelevanceInspector
-    : public TimelineInspector<Database::Implementation::RouteEntry>
+  : public TimelineInspector<Database::Implementation::RouteEntry>
 {
 public:
 
@@ -878,33 +898,33 @@ public:
   const Version after;
 
   ViewerAfterRelevanceInspector(Version _after)
-    : after(_after)
+  : after(_after)
   {
     // Do nothing
   }
 
   void inspect(
-      const RouteEntry* entry,
-      const std::function<bool(const RouteEntry&)>& relevant) final
+    const RouteEntry* entry,
+    const std::function<bool(const RouteEntry&)>& relevant) final
   {
     entry = get_most_recent(entry);
     if (rmf_utils::modular(after).less_than(entry->schedule_version)
-        && entry->route && relevant(*entry))
+      && entry->route && relevant(*entry))
     {
       routes.emplace_back(
-            Storage{
-              entry->participant,
-              entry->route_id,
-              entry->route,
-              entry->description
-            });
+        Storage{
+          entry->participant,
+          entry->route_id,
+          entry->route,
+          entry->description
+        });
     }
   }
 };
 
 //==============================================================================
 class CullRelevanceInspector
-    : public TimelineInspector<Database::Implementation::RouteEntry>
+  : public TimelineInspector<Database::Implementation::RouteEntry>
 {
 public:
 
@@ -925,10 +945,10 @@ public:
   std::vector<Info> routes;
 
   void inspect(
-      const RouteEntry* entry,
-      const std::function<bool(const RouteEntry&)>& /*relevant*/) final
+    const RouteEntry* entry,
+    const std::function<bool(const RouteEntry&)>& /*relevant*/) final
   {
-    while(entry->successor && entry->successor->route)
+    while (entry->successor && entry->successor->route)
       entry = entry->successor;
 
     assert(entry->route->trajectory().finish_time());
@@ -960,7 +980,7 @@ const std::unordered_set<ParticipantId>& Database::participant_ids() const
 
 //==============================================================================
 std::shared_ptr<const ParticipantDescription> Database::get_participant(
-    std::size_t participant_id) const
+  std::size_t participant_id) const
 {
   const auto state_it = _pimpl->states.find(participant_id);
   if (state_it == _pimpl->states.end())
@@ -971,7 +991,7 @@ std::shared_ptr<const ParticipantDescription> Database::get_participant(
 
 //==============================================================================
 rmf_utils::optional<Itinerary> Database::get_itinerary(
-    std::size_t participant_id) const
+  std::size_t participant_id) const
 {
   const auto state_it = _pimpl->states.find(participant_id);
   if (state_it == _pimpl->states.end())
@@ -1008,8 +1028,8 @@ const Inconsistencies& Database::inconsistencies() const
 
 //==============================================================================
 auto Database::changes(
-    const Query& parameters,
-    rmf_utils::optional<Version> after) const -> Patch
+  const Query& parameters,
+  rmf_utils::optional<Version> after) const -> Patch
 {
   std::unordered_map<ParticipantId, ParticipantChanges> changes;
   if (after)
@@ -1032,19 +1052,19 @@ auto Database::changes(
     for (const auto& d : p.second.delays)
     {
       delays.emplace_back(
-            Change::Delay{
-              d.second.from,
-              d.second.duration
-            });
+        Change::Delay{
+          d.second.from,
+          d.second.duration
+        });
     }
 
     part_patches.emplace_back(
-          Patch::Participant{
-            p.first,
-            Change::Erase(std::move(p.second.erasures)),
-            std::move(delays),
-            Change::Add(std::move(p.second.additions))
-          });
+      Patch::Participant{
+        p.first,
+        Change::Erase(std::move(p.second.erasures)),
+        std::move(delays),
+        Change::Add(std::move(p.second.additions))
+      });
   }
 
   std::vector<Change::RegisterParticipant> registered;
@@ -1087,11 +1107,11 @@ auto Database::changes(
   }
 
   return Patch(
-        std::move(unregistered),
-        std::move(registered),
-        std::move(part_patches),
-        cull,
-        _pimpl->schedule_version);
+    std::move(unregistered),
+    std::move(registered),
+    std::move(part_patches),
+    cull,
+    _pimpl->schedule_version);
 }
 
 //==============================================================================
@@ -1133,7 +1153,7 @@ Version Database::cull(Time time)
   for (auto p_cull_it = p_cull_begin; p_cull_it != p_cull_end; ++p_cull_it)
   {
     const auto remove_it =
-        _pimpl->remove_participant_version.find(p_cull_it->second);
+      _pimpl->remove_participant_version.find(p_cull_it->second);
     assert(remove_it != _pimpl->remove_participant_version.end());
 
     _pimpl->remove_participant_version.erase(remove_it);
@@ -1147,8 +1167,8 @@ Version Database::cull(Time time)
 
   // Record the occurrence of this cull
   _pimpl->last_cull = Implementation::CullInfo{
-      Change::Cull(time),
-      _pimpl->schedule_version
+    Change::Cull(time),
+    _pimpl->schedule_version
   };
 
   return _pimpl->schedule_version;
@@ -1166,9 +1186,11 @@ ItineraryVersion Database::itinerary_version(ParticipantId participant) const
   const auto p_it = _pimpl->states.find(participant);
   if (p_it == _pimpl->states.end())
   {
+    // *INDENT-OFF*
     throw std::runtime_error(
-          "[Database::itinerary_version] No participant with ID ["
-          + std::to_string(participant) + "]");
+      "[Database::itinerary_version] No participant with ID ["
+      + std::to_string(participant) + "]");
+    // *INDENT-ON*
   }
 
   return p_it->second.tracker->last_known_version();

--- a/rmf_traffic/src/rmf_traffic/schedule/Inconsistencies.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Inconsistencies.cpp
@@ -43,14 +43,14 @@ public:
 
   const RangesSet& set;
   ItineraryVersion last_known_version =
-      std::numeric_limits<ItineraryVersion>::max();
+    std::numeric_limits<ItineraryVersion>::max();
 
   using raw_iterator = RangesSet::const_iterator;
   static const_iterator make_iterator(raw_iterator it)
   {
     const_iterator result;
     result._pimpl = rmf_utils::make_impl<const_iterator::Implementation>(
-          const_iterator::Implementation{it});
+      const_iterator::Implementation{it});
     return result;
   }
 
@@ -107,8 +107,8 @@ ItineraryVersion Inconsistencies::Ranges::last_known_version() const
 //==============================================================================
 std::unique_ptr<InconsistencyTracker>
 Inconsistencies::Implementation::register_participant(
-    Inconsistencies& inconsistencies,
-    ParticipantId id)
+  Inconsistencies& inconsistencies,
+  ParticipantId id)
 {
   auto& _inconsistencies = inconsistencies._pimpl->_inconsistencies;
   auto& _api = inconsistencies._pimpl->_api;
@@ -118,17 +118,17 @@ Inconsistencies::Implementation::register_participant(
   assert(it.second);
   RangesSet& ranges = it.first->second;
   const auto ranges_it = _api.insert(
-        std::make_pair(
-          id,
-          Element{
-            id,
-            Ranges::Implementation::make(ranges)
-          }));
+    std::make_pair(
+      id,
+      Element{
+        id,
+        Ranges::Implementation::make(ranges)
+      }));
 
   auto& ranges_api = ranges_it.first->second.ranges;
   return std::make_unique<InconsistencyTracker>(
-        ranges,
-        Ranges::Implementation::get_last_known_version(ranges_api));
+    ranges,
+    Ranges::Implementation::get_last_known_version(ranges_api));
 }
 
 //==============================================================================
@@ -191,7 +191,7 @@ auto Inconsistencies::Implementation::make_iterator(raw_iterator it)
 {
   const_iterator result;
   result._pimpl = rmf_utils::make_impl<const_iterator::Implementation>(
-        const_iterator::Implementation{it});
+    const_iterator::Implementation{it});
   return result;
 }
 

--- a/rmf_traffic/src/rmf_traffic/schedule/InconsistenciesInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/InconsistenciesInternal.hpp
@@ -34,8 +34,8 @@ class Inconsistencies::Implementation
 public:
 
   static std::unique_ptr<InconsistencyTracker> register_participant(
-      Inconsistencies& inconsistencies,
-      ParticipantId id);
+    Inconsistencies& inconsistencies,
+    ParticipantId id);
 
   void unregister_participant(ParticipantId id);
 
@@ -56,7 +56,6 @@ private:
   static const_iterator make_iterator(raw_iterator it);
 
 };
-
 
 
 } // namespace schedule

--- a/rmf_traffic/src/rmf_traffic/schedule/InconsistencyTracker.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/InconsistencyTracker.cpp
@@ -24,8 +24,8 @@ namespace rmf_traffic {
 namespace schedule {
 
 InconsistencyTracker::InconsistencyTracker(
-    RangesSet& ranges,
-    ItineraryVersion& last_known_version)
+  RangesSet& ranges,
+  ItineraryVersion& last_known_version)
 : _ranges(ranges),
   _last_known_version(last_known_version)
 {
@@ -33,7 +33,7 @@ InconsistencyTracker::InconsistencyTracker(
 }
 
 //==============================================================================
-void InconsistencyTracker::Ticket::set(std::function<void ()> change)
+void InconsistencyTracker::Ticket::set(std::function<void()> change)
 {
   _set = true;
   _callback = change;
@@ -41,8 +41,8 @@ void InconsistencyTracker::Ticket::set(std::function<void ()> change)
 
 //==============================================================================
 InconsistencyTracker::Ticket::Ticket(
-    InconsistencyTracker& parent,
-    std::function<void()>& callback)
+  InconsistencyTracker& parent,
+  std::function<void()>& callback)
 : _parent(parent),
   _callback(callback)
 {
@@ -69,8 +69,8 @@ InconsistencyTracker::Ticket::~Ticket()
 
 //==============================================================================
 auto InconsistencyTracker::check(
-    const ItineraryVersion version,
-    const bool nullifying)
+  const ItineraryVersion version,
+  const bool nullifying)
 -> std::unique_ptr<Ticket>
 {
   using Range = Inconsistencies::Ranges::Range;
@@ -238,7 +238,7 @@ auto InconsistencyTracker::check(
         // Since this is a nullifying change, it eliminates all ranges of
         // inconsistencies that come before it.
         const auto hint_it =
-            _ranges.erase(_ranges.begin(), ++RangesSet::iterator(range_it));
+          _ranges.erase(_ranges.begin(), ++RangesSet::iterator(range_it));
 
         if (version == upper)
         {

--- a/rmf_traffic/src/rmf_traffic/schedule/InconsistencyTracker.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/InconsistencyTracker.hpp
@@ -55,8 +55,8 @@ class InconsistencyTracker
 public:
 
   InconsistencyTracker(
-      RangesSet& parent,
-      ItineraryVersion& last_known_version);
+    RangesSet& parent,
+    ItineraryVersion& last_known_version);
 
   /// The Ticket class is a way to inform the caller that there is an
   /// inconsistency with the version of an incoming change. When the
@@ -75,8 +75,8 @@ public:
     void set(std::function<void()> change);
 
     Ticket(
-        InconsistencyTracker& parent,
-        std::function<void()>& callback);
+      InconsistencyTracker& parent,
+      std::function<void()>& callback);
 
     Ticket(const Ticket&) = delete;
     Ticket& operator=(const Ticket&) = delete;
@@ -112,8 +112,8 @@ public:
   // semantics aren't right, but maybe the STL version would. Or maybe we need
   // a moveable version of std::reference_wrapper.
   std::unique_ptr<Ticket> check(
-      ItineraryVersion version,
-      bool nullifying = false);
+    ItineraryVersion version,
+    bool nullifying = false);
 
   ItineraryVersion expected_version() const
   {

--- a/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
@@ -55,9 +55,9 @@ public:
   Version latest_version = 0;
 
   static void erase_routes(
-      const ParticipantId participant,
-      ParticipantState& state,
-      const Change::Erase& erase)
+    const ParticipantId participant,
+    ParticipantState& state,
+    const Change::Erase& erase)
   {
     for (const RouteId id : erase.ids())
     {
@@ -75,8 +75,8 @@ public:
   }
 
   void apply_delay(
-      ParticipantState& state,
-      const Change::Delay& delay)
+    ParticipantState& state,
+    const Change::Delay& delay)
   {
     for (auto& s : state.storage)
     {
@@ -84,12 +84,12 @@ public:
       assert(entry);
       assert(entry->route);
       auto delayed = schedule::apply_delay(
-            entry->route->trajectory(), delay.from(), delay.duration());
+        entry->route->trajectory(), delay.from(), delay.duration());
       if (!delayed)
         continue;
 
       auto new_route = std::make_shared<Route>(
-            entry->route->map(), std::move(*delayed));
+        entry->route->map(), std::move(*delayed));
 
       entry = std::make_unique<RouteEntry>(*entry);
       entry->route = std::move(new_route);
@@ -98,9 +98,9 @@ public:
   }
 
   void add_routes(
-      const ParticipantId participant,
-      ParticipantState& state,
-      const Change::Add& add)
+    const ParticipantId participant,
+    ParticipantState& state,
+    const Change::Add& add)
   {
     for (const auto& item : add.items())
     {
@@ -121,13 +121,13 @@ public:
 
       auto& entry = insertion.first->second;
       entry = std::make_unique<RouteEntry>(
-            RouteEntry{
-              std::move(route),
-              participant,
-              route_id,
-              state.description,
-              nullptr
-            });
+        RouteEntry{
+          std::move(route),
+          participant,
+          route_id,
+          state.description,
+          nullptr
+        });
 
       timeline.insert(*entry);
     }
@@ -137,7 +137,7 @@ public:
 namespace {
 //==============================================================================
 class MirrorViewRelevanceInspector
-    : public TimelineInspector<Mirror::Implementation::RouteEntry>
+  : public TimelineInspector<Mirror::Implementation::RouteEntry>
 {
 public:
 
@@ -147,20 +147,20 @@ public:
   std::vector<Storage> routes;
 
   void inspect(
-      const RouteEntry* entry,
-      const std::function<bool(const RouteEntry&)>& relevant) final
+    const RouteEntry* entry,
+    const std::function<bool(const RouteEntry&)>& relevant) final
   {
     assert(entry);
     assert(entry->route);
     if (relevant(*entry))
     {
       routes.emplace_back(
-            Storage{
-              entry->participant,
-              entry->route_id,
-              entry->route,
-              entry->description
-            });
+        Storage{
+          entry->participant,
+          entry->route_id,
+          entry->route,
+          entry->description
+        });
     }
   }
 
@@ -168,7 +168,7 @@ public:
 
 //==============================================================================
 class MirrorCullRelevanceInspector
-    : public TimelineInspector<Mirror::Implementation::RouteEntry>
+  : public TimelineInspector<Mirror::Implementation::RouteEntry>
 {
 public:
 
@@ -182,8 +182,8 @@ public:
   std::vector<Info> info;
 
   void inspect(
-      const RouteEntry* entry,
-      const std::function<bool(const RouteEntry&)>& relevant) final
+    const RouteEntry* entry,
+    const std::function<bool(const RouteEntry&)>& relevant) final
   {
     assert(entry);
     assert(entry->route);
@@ -211,7 +211,7 @@ const std::unordered_set<ParticipantId>& Mirror::participant_ids() const
 
 //==============================================================================
 std::shared_ptr<const ParticipantDescription> Mirror::get_participant(
-    std::size_t participant_id) const
+  std::size_t participant_id) const
 {
   const auto p = _pimpl->states.find(participant_id);
   if (p == _pimpl->states.end())
@@ -222,7 +222,7 @@ std::shared_ptr<const ParticipantDescription> Mirror::get_participant(
 
 //==============================================================================
 rmf_utils::optional<Itinerary> Mirror::get_itinerary(
-    std::size_t participant_id) const
+  std::size_t participant_id) const
 {
   const auto p = _pimpl->states.find(participant_id);
   if (p == _pimpl->states.end())
@@ -273,12 +273,12 @@ Version Mirror::update(const Patch& patch)
   {
     const ParticipantId id = registered.id();
     const bool inserted = _pimpl->states.insert(
-          std::make_pair(
-            id,
-            Implementation::ParticipantState{
-              {},
-              std::make_shared<ParticipantDescription>(registered.description())
-            })).second;
+      std::make_pair(
+        id,
+        Implementation::ParticipantState{
+          {},
+          std::make_shared<ParticipantDescription>(registered.description())
+        })).second;
 
     _pimpl->participant_ids.insert(id);
 

--- a/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
@@ -506,11 +506,13 @@ public:
   {
     if (!data->participants.insert(new_participant).second)
     {
+      // *INDENT-OFF*
       throw std::runtime_error(
-              "[rmf_traffic::schedule::Negotiation::add_participant] "
-              "Participant [" + std::to_string(
-                new_participant) + "] is already "
-              "present in the Negotiation");
+        "[rmf_traffic::schedule::Negotiation::add_participant] "
+        "Participant [" + std::to_string(
+          new_participant) + "] is already "
+        "present in the Negotiation");
+      // *INDENT-ON*
     }
 
     // We can update the maximum number of terminating tables by just

--- a/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Negotiation.cpp
@@ -30,7 +30,7 @@ namespace {
 std::size_t factorial(std::size_t N)
 {
   std::size_t output = 1;
-  while(N > 1)
+  while (N > 1)
   {
     output *= N;
     --N;
@@ -60,8 +60,8 @@ std::size_t factorial(std::size_t N)
 /// \param[in] num_participants
 ///   The total number of participants in the negotiation
 std::size_t termination_factor(
-    const std::size_t depth,
-    const std::size_t num_participants)
+  const std::size_t depth,
+  const std::size_t num_participants)
 {
   return factorial(num_participants - depth);
 }
@@ -134,40 +134,40 @@ public:
   std::weak_ptr<Table> weak_parent;
 
   Implementation(
-      TablePtr owner_,
-      std::shared_ptr<NegotiationData> negotiation_data_,
-      const Viewer& viewer_,
-      ParticipantId participant_,
-      std::size_t depth_,
-      std::vector<ParticipantId> submitted_,
-      std::vector<ParticipantId> unsubmitted_,
-      Proposal initial_proposal_,
-      TablePtr parent_)
-    : viewer(&viewer_),
-      unsubmitted(std::move(unsubmitted_)),
-      proposal(std::move(initial_proposal_)),
-      participant(participant_),
-      depth(depth_),
-      weak_negotiation_data(negotiation_data_),
-      weak_owner(owner_),
-      weak_parent(std::move(parent_))
+    TablePtr owner_,
+    std::shared_ptr<NegotiationData> negotiation_data_,
+    const Viewer& viewer_,
+    ParticipantId participant_,
+    std::size_t depth_,
+    std::vector<ParticipantId> submitted_,
+    std::vector<ParticipantId> unsubmitted_,
+    Proposal initial_proposal_,
+    TablePtr parent_)
+  : viewer(&viewer_),
+    unsubmitted(std::move(unsubmitted_)),
+    proposal(std::move(initial_proposal_)),
+    participant(participant_),
+    depth(depth_),
+    weak_negotiation_data(negotiation_data_),
+    weak_owner(owner_),
+    weak_parent(std::move(parent_))
   {
     for (const auto& p : proposal)
     {
       const ParticipantId participant = p.participant;
       const auto& description = viewer->get_participant(participant);
-      for (std::size_t i=0; i < p.itinerary.size(); ++i)
+      for (std::size_t i = 0; i < p.itinerary.size(); ++i)
       {
         const auto& route = p.itinerary[i];
 
         auto entry = std::make_unique<RouteEntry>(
-              RouteEntry{
-                route,
-                participant,
-                i,
-                description,
-                nullptr
-              });
+          RouteEntry{
+            route,
+            participant,
+            i,
+            description,
+            nullptr
+          });
 
         timeline.insert(*entry);
         entries.push_back(std::move(entry));
@@ -176,7 +176,7 @@ public:
 
     std::vector<ParticipantId> all_participants = submitted_;
     all_participants.insert(
-          all_participants.end(), unsubmitted.begin(), unsubmitted.end());
+      all_participants.end(), unsubmitted.begin(), unsubmitted.end());
     participant_query = Query::Participants::make_all_except(all_participants);
 
     // Add this Table's participant to the sequence
@@ -185,19 +185,22 @@ public:
 
     // Remove this Table's participant from the unsubmitted
     const auto it = std::remove_if(unsubmitted.begin(), unsubmitted.end(),
-                   [&](const ParticipantId p) { return p == participant; });
+        [&](const ParticipantId p) { return p == participant; });
     assert(it != unsubmitted.end());
     unsubmitted.erase(it, unsubmitted.end());
 
-    assert(std::find(unsubmitted.begin(), unsubmitted.end(), participant) == unsubmitted.end());
+    assert(std::find(unsubmitted.begin(),
+      unsubmitted.end(), participant) == unsubmitted.end());
   }
 
   Viewer::View query(const Query::Spacetime& spacetime) const;
 
   void add_participant(const ParticipantId new_participant)
   {
-    assert(std::find(unsubmitted.begin(), unsubmitted.end(), new_participant) == unsubmitted.end());
-    assert(std::find(sequence.begin(), sequence.end(), new_participant) == sequence.end());
+    assert(std::find(unsubmitted.begin(),
+      unsubmitted.end(), new_participant) == unsubmitted.end());
+    assert(std::find(sequence.begin(),
+      sequence.end(), new_participant) == sequence.end());
     unsubmitted.push_back(new_participant);
 
     if (itinerary)
@@ -213,7 +216,8 @@ public:
     assert(itinerary);
     assert(proposal.size() == depth);
 
-    assert(std::find(unsubmitted.begin(), unsubmitted.end(), participant) == unsubmitted.end());
+    assert(std::find(unsubmitted.begin(),
+      unsubmitted.end(), participant) == unsubmitted.end());
 
     std::unordered_map<ParticipantId, Table> descendants;
     for (const auto u : unsubmitted)
@@ -224,23 +228,23 @@ public:
   {
     auto table = std::make_shared<Table>(Table());
     table->_pimpl = rmf_utils::make_unique_impl<Implementation>(
-          table, weak_negotiation_data.lock(), *viewer, p, depth+1,
-          sequence, unsubmitted, proposal, weak_owner.lock());
+      table, weak_negotiation_data.lock(), *viewer, p, depth+1,
+      sequence, unsubmitted, proposal, weak_owner.lock());
 
     descendants.insert(std::make_pair(p, std::move(table)));
   }
 
   static TablePtr make_root(
-      const Viewer& viewer,
-      const std::shared_ptr<NegotiationData> negotiation_data,
-      const ParticipantId participant,
-      const std::vector<ParticipantId>& participants)
+    const Viewer& viewer,
+    const std::shared_ptr<NegotiationData> negotiation_data,
+    const ParticipantId participant,
+    const std::vector<ParticipantId>& participants)
   {
     auto table = std::make_shared<Table>(Table());
     table->_pimpl = rmf_utils::make_unique_impl<Implementation>(
-          Implementation(
-            table, negotiation_data, viewer, participant, 1, {},
-            participants, {}, nullptr));
+      Implementation(
+        table, negotiation_data, viewer, participant, 1, {},
+        participants, {}, nullptr));
 
     return table;
   }
@@ -256,8 +260,8 @@ public:
   }
 
   bool submit(
-      std::vector<Route> new_itinerary,
-      const Version new_version)
+    std::vector<Route> new_itinerary,
+    const Version new_version)
   {
     if (version && rmf_utils::modular(new_version).less_than_or_equal(*version))
       return false;
@@ -270,7 +274,7 @@ public:
     {
       negotiation_data->rejected_tables.erase(this);
       negotiation_data->num_terminated_tables -=
-          termination_factor(depth, negotiation_data->participants.size());
+        termination_factor(depth, negotiation_data->participants.size());
     }
     else if (itinerary && descendants.empty())
     {
@@ -340,26 +344,26 @@ public:
     if (negotiation_data)
     {
       negotiation_data->num_terminated_tables += termination_factor(
-            depth, negotiation_data->participants.size());
+        depth, negotiation_data->participants.size());
       negotiation_data->rejected_tables.insert(this);
 
       // Erase any successful tables that branched off of this rejected table
       const auto erase_it = std::remove_if(
-            negotiation_data->successful_tables.begin(),
-            negotiation_data->successful_tables.end(),
-            [&](const std::vector<ParticipantId>& table)
-      {
-        for (std::size_t i=0; i < sequence.size(); ++i)
+        negotiation_data->successful_tables.begin(),
+        negotiation_data->successful_tables.end(),
+        [&](const std::vector<ParticipantId>& table)
         {
-          if (table[i] != sequence[i])
-            return false;
-        }
+          for (std::size_t i = 0; i < sequence.size(); ++i)
+          {
+            if (table[i] != sequence[i])
+              return false;
+          }
 
-        return true;
-      });
+          return true;
+        });
 
       negotiation_data->successful_tables.erase(
-            erase_it, negotiation_data->successful_tables.end());
+        erase_it, negotiation_data->successful_tables.end());
     }
   }
 
@@ -387,8 +391,8 @@ public:
         if (table->_pimpl->rejected && negotiation_data)
         {
           negotiation_data->num_terminated_tables -=
-              termination_factor(
-                table->_pimpl->depth, negotiation_data->participants.size());
+            termination_factor(
+            table->_pimpl->depth, negotiation_data->participants.size());
 
           negotiation_data->rejected_tables.erase(table->_pimpl.get());
         }
@@ -409,10 +413,10 @@ class Negotiation::Implementation
 public:
 
   Implementation(
-      const Viewer& viewer_,
-      std::vector<ParticipantId> participants_)
-    : viewer(&viewer_),
-      data(std::make_shared<NegotiationData>())
+    const Viewer& viewer_,
+    std::vector<ParticipantId> participants_)
+  : viewer(&viewer_),
+    data(std::make_shared<NegotiationData>())
   {
     for (const auto p : participants_)
       data->participants.insert(p);
@@ -422,7 +426,7 @@ public:
     for (const auto p : participants_)
     {
       tables[p] = Table::Implementation::make_root(
-            viewer_, data, p, participants_);
+        viewer_, data, p, participants_);
     }
   }
 
@@ -444,7 +448,7 @@ public:
   }
 
   TablePtr get_entry(
-      const std::vector<ParticipantId>& table)
+    const std::vector<ParticipantId>& table)
   {
     // TODO(MXG): We could use a TablePtr* here to avoid unnecessary reference
     // counting. However, it would add another layer of indirection and make the
@@ -469,8 +473,8 @@ public:
   }
 
   TablePtr get_entry(
-      const ParticipantId for_participant,
-      const std::vector<ParticipantId>& to_accommodate)
+    const ParticipantId for_participant,
+    const std::vector<ParticipantId>& to_accommodate)
   {
     TableMap* map = nullptr;
     if (to_accommodate.empty())
@@ -491,11 +495,11 @@ public:
   }
 
   ConstTablePtr get_entry(
-      const ParticipantId for_participant,
-      const std::vector<ParticipantId>& to_accommodate) const
+    const ParticipantId for_participant,
+    const std::vector<ParticipantId>& to_accommodate) const
   {
     return const_cast<Implementation&>(*this).get_entry(
-          for_participant, to_accommodate);
+      for_participant, to_accommodate);
   }
 
   void add_participant(const ParticipantId new_participant)
@@ -503,9 +507,10 @@ public:
     if (!data->participants.insert(new_participant).second)
     {
       throw std::runtime_error(
-          "[rmf_traffic::schedule::Negotiation::add_participant] "
-          "Participant [" + std::to_string(new_participant) + "] is already "
-          "present in the Negotiation");
+              "[rmf_traffic::schedule::Negotiation::add_participant] "
+              "Participant [" + std::to_string(
+                new_participant) + "] is already "
+              "present in the Negotiation");
     }
 
     // We can update the maximum number of terminating tables by just
@@ -552,19 +557,19 @@ public:
       t->add_participant(new_participant);
 
     tables[new_participant] = Table::Implementation::make_root(
-          *viewer, data, new_participant,
-          std::vector<ParticipantId>(
-            data->participants.begin(),
-            data->participants.end()));
+      *viewer, data, new_participant,
+      std::vector<ParticipantId>(
+        data->participants.begin(),
+        data->participants.end()));
   }
 };
 
 //==============================================================================
 Negotiation::Negotiation(
-    const Viewer& viewer,
-    std::vector<ParticipantId> participants)
-  : _pimpl(rmf_utils::make_unique_impl<Implementation>(
-             viewer, std::move(participants)))
+  const Viewer& viewer,
+  std::vector<ParticipantId> participants)
+: _pimpl(rmf_utils::make_unique_impl<Implementation>(
+      viewer, std::move(participants)))
 {
   // Do nothing
 }
@@ -596,7 +601,7 @@ bool Negotiation::complete() const
 namespace {
 //==============================================================================
 class NegotiationRelevanceInspector
-    : public TimelineInspector<Negotiation::Table::Implementation::RouteEntry>
+  : public TimelineInspector<Negotiation::Table::Implementation::RouteEntry>
 {
 public:
 
@@ -607,19 +612,19 @@ public:
   std::vector<Storage> routes;
 
   void inspect(
-      const RouteEntry* entry,
-      const std::function<bool(const RouteEntry&)>& relevant) final
+    const RouteEntry* entry,
+    const std::function<bool(const RouteEntry&)>& relevant) final
   {
     assert(entry->route);
     if (relevant(*entry))
     {
       routes.emplace_back(
-            Storage{
-              entry->participant,
-              entry->route_id,
-              entry->route,
-              entry->description
-            });
+        Storage{
+          entry->participant,
+          entry->route_id,
+          entry->route,
+          entry->description
+        });
     }
   }
 };
@@ -627,7 +632,7 @@ public:
 
 //==============================================================================
 Viewer::View Negotiation::Table::Implementation::query(
-    const Query::Spacetime &spacetime) const
+  const Query::Spacetime& spacetime) const
 {
   Query query = query_all();
   query.spacetime() = spacetime;
@@ -642,7 +647,7 @@ Viewer::View Negotiation::Table::Implementation::query(
 
   // Merge them together into a single view
   Viewer::View::Implementation::append_to_view(
-        view, std::move(inspector.routes));
+    view, std::move(inspector.routes));
 
   return view;
 }
@@ -691,8 +696,8 @@ const std::vector<ParticipantId>& Negotiation::Table::sequence() const
 
 //==============================================================================
 bool Negotiation::Table::submit(
-    std::vector<Route> itinerary,
-    const Version version)
+  std::vector<Route> itinerary,
+  const Version version)
 {
   return _pimpl->submit(std::move(itinerary), version);
 }
@@ -770,30 +775,30 @@ Negotiation::Table::Table()
 
 //==============================================================================
 auto Negotiation::table(
-    const ParticipantId for_participant,
-    const std::vector<ParticipantId>& to_accommodate) -> TablePtr
+  const ParticipantId for_participant,
+  const std::vector<ParticipantId>& to_accommodate) -> TablePtr
 {
   return _pimpl->get_entry(for_participant, to_accommodate);
 }
 
 //==============================================================================
 auto Negotiation::table(
-    const ParticipantId for_participant,
-    const std::vector<ParticipantId>& to_accommodate) const -> ConstTablePtr
+  const ParticipantId for_participant,
+  const std::vector<ParticipantId>& to_accommodate) const -> ConstTablePtr
 {
   return _pimpl->get_entry(for_participant, to_accommodate);
 }
 
 //==============================================================================
 auto Negotiation::table(
-    const std::vector<ParticipantId>& sequence) -> TablePtr
+  const std::vector<ParticipantId>& sequence) -> TablePtr
 {
   return _pimpl->get_entry(sequence);
 }
 
 //==============================================================================
 auto Negotiation::table(
-    const std::vector<ParticipantId>& sequence) const -> ConstTablePtr
+  const std::vector<ParticipantId>& sequence) const -> ConstTablePtr
 {
   return _pimpl->get_entry(sequence);
 }
@@ -855,7 +860,7 @@ rmf_utils::optional<Time> get_finish_time(const Itinerary& itinerary)
 
 //==============================================================================
 std::size_t QuickestFinishEvaluator::choose(
-    const std::vector<const Negotiation::Proposal*>& proposals) const
+  const std::vector<const Negotiation::Proposal*>& proposals) const
 {
   std::unordered_map<ParticipantId, Time> best_finish_times;
 
@@ -876,7 +881,7 @@ std::size_t QuickestFinishEvaluator::choose(
       finish_times[p.participant] = *finish_time;
 
       const auto insertion = best_finish_times.insert(
-            std::make_pair(p.participant, *finish_time));
+        std::make_pair(p.participant, *finish_time));
 
       if (insertion.second)
       {
@@ -894,7 +899,7 @@ std::size_t QuickestFinishEvaluator::choose(
 
   double best_penalty = std::numeric_limits<double>::infinity();
   std::size_t best_index = std::numeric_limits<std::size_t>::max();
-  for (std::size_t i=0; i < proposals.size(); ++i)
+  for (std::size_t i = 0; i < proposals.size(); ++i)
   {
     const auto& finish_times = all_finish_times[i];
     double penalty = 0;

--- a/rmf_traffic/src/rmf_traffic/schedule/Negotiator.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Negotiator.cpp
@@ -33,45 +33,45 @@ public:
 
 //==============================================================================
 SimpleResponder::SimpleResponder(
-    std::shared_ptr<schedule::Negotiation> negotiation,
-    schedule::ParticipantId for_participant,
-    std::vector<schedule::ParticipantId> to_accommodate)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(negotiation),
-               for_participant,
-               std::move(to_accommodate)
-             }))
+  std::shared_ptr<schedule::Negotiation> negotiation,
+  schedule::ParticipantId for_participant,
+  std::vector<schedule::ParticipantId> to_accommodate)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(negotiation),
+        for_participant,
+        std::move(to_accommodate)
+      }))
 {
   // Do nothing
 }
 
 //==============================================================================
 SimpleResponder::SimpleResponder(
-    std::shared_ptr<schedule::Negotiation> negotiation,
-    std::vector<schedule::ParticipantId> sequence)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(negotiation),
-               sequence.back(),
-               std::move(sequence)
-             }))
+  std::shared_ptr<schedule::Negotiation> negotiation,
+  std::vector<schedule::ParticipantId> sequence)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(negotiation),
+        sequence.back(),
+        std::move(sequence)
+      }))
 {
   _pimpl->to_accommodate.pop_back();
 }
 
 //==============================================================================
 void SimpleResponder::submit(std::vector<Route> itinerary,
-    std::function<UpdateVersion()> /*approval_callback*/) const
+  std::function<UpdateVersion()> /*approval_callback*/) const
 {
   const auto table = _pimpl->negotiation->table(
-        _pimpl->for_participant, _pimpl->to_accommodate);
+    _pimpl->for_participant, _pimpl->to_accommodate);
 
   if (table)
   {
     table->submit(
-          std::move(itinerary),
-          table->version()? *table->version()+1 : 0);
+      std::move(itinerary),
+      table->version() ? *table->version()+1 : 0);
   }
 }
 
@@ -86,10 +86,10 @@ void SimpleResponder::reject() const
   }
 
   const auto table = _pimpl->negotiation->table(
-        _pimpl->for_participant, _pimpl->to_accommodate);
+    _pimpl->for_participant, _pimpl->to_accommodate);
   if (table)
   {
-    table->reject(table->version()? *table->version() : 0);
+    table->reject(table->version() ? *table->version() : 0);
     return;
   }
 

--- a/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Participant.cpp
@@ -30,21 +30,21 @@ ItineraryVersion Participant::Debug::get_itinerary_version(const Participant& p)
 
 //==============================================================================
 Participant Participant::Implementation::make(
-    ParticipantDescription description,
-    Writer& writer,
-    RectificationRequesterFactory* rectifier_factory)
+  ParticipantDescription description,
+  Writer& writer,
+  RectificationRequesterFactory* rectifier_factory)
 {
   const ParticipantId id = writer.register_participant(description);
 
   Participant participant;
   participant._pimpl = rmf_utils::make_unique_impl<Implementation>(
-        id, std::move(description), writer);
+    id, std::move(description), writer);
 
   if (rectifier_factory)
   {
     participant._pimpl->_rectification =
-        rectifier_factory->make(
-          Rectifier::Implementation::make(*participant._pimpl), id);
+      rectifier_factory->make(
+      Rectifier::Implementation::make(*participant._pimpl), id);
   }
 
   return participant;
@@ -52,8 +52,8 @@ Participant Participant::Implementation::make(
 
 //==============================================================================
 void Participant::Implementation::retransmit(
-    const std::vector<Rectifier::Range>& ranges,
-    const ItineraryVersion last_known_version)
+  const std::vector<Rectifier::Range>& ranges,
+  const ItineraryVersion last_known_version)
 {
   for (const auto& range : ranges)
   {
@@ -97,9 +97,9 @@ ItineraryVersion Participant::Implementation::current_version() const
 
 //==============================================================================
 Participant::Implementation::Implementation(
-    ParticipantId id,
-    ParticipantDescription description,
-    Writer& writer)
+  ParticipantId id,
+  ParticipantDescription description,
+  Writer& writer)
 : _id(id),
   _description(std::move(description)),
   _writer(writer)
@@ -116,18 +116,18 @@ Participant::Implementation::~Implementation()
 
 //==============================================================================
 Writer::Input Participant::Implementation::make_input(
-    std::vector<Route> itinerary)
+  std::vector<Route> itinerary)
 {
   Writer::Input input;
   input.reserve(itinerary.size());
 
-  for (std::size_t i=0; i < itinerary.size(); ++i)
+  for (std::size_t i = 0; i < itinerary.size(); ++i)
   {
     input.emplace_back(
-          Writer::Item{
-            ++_last_route_id,
-            std::make_shared<Route>(std::move(itinerary[i]))
-          });
+      Writer::Item{
+        ++_last_route_id,
+        std::make_shared<Route>(std::move(itinerary[i]))
+      });
   }
 
   return input;
@@ -158,10 +158,11 @@ RouteId Participant::set(std::vector<Route> itinerary)
 
   const ItineraryVersion itinerary_version = _pimpl->get_next_version();
   const ParticipantId id = _pimpl->_id;
-  auto change = [this, input = std::move(input), itinerary_version, id]()
-  {
-    this->_pimpl->_writer.set(id, input, itinerary_version);
-  };
+  auto change =
+    [this, input = std::move(input), itinerary_version, id]()
+    {
+      this->_pimpl->_writer.set(id, input, itinerary_version);
+    };
 
   _pimpl->_change_history[itinerary_version] = change;
   change();
@@ -179,17 +180,18 @@ RouteId Participant::extend(const std::vector<Route>& additional_routes)
   auto input = _pimpl->make_input(std::move(additional_routes));
 
   _pimpl->_current_itinerary.reserve(
-        _pimpl->_current_itinerary.size() + input.size());
+    _pimpl->_current_itinerary.size() + input.size());
 
   for (const auto& item : input)
     _pimpl->_current_itinerary.push_back(item);
 
   const ItineraryVersion itinerary_version = _pimpl->get_next_version();
   const ParticipantId id = _pimpl->_id;
-  auto change = [this, input = std::move(input), itinerary_version, id]()
-  {
-    this->_pimpl->_writer.extend(id, input, itinerary_version);
-  };
+  auto change =
+    [this, input = std::move(input), itinerary_version, id]()
+    {
+      this->_pimpl->_writer.extend(id, input, itinerary_version);
+    };
 
   _pimpl->_change_history[itinerary_version] = change;
   change();
@@ -225,10 +227,11 @@ void Participant::delay(Time from, Duration delay)
 
   const ItineraryVersion itinerary_version = _pimpl->get_next_version();
   const ParticipantId id = _pimpl->_id;
-  auto change = [this, from, delay, itinerary_version, id]()
-  {
-    this->_pimpl->_writer.delay(id, from, delay, itinerary_version);
-  };
+  auto change =
+    [this, from, delay, itinerary_version, id]()
+    {
+      this->_pimpl->_writer.delay(id, from, delay, itinerary_version);
+    };
 
   _pimpl->_change_history[itinerary_version] = change;
   change();
@@ -238,12 +241,12 @@ void Participant::delay(Time from, Duration delay)
 void Participant::erase(const std::unordered_set<RouteId>& input_routes)
 {
   const auto remove_it = std::remove_if(
-        _pimpl->_current_itinerary.begin(),
-        _pimpl->_current_itinerary.end(),
-        [&](const Writer::Item& item)
-  {
-    return input_routes.count(item.id) > 0;
-  });
+    _pimpl->_current_itinerary.begin(),
+    _pimpl->_current_itinerary.end(),
+    [&](const Writer::Item& item)
+    {
+      return input_routes.count(item.id) > 0;
+    });
 
   if (remove_it == _pimpl->_current_itinerary.end())
   {
@@ -261,10 +264,11 @@ void Participant::erase(const std::unordered_set<RouteId>& input_routes)
 
   const ItineraryVersion itinerary_version = _pimpl->get_next_version();
   const ParticipantId id = _pimpl->_id;
-  auto change = [this, routes = std::move(routes), itinerary_version, id]()
-  {
-    this->_pimpl->_writer.erase(id, routes, itinerary_version);
-  };
+  auto change =
+    [this, routes = std::move(routes), itinerary_version, id]()
+    {
+      this->_pimpl->_writer.erase(id, routes, itinerary_version);
+    };
 
   _pimpl->_change_history[itinerary_version] = change;
   change();
@@ -283,10 +287,11 @@ void Participant::clear()
 
   const ItineraryVersion itinerary_version = _pimpl->get_next_version();
   const ParticipantId id = _pimpl->_id;
-  auto change = [this, itinerary_version, id]()
-  {
-    this->_pimpl->_writer.erase(id, itinerary_version);
-  };
+  auto change =
+    [this, itinerary_version, id]()
+    {
+      this->_pimpl->_writer.erase(id, itinerary_version);
+    };
 
   _pimpl->_change_history[itinerary_version] = change;
   change();
@@ -330,14 +335,14 @@ Participant::Participant()
 
 //==============================================================================
 Participant make_participant(
-    ParticipantDescription description,
-    Writer& writer,
-    RectificationRequesterFactory* rectifier_factory)
+  ParticipantDescription description,
+  Writer& writer,
+  RectificationRequesterFactory* rectifier_factory)
 {
   return Participant::Implementation::make(
-        std::move(description),
-        writer,
-        rectifier_factory);
+    std::move(description),
+    writer,
+    rectifier_factory);
 }
 
 } // namespace schedule

--- a/rmf_traffic/src/rmf_traffic/schedule/ParticipantDescription.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/ParticipantDescription.cpp
@@ -34,17 +34,17 @@ public:
 
 //==============================================================================
 ParticipantDescription::ParticipantDescription(
-    std::string name,
-    std::string owner,
-    Rx responsiveness,
-    Profile profile)
+  std::string name,
+  std::string owner,
+  Rx responsiveness,
+  Profile profile)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{
-             std::move(name),
-             std::move(owner),
-             std::move(responsiveness),
-             std::move(profile)
-           }))
+      Implementation{
+        std::move(name),
+        std::move(owner),
+        std::move(responsiveness),
+        std::move(profile)
+      }))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/schedule/ParticipantInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/ParticipantInternal.hpp
@@ -33,22 +33,22 @@ class Participant::Implementation
 public:
 
   static Participant make(
-      ParticipantDescription description,
-      Writer& writer,
-      RectificationRequesterFactory* rectifier_factory);
+    ParticipantDescription description,
+    Writer& writer,
+    RectificationRequesterFactory* rectifier_factory);
 
   void retransmit(
-      const std::vector<Rectifier::Range>& from,
-      ItineraryVersion last_known);
+    const std::vector<Rectifier::Range>& from,
+    ItineraryVersion last_known);
 
   ItineraryVersion current_version() const;
 
   // Note: It would be better if this constructor were private, but we need to
   // make it public so it can be used by rmf_utils::make_unique_impl
   Implementation(
-      ParticipantId id,
-      ParticipantDescription description,
-      Writer& writer);
+    ParticipantId id,
+    ParticipantDescription description,
+    Writer& writer);
 
   ~Implementation();
 
@@ -64,7 +64,7 @@ private:
   std::unique_ptr<RectificationRequester> _rectification;
 
   using ChangeHistory =
-      std::map<RouteId, std::function<void()>, rmf_utils::ModularLess<RouteId>>;
+    std::map<RouteId, std::function<void()>, rmf_utils::ModularLess<RouteId>>;
 
   Writer::Input _current_itinerary;
 

--- a/rmf_traffic/src/rmf_traffic/schedule/Patch.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Patch.cpp
@@ -35,17 +35,17 @@ public:
 
 //==============================================================================
 Patch::Participant::Participant(
-    ParticipantId id,
-    Change::Erase erasures,
-    std::vector<Change::Delay> delays,
-    Change::Add additions)
+  ParticipantId id,
+  Change::Erase erasures,
+  std::vector<Change::Delay> delays,
+  Change::Add additions)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{
-             id,
-             std::move(erasures),
-             std::move(delays),
-             std::move(additions)
-           }))
+      Implementation{
+        id,
+        std::move(erasures),
+        std::move(delays),
+        std::move(additions)
+      }))
 {
   // Do nothing
 }
@@ -98,19 +98,19 @@ public:
 
 //==============================================================================
 Patch::Patch(
-    std::vector<Change::UnregisterParticipant> removed_participants,
-    std::vector<Change::RegisterParticipant> new_participants,
-    std::vector<Participant> changes,
-    rmf_utils::optional<Change::Cull> cull,
-    Version latest_version)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{
-               std::move(removed_participants),
-               std::move(new_participants),
-               std::move(changes),
-               cull,
-               latest_version
-             }))
+  std::vector<Change::UnregisterParticipant> removed_participants,
+  std::vector<Change::RegisterParticipant> new_participants,
+  std::vector<Participant> changes,
+  rmf_utils::optional<Change::Cull> cull,
+  Version latest_version)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{
+        std::move(removed_participants),
+        std::move(new_participants),
+        std::move(changes),
+        cull,
+        latest_version
+      }))
 {
   // Do nothing
 }

--- a/rmf_traffic/src/rmf_traffic/schedule/Query.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Query.cpp
@@ -68,38 +68,38 @@ public:
   rmf_utils::optional<Time> upper_bound;
 
   static Timespan make(
-      std::vector<std::string> maps,
-      rmf_utils::optional<Time> lower_bound,
-      rmf_utils::optional<Time> upper_bound)
+    std::vector<std::string> maps,
+    rmf_utils::optional<Time> lower_bound,
+    rmf_utils::optional<Time> upper_bound)
   {
     Timespan span;
     span._pimpl = rmf_utils::make_impl<Implementation>(
-          Implementation{
-            std::unordered_set<std::string>{
-              std::make_move_iterator(maps.begin()),
-              std::make_move_iterator(maps.end())
-            },
-            false,
-            lower_bound,
-            upper_bound
-          });
+      Implementation{
+        std::unordered_set<std::string>{
+          std::make_move_iterator(maps.begin()),
+          std::make_move_iterator(maps.end())
+        },
+        false,
+        lower_bound,
+        upper_bound
+      });
 
     return span;
   }
 
   static Timespan make(
-      bool query_all_maps,
-      rmf_utils::optional<Time> lower_bound,
-      rmf_utils::optional<Time> upper_bound)
+    bool query_all_maps,
+    rmf_utils::optional<Time> lower_bound,
+    rmf_utils::optional<Time> upper_bound)
   {
     Timespan span;
     span._pimpl = rmf_utils::make_impl<Implementation>(
-          Implementation{
-            {},
-            query_all_maps,
-            lower_bound,
-            upper_bound
-          });
+      Implementation{
+        {},
+        query_all_maps,
+        lower_bound,
+        upper_bound
+      });
 
     return span;
   }
@@ -119,10 +119,10 @@ public:
   // regions_instance and timespan_instance uninitialized until they actually
   // get used.
   Implementation()
-    : regions_instance(Regions::Implementation::make({})),
-      timespan_instance(
-        Timespan::Implementation::make(
-          {}, rmf_utils::nullopt, rmf_utils::nullopt))
+  : regions_instance(Regions::Implementation::make({})),
+    timespan_instance(
+      Timespan::Implementation::make(
+        {}, rmf_utils::nullopt, rmf_utils::nullopt))
   {
     // Do nothing
   }
@@ -130,40 +130,40 @@ public:
 
 //==============================================================================
 Query::Spacetime::Spacetime()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   query_all();
 }
 
 //==============================================================================
 Query::Spacetime::Spacetime(std::vector<Region> regions)
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   query_regions(std::move(regions));
 }
 
 //==============================================================================
 Query::Spacetime::Spacetime(std::vector<std::string> maps)
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   query_timespan(std::move(maps));
 }
 
 //==============================================================================
 Query::Spacetime::Spacetime(
-    std::vector<std::string> maps,
-    Time lower_bound)
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+  std::vector<std::string> maps,
+  Time lower_bound)
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   query_timespan(std::move(maps), lower_bound);
 }
 
 //==============================================================================
 Query::Spacetime::Spacetime(
-    std::vector<std::string> maps,
-    Time lower_bound,
-    Time upper_bound)
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+  std::vector<std::string> maps,
+  Time lower_bound,
+  Time upper_bound)
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   query_timespan(std::move(maps), lower_bound, upper_bound);
 }
@@ -201,10 +201,10 @@ auto Query::Spacetime::Regions::erase(iterator it) -> iterator
 
 //==============================================================================
 auto Query::Spacetime::Regions::erase(
-    iterator first, iterator last) -> iterator
+  iterator first, iterator last) -> iterator
 {
   return Implementation::make_iterator(
-        _pimpl->regions.erase(first._pimpl->iter, last._pimpl->iter));
+    _pimpl->regions.erase(first._pimpl->iter, last._pimpl->iter));
 }
 
 //==============================================================================
@@ -217,7 +217,7 @@ auto Query::Spacetime::Regions::begin() -> iterator
 auto Query::Spacetime::Regions::begin() const -> const_iterator
 {
   return Implementation::make_iterator(
-        const_cast<Implementation::RegionSet&>(_pimpl->regions).begin());
+    const_cast<Implementation::RegionSet&>(_pimpl->regions).begin());
 }
 
 //==============================================================================
@@ -236,7 +236,7 @@ auto Query::Spacetime::Regions::end() -> iterator
 auto Query::Spacetime::Regions::end() const -> const_iterator
 {
   return Implementation::make_iterator(
-        const_cast<Implementation::RegionSet&>(_pimpl->regions).end());
+    const_cast<Implementation::RegionSet&>(_pimpl->regions).end());
 }
 
 //==============================================================================
@@ -253,7 +253,7 @@ std::size_t Query::Spacetime::Regions::size() const
 
 //==============================================================================
 Query::Spacetime::Regions::Regions()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
@@ -274,7 +274,7 @@ auto Query::Spacetime::Timespan::add_map(std::string map_name) -> Timespan&
 
 //==============================================================================
 auto Query::Spacetime::Timespan::remove_map(const std::string& map_name)
-  -> Timespan&
+-> Timespan&
 {
   _pimpl->maps.erase(map_name);
   return *this;
@@ -303,7 +303,7 @@ auto Query::Spacetime::Timespan::all_maps(bool query_all_maps) -> Timespan&
 //==============================================================================
 const Time* Query::Spacetime::Timespan::get_lower_time_bound() const
 {
-  if(_pimpl->lower_bound)
+  if (_pimpl->lower_bound)
     return &(*_pimpl->lower_bound);
 
   return nullptr;
@@ -326,7 +326,7 @@ auto Query::Spacetime::Timespan::remove_lower_time_bound() -> Timespan&
 //==============================================================================
 const Time* Query::Spacetime::Timespan::get_upper_time_bound() const
 {
-  if(_pimpl->upper_bound)
+  if (_pimpl->upper_bound)
     return &(*_pimpl->upper_bound);
 
   return nullptr;
@@ -357,14 +357,14 @@ auto Query::Spacetime::query_regions(std::vector<Region> regions) -> Regions&
 {
   _pimpl->mode = Mode::Regions;
   _pimpl->regions_instance =
-      Regions::Implementation::make(std::move(regions));
+    Regions::Implementation::make(std::move(regions));
   return _pimpl->regions_instance;
 }
 
 //==============================================================================
 auto Query::Spacetime::regions() -> Regions*
 {
-  if(Mode::Regions == _pimpl->mode)
+  if (Mode::Regions == _pimpl->mode)
     return &_pimpl->regions_instance;
 
   return nullptr;
@@ -373,7 +373,7 @@ auto Query::Spacetime::regions() -> Regions*
 //==============================================================================
 auto Query::Spacetime::regions() const -> const Regions*
 {
-  if(Mode::Regions == _pimpl->mode)
+  if (Mode::Regions == _pimpl->mode)
     return &_pimpl->regions_instance;
 
   return nullptr;
@@ -381,41 +381,41 @@ auto Query::Spacetime::regions() const -> const Regions*
 
 //==============================================================================
 auto Query::Spacetime::query_timespan(
-    std::vector<std::string> maps,
-    Time lower_bound,
-    Time upper_bound) -> Timespan&
+  std::vector<std::string> maps,
+  Time lower_bound,
+  Time upper_bound) -> Timespan&
 {
   _pimpl->mode = Mode::Timespan;
   _pimpl->timespan_instance =
-      Timespan::Implementation::make(
-        std::move(maps), lower_bound, upper_bound);
+    Timespan::Implementation::make(
+    std::move(maps), lower_bound, upper_bound);
 
   return _pimpl->timespan_instance;
 }
 
 //==============================================================================
 auto Query::Spacetime::query_timespan(
-    std::vector<std::string> maps,
-    Time lower_bound) -> Timespan&
+  std::vector<std::string> maps,
+  Time lower_bound) -> Timespan&
 {
   _pimpl->mode = Mode::Timespan;
   _pimpl->timespan_instance =
-      Timespan::Implementation::make(
-        std::move(maps), lower_bound, rmf_utils::nullopt);
+    Timespan::Implementation::make(
+    std::move(maps), lower_bound, rmf_utils::nullopt);
 
   return _pimpl->timespan_instance;
 }
 
 //==============================================================================
 auto Query::Spacetime::query_timespan(
-    std::vector<std::string> maps) -> Timespan&
+  std::vector<std::string> maps) -> Timespan&
 {
   _pimpl->mode = Mode::Timespan;
   _pimpl->timespan_instance =
-      Timespan::Implementation::make(
-        std::move(maps),
-        rmf_utils::nullopt,
-        rmf_utils::nullopt);
+    Timespan::Implementation::make(
+    std::move(maps),
+    rmf_utils::nullopt,
+    rmf_utils::nullopt);
 
   return _pimpl->timespan_instance;
 }
@@ -425,10 +425,10 @@ auto Query::Spacetime::query_timespan(bool query_all_maps) -> Timespan&
 {
   _pimpl->mode = Mode::Timespan;
   _pimpl->timespan_instance =
-      Timespan::Implementation::make(
-        query_all_maps,
-        rmf_utils::nullopt,
-        rmf_utils::nullopt);
+    Timespan::Implementation::make(
+    query_all_maps,
+    rmf_utils::nullopt,
+    rmf_utils::nullopt);
 
   return _pimpl->timespan_instance;
 }
@@ -436,7 +436,7 @@ auto Query::Spacetime::query_timespan(bool query_all_maps) -> Timespan&
 //==============================================================================
 auto Query::Spacetime::timespan() -> Timespan*
 {
-  if(Mode::Timespan == _pimpl->mode)
+  if (Mode::Timespan == _pimpl->mode)
     return &_pimpl->timespan_instance;
 
   return nullptr;
@@ -445,7 +445,7 @@ auto Query::Spacetime::timespan() -> Timespan*
 //==============================================================================
 auto Query::Spacetime::timespan() const -> const Timespan*
 {
-  if(Mode::Timespan == _pimpl->mode)
+  if (Mode::Timespan == _pimpl->mode)
     return &_pimpl->timespan_instance;
 
   return nullptr;
@@ -503,7 +503,7 @@ public:
 //==============================================================================
 Query::Participants::Include::Include(std::vector<ParticipantId> ids)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-           Implementation{uniquify(std::move(ids))}))
+      Implementation{uniquify(std::move(ids))}))
 {
   // Do nothing
 }
@@ -539,8 +539,8 @@ public:
 
 //==============================================================================
 Query::Participants::Exclude::Exclude(std::vector<ParticipantId> ids)
-  : _pimpl(rmf_utils::make_impl<Implementation>(
-             Implementation{uniquify(std::move(ids))}))
+: _pimpl(rmf_utils::make_impl<Implementation>(
+      Implementation{uniquify(std::move(ids))}))
 {
   // Do nothing
 }
@@ -567,7 +567,7 @@ Query::Participants::Exclude::Exclude()
 
 //==============================================================================
 Query::Participants::Participants()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
@@ -585,7 +585,7 @@ auto Query::Participants::make_only(std::vector<ParticipantId> ids)
   Participants participants;
   participants._pimpl->mode = Mode::Include;
   participants._pimpl->include._pimpl =
-      rmf_utils::make_impl<Include::Implementation>();
+    rmf_utils::make_impl<Include::Implementation>();
 
   participants._pimpl->include.set_ids(std::move(ids));
   return participants;
@@ -598,7 +598,7 @@ auto Query::Participants::make_all_except(std::vector<ParticipantId> ids)
   Participants participants;
   participants._pimpl->mode = Mode::Exclude;
   participants._pimpl->exclude._pimpl =
-      rmf_utils::make_impl<Exclude::Implementation>();
+    rmf_utils::make_impl<Exclude::Implementation>();
 
   participants._pimpl->exclude.set_ids(std::move(ids));
   return participants;
@@ -685,7 +685,7 @@ public:
   }
 
   static Query make_query(
-      std::vector<Region> regions)
+    std::vector<Region> regions)
   {
     Query result;
     result.spacetime().query_regions(std::move(regions));
@@ -693,17 +693,17 @@ public:
   }
 
   static Query make_query(
-      std::vector<std::string> maps,
-      const Time* start_time,
-      const Time* finish_time)
+    std::vector<std::string> maps,
+    const Time* start_time,
+    const Time* finish_time)
   {
     Query result;
     result.spacetime().query_timespan(std::move(maps));
     auto& timespan = *result.spacetime().timespan();
-    if(start_time)
+    if (start_time)
       timespan.set_lower_time_bound(*start_time);
 
-    if(finish_time)
+    if (finish_time)
       timespan.set_upper_time_bound(*finish_time);
 
     return result;
@@ -736,7 +736,7 @@ auto Query::participants() const -> const Participants&
 
 //==============================================================================
 Query::Query()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
@@ -755,12 +755,12 @@ Query make_query(std::vector<Region> regions)
 
 //==============================================================================
 Query make_query(
-    std::vector<std::string> maps,
-    const Time* start_time,
-    const Time* finish_time)
+  std::vector<std::string> maps,
+  const Time* start_time,
+  const Time* finish_time)
 {
   return Query::Implementation::make_query(
-        std::move(maps), start_time, finish_time);
+    std::move(maps), start_time, finish_time);
 }
 
 } // namespace schedule

--- a/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
@@ -24,19 +24,19 @@ namespace schedule {
 
 //==============================================================================
 Rectifier Rectifier::Implementation::make(
-    Participant::Implementation& participant)
+  Participant::Implementation& participant)
 {
   Rectifier rectifier;
   rectifier._pimpl = rmf_utils::make_unique_impl<Implementation>(
-        Implementation{participant});
+    Implementation{participant});
 
   return rectifier;
 }
 
 //==============================================================================
 void Rectifier::retransmit(
-    const std::vector<Range>& ranges,
-    ItineraryVersion last_known_version)
+  const std::vector<Range>& ranges,
+  ItineraryVersion last_known_version)
 {
   _pimpl->participant.retransmit(ranges, last_known_version);
 }
@@ -64,13 +64,13 @@ public:
   };
 
   DatabaseRectificationRequester(
-      const Database& database,
-      Rectifier rectifier,
-      ParticipantId id)
-    : _database(database),
-      _handle(std::make_shared<Handle>(Handle{*this})),
-      _rectifier(std::move(rectifier)),
-      _participant_id(id)
+    const Database& database,
+    Rectifier rectifier,
+    ParticipantId id)
+  : _database(database),
+    _handle(std::make_shared<Handle>(Handle{*this})),
+    _rectifier(std::move(rectifier)),
+    _participant_id(id)
   {
     // Do nothing
   }
@@ -116,9 +116,9 @@ public:
 
 //==============================================================================
 DatabaseRectificationRequesterFactory::DatabaseRectificationRequesterFactory(
-    const Database& database)
-  : _pimpl(rmf_utils::make_unique_impl<Implementation>(
-             Implementation{database, {}}))
+  const Database& database)
+: _pimpl(rmf_utils::make_unique_impl<Implementation>(
+      Implementation{database, {}}))
 {
   // Do nothing
 }
@@ -126,11 +126,11 @@ DatabaseRectificationRequesterFactory::DatabaseRectificationRequesterFactory(
 //==============================================================================
 std::unique_ptr<RectificationRequester>
 DatabaseRectificationRequesterFactory::make(
-    Rectifier rectifier,
-    ParticipantId participant_id)
+  Rectifier rectifier,
+  ParticipantId participant_id)
 {
   auto requester = std::make_unique<DatabaseRectificationRequester>(
-        _pimpl->_database, std::move(rectifier), participant_id);
+    _pimpl->_database, std::move(rectifier), participant_id);
 
   _pimpl->_handles.push_back(requester->_handle);
   return std::move(requester);
@@ -151,10 +151,10 @@ void DatabaseRectificationRequesterFactory::rectify()
 
   // If any handles have expired, remove them
   handles.erase(std::remove_if(
-                  handles.begin(),
-                  handles.end(),
-                  [](const WeakHandlePtr& h){ return h.expired(); }),
-                handles.end());
+      handles.begin(),
+      handles.end(),
+      [](const WeakHandlePtr& h) { return h.expired(); }),
+    handles.end());
 }
 
 } // namespace schedule

--- a/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
@@ -46,7 +46,7 @@ const Duration PartialBucketDuration = std::chrono::seconds(50);
 struct ParticipantFilter
 {
   static std::unordered_set<ParticipantId> convert(
-      const std::vector<ParticipantId>& ids)
+    const std::vector<ParticipantId>& ids)
   {
     std::unordered_set<ParticipantId> output;
     for (const auto id : ids)
@@ -114,7 +114,7 @@ public:
   using Bucket = std::vector<const Entry*>;
   using BucketPtr = std::shared_ptr<Bucket>;
   using Checked =
-      std::unordered_map<ParticipantId, std::unordered_set<RouteId>>;
+    std::unordered_map<ParticipantId, std::unordered_set<RouteId>>;
 
   // TODO(MXG): Come up with a better name for this data structure than Entries
   using Entries = std::map<Time, BucketPtr>;
@@ -125,8 +125,8 @@ public:
   struct Handle
   {
     Handle(
-        const Entry* entry,
-        std::vector<std::weak_ptr<Bucket>> buckets)
+      const Entry* entry,
+      std::vector<std::weak_ptr<Bucket>> buckets)
     : _entry(entry),
       _buckets(std::move(buckets))
     {
@@ -154,7 +154,7 @@ public:
 
   /// Constructor
   Timeline()
-    : _all_bucket(std::make_shared<Bucket>())
+  : _all_bucket(std::make_shared<Bucket>())
   {
     // Do nothing
   }
@@ -173,7 +173,7 @@ public:
       const std::string& map_name = entry.route->map();
 
       const auto map_it = _timelines.insert(
-            std::make_pair(map_name, Entries())).first;
+        std::make_pair(map_name, Entries())).first;
 
       Entries& timeline = map_it->second;
 
@@ -188,14 +188,14 @@ public:
     }
 
     entry.timeline_handle = std::make_shared<Handle>(
-          &entry, std::move(buckets));
+      &entry, std::move(buckets));
   }
 
   /// Inspect the timeline for entries that match the query
   template<typename Inspector>
   void inspect(
-      const Query& query,
-      Inspector& inspector) const
+    const Query& query,
+    Inspector& inspector) const
   {
     const Query::Participants& participants = query.participants();
     const Query::Participants::Mode mode = participants.get_mode();
@@ -203,29 +203,29 @@ public:
     if (Query::Participants::Mode::All == mode)
     {
       inspect_spacetime(
-            query.spacetime(),
-            ParticipantFilter::AllowAll(),
-            inspector);
+        query.spacetime(),
+        ParticipantFilter::AllowAll(),
+        inspector);
     }
     else if (Query::Participants::Mode::Include == mode)
     {
       inspect_spacetime(
-            query.spacetime(),
-            ParticipantFilter::Include(participants.include()->get_ids()),
-            inspector);
+        query.spacetime(),
+        ParticipantFilter::Include(participants.include()->get_ids()),
+        inspector);
     }
     else if (Query::Participants::Mode::Exclude == mode)
     {
       inspect_spacetime(
-            query.spacetime(),
-            ParticipantFilter::Exclude(participants.exclude()->get_ids()),
-            inspector);
+        query.spacetime(),
+        ParticipantFilter::Exclude(participants.exclude()->get_ids()),
+        inspector);
     }
     else
     {
       throw std::runtime_error(
-            "Unexpected Query::Participants mode: "
-            + std::to_string(static_cast<uint16_t>(mode)));
+              "Unexpected Query::Participants mode: "
+              + std::to_string(static_cast<uint16_t>(mode)));
     }
   }
 
@@ -249,9 +249,9 @@ private:
 
   template<typename Inspector, typename ParticipantFilter>
   void inspect_spacetime(
-      const Query::Spacetime& spacetime,
-      const ParticipantFilter& participant_filter,
-      Inspector& inspector) const
+    const Query::Spacetime& spacetime,
+    const ParticipantFilter& participant_filter,
+    Inspector& inspector) const
   {
     const Query::Spacetime::Mode mode = spacetime.get_mode();
 
@@ -262,19 +262,19 @@ private:
     else if (Query::Spacetime::Mode::Regions == mode)
     {
       inspect_spacetime_regions(
-            *spacetime.regions(), participant_filter, inspector);
+        *spacetime.regions(), participant_filter, inspector);
     }
     else if (Query::Spacetime::Mode::Timespan == mode)
     {
       inspect_spacetime_timespan(
-            *spacetime.timespan(), participant_filter, inspector);
+        *spacetime.timespan(), participant_filter, inspector);
     }
   }
 
   template<typename Inspector, typename ParticipantFilter>
   void inspect_all_spacetime(
-      const ParticipantFilter& participant_filter,
-      Inspector& inspector) const
+    const ParticipantFilter& participant_filter,
+    Inspector& inspector) const
   {
     Checked checked;
 
@@ -293,19 +293,21 @@ private:
 
   template<typename Inspector, typename ParticipantFilter>
   void inspect_spacetime_regions(
-      const Query::Spacetime::Regions& regions,
-      const ParticipantFilter& participant_filter,
-      Inspector& inspector) const
+    const Query::Spacetime::Regions& regions,
+    const ParticipantFilter& participant_filter,
+    Inspector& inspector) const
   {
     Checked checked;
 
     rmf_traffic::internal::Spacetime spacetime_data;
-    const auto relevant = [&spacetime_data](const Entry& entry) -> bool {
-      return rmf_traffic::internal::detect_conflicts(
-            entry.description->profile(),
-            entry.route->trajectory(),
-            spacetime_data);
-    };
+    const auto relevant =
+      [&spacetime_data](const Entry& entry) -> bool
+      {
+        return rmf_traffic::internal::detect_conflicts(
+          entry.description->profile(),
+          entry.route->trajectory(),
+          spacetime_data);
+      };
 
     for (const Region& region : regions)
     {
@@ -322,10 +324,10 @@ private:
       spacetime_data.upper_time_bound = upper_time_bound;
 
       const auto timeline_begin =
-          get_timeline_begin(timeline, lower_time_bound);
+        get_timeline_begin(timeline, lower_time_bound);
 
       const auto timeline_end =
-          get_timeline_end(timeline, upper_time_bound);
+        get_timeline_end(timeline, upper_time_bound);
 
       if (timeline_begin == timeline_end)
       {
@@ -340,21 +342,21 @@ private:
         spacetime_data.shape = space_it->get_shape();
 
         inspect_entries(
-              relevant,
-              participant_filter,
-              inspector,
-              timeline_begin,
-              timeline_end,
-              checked);
+          relevant,
+          participant_filter,
+          inspector,
+          timeline_begin,
+          timeline_end,
+          checked);
       }
     }
   }
 
   template<typename Inspector, typename ParticipantFilter>
   void inspect_spacetime_timespan(
-      const Query::Spacetime::Timespan& timespan,
-      const ParticipantFilter& participant_filter,
-      Inspector& inspector) const
+    const Query::Spacetime::Timespan& timespan,
+    const ParticipantFilter& participant_filter,
+    Inspector& inspector) const
   {
     Checked checked;
 
@@ -362,18 +364,18 @@ private:
     const Time* const upper_time_bound = timespan.get_upper_time_bound();
 
     const auto relevant = [&lower_time_bound, &upper_time_bound](
-        const Entry& entry) -> bool
-    {
-      const Trajectory& trajectory = entry.route->trajectory();
-      assert(trajectory.start_time());
-      if (lower_time_bound && *trajectory.finish_time() < *lower_time_bound)
-        return false;
+      const Entry& entry) -> bool
+      {
+        const Trajectory& trajectory = entry.route->trajectory();
+        assert(trajectory.start_time());
+        if (lower_time_bound && *trajectory.finish_time() < *lower_time_bound)
+          return false;
 
-      if (upper_time_bound && *upper_time_bound < *trajectory.start_time())
-        return false;
+        if (upper_time_bound && *upper_time_bound < *trajectory.start_time())
+          return false;
 
-      return true;
-    };
+        return true;
+      };
 
     if (timespan.all_maps())
     {
@@ -381,12 +383,12 @@ private:
       {
         const Entries& timeline = timeline_it.second;
         inspect_entries(
-              relevant,
-              participant_filter,
-              inspector,
-              get_timeline_begin(timeline, lower_time_bound),
-              get_timeline_end(timeline, upper_time_bound),
-              checked);
+          relevant,
+          participant_filter,
+          inspector,
+          get_timeline_begin(timeline, lower_time_bound),
+          get_timeline_end(timeline, upper_time_bound),
+          checked);
       }
     }
     else
@@ -400,24 +402,24 @@ private:
 
         const Entries& timeline = map_it->second;
         inspect_entries(
-              relevant,
-              participant_filter,
-              inspector,
-              get_timeline_begin(timeline, lower_time_bound),
-              get_timeline_end(timeline, upper_time_bound),
-              checked);
+          relevant,
+          participant_filter,
+          inspector,
+          get_timeline_begin(timeline, lower_time_bound),
+          get_timeline_end(timeline, upper_time_bound),
+          checked);
       }
     }
   }
 
   template<typename Inspector, typename ParticipantFilter>
   void inspect_entries(
-      const std::function<bool(const Entry&)>& relevant,
-      const ParticipantFilter& participant_filter,
-      Inspector& inspector,
-      const typename Entries::const_iterator& timeline_begin,
-      const typename Entries::const_iterator& timeline_end,
-      Checked& checked) const
+    const std::function<bool(const Entry&)>& relevant,
+    const ParticipantFilter& participant_filter,
+    Inspector& inspector,
+    const typename Entries::const_iterator& timeline_begin,
+    const typename Entries::const_iterator& timeline_end,
+    Checked& checked) const
   {
     auto timeline_it = timeline_begin;
     for (; timeline_it != timeline_end; ++timeline_it)
@@ -442,65 +444,65 @@ private:
 
   //============================================================================
   static typename Entries::iterator get_timeline_iterator(
-      Entries& timeline, const Time time)
+    Entries& timeline, const Time time)
   {
     auto start_it = timeline.lower_bound(time);
 
-    if(start_it == timeline.end())
+    if (start_it == timeline.end())
     {
-      if(timeline.empty())
+      if (timeline.empty())
       {
         // This timeline is completely empty, so we'll begin creating buckets
         // starting from the time of this trajectory.
         return timeline.insert(
-              timeline.end(),
-              std::make_pair(
-                time + PartialBucketDuration,
-                std::make_shared<Bucket>()));
+          timeline.end(),
+          std::make_pair(
+            time + PartialBucketDuration,
+            std::make_shared<Bucket>()));
       }
 
       auto last_it = --timeline.end();
-      while(last_it->first < time)
+      while (last_it->first < time)
       {
         last_it = timeline.insert(
-              timeline.end(),
-              std::make_pair(
-                last_it->first + BucketDuration,
-                std::make_shared<Bucket>()));
+          timeline.end(),
+          std::make_pair(
+            last_it->first + BucketDuration,
+            std::make_shared<Bucket>()));
       }
 
       return last_it;
     }
 
-    while(time + BucketDuration < start_it->first)
+    while (time + BucketDuration < start_it->first)
     {
       start_it = timeline.insert(
-            start_it,
-            std::make_pair(
-              start_it->first - BucketDuration,
-              std::make_shared<Bucket>()));
+        start_it,
+        std::make_pair(
+          start_it->first - BucketDuration,
+          std::make_shared<Bucket>()));
     }
 
     return start_it;
   }
 
   static typename Entries::const_iterator get_timeline_begin(
-      const Entries& timeline,
-      const Time* const lower_time_bound)
+    const Entries& timeline,
+    const Time* const lower_time_bound)
   {
-    return (lower_time_bound == nullptr)?
-          timeline.begin() : timeline.lower_bound(*lower_time_bound);
+    return (lower_time_bound == nullptr) ?
+      timeline.begin() : timeline.lower_bound(*lower_time_bound);
   }
 
   static typename Entries::const_iterator get_timeline_end(
-      const Entries& timeline,
-      const Time* upper_time_bound)
+    const Entries& timeline,
+    const Time* upper_time_bound)
   {
-    if(upper_time_bound == nullptr)
+    if (upper_time_bound == nullptr)
       return timeline.end();
 
     auto end = timeline.upper_bound(*upper_time_bound);
-    if(end == timeline.end())
+    if (end == timeline.end())
       return end;
 
     return ++end;
@@ -518,8 +520,8 @@ class TimelineInspector
 public:
 
   virtual void inspect(
-      const Entry* entry,
-      const std::function<bool(const Entry& entry)>& relevant) = 0;
+    const Entry* entry,
+    const std::function<bool(const Entry& entry)>& relevant) = 0;
 
   virtual ~TimelineInspector() = default;
 };

--- a/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Timeline.hpp
@@ -223,9 +223,11 @@ public:
     }
     else
     {
+      // *INDENT-OFF*
       throw std::runtime_error(
-              "Unexpected Query::Participants mode: "
-              + std::to_string(static_cast<uint16_t>(mode)));
+        "Unexpected Query::Participants mode: "
+        + std::to_string(static_cast<uint16_t>(mode)));
+      // *INDENT-ON*
     }
   }
 

--- a/rmf_traffic/src/rmf_traffic/schedule/ViewerInternal.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/ViewerInternal.hpp
@@ -47,10 +47,10 @@ public:
 
     View view;
     view._pimpl = rmf_utils::make_impl<Implementation>(
-          Implementation{
-            std::move(input),
-            std::move(elements)
-          });
+      Implementation{
+        std::move(input),
+        std::move(elements)
+      });
     return view;
   }
 
@@ -58,13 +58,13 @@ public:
   {
     append_to_elements(view._pimpl->elements, input);
     view._pimpl->storage.insert(
-          view._pimpl->storage.end(),
-          std::make_move_iterator(input.begin()),
-          std::make_move_iterator(input.end()));
+      view._pimpl->storage.end(),
+      std::make_move_iterator(input.begin()),
+      std::make_move_iterator(input.end()));
   }
 
   static std::vector<Element> make_elements(
-      const std::vector<Storage>& input)
+    const std::vector<Storage>& input)
   {
     std::vector<Element> elements;
     append_to_elements(elements, input);
@@ -72,15 +72,15 @@ public:
   }
 
   static void append_to_elements(
-      std::vector<Element>& elements,
-      const std::vector<Storage>& input)
+    std::vector<Element>& elements,
+    const std::vector<Storage>& input)
   {
     elements.reserve(elements.size() + input.size());
     for (const auto& s : input)
     {
       assert(s.route);
       elements.emplace_back(
-            Element{s.participant, s.route_id, *s.route, *s.description});
+        Element{s.participant, s.route_id, *s.route, *s.description});
     }
   }
 };

--- a/rmf_traffic/src/rmf_traffic/schedule/debug_Database.hpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/debug_Database.hpp
@@ -45,8 +45,8 @@ public:
   // Returns the itinerary of a participant with given ParticipantId in the form
   // of Writer::Input
   static rmf_utils::optional<Writer::Input> get_itinerary(
-      const Database& db,
-      const ParticipantId participant);
+    const Database& db,
+    const ParticipantId participant);
 
 };
 

--- a/rmf_traffic/src/submission_component.cpp
+++ b/rmf_traffic/src/submission_component.cpp
@@ -30,9 +30,7 @@ class SubmissionComponent : public rclcpp::Node
 public:
 
 
-
 private:
-
 
 
 };

--- a/rmf_traffic/test/regression/regress_Negotiation.cpp
+++ b/rmf_traffic/test/regression/regress_Negotiation.cpp
@@ -26,9 +26,9 @@ namespace {
 struct MockNegotiator : public rmf_traffic::schedule::Negotiator
 {
   virtual void respond(
-      std::shared_ptr<const rmf_traffic::schedule::Negotiation::Table>,
-      const Responder& responder,
-      const bool* = nullptr) final
+    std::shared_ptr<const rmf_traffic::schedule::Negotiation::Table>,
+    const Responder& responder,
+    const bool* = nullptr) final
   {
     if (_submit)
       responder.submit({});
@@ -60,29 +60,29 @@ struct Table
 
 //==============================================================================
 void apply_submissions(
-    const std::shared_ptr<rmf_traffic::schedule::Negotiation>& negotiation,
-    const std::vector<Table>& submitted)
+  const std::shared_ptr<rmf_traffic::schedule::Negotiation>& negotiation,
+  const std::vector<Table>& submitted)
 {
   using Responder = rmf_traffic::schedule::SimpleResponder;
   for (const auto& table : submitted)
   {
     MockNegotiator().submit().respond(
-          negotiation->table(table.for_participant, table.to_accommodate),
-          Responder(negotiation, table.for_participant, table.to_accommodate));
+      negotiation->table(table.for_participant, table.to_accommodate),
+      Responder(negotiation, table.for_participant, table.to_accommodate));
   }
 }
 
 //==============================================================================
 void apply_rejection(
-    const std::shared_ptr<rmf_traffic::schedule::Negotiation>& negotiation,
-    const std::vector<Table>& rejected)
+  const std::shared_ptr<rmf_traffic::schedule::Negotiation>& negotiation,
+  const std::vector<Table>& rejected)
 {
   using Responder = rmf_traffic::schedule::SimpleResponder;
   for (const auto& table : rejected)
   {
     MockNegotiator().reject().respond(
-          negotiation->table(table.for_participant, table.to_accommodate),
-          Responder(negotiation, table.for_participant, table.to_accommodate));
+      negotiation->table(table.for_participant, table.to_accommodate),
+      Responder(negotiation, table.for_participant, table.to_accommodate));
   }
 }
 
@@ -95,8 +95,8 @@ SCENARIO("Identify a failed negotiation")
   // while adding participants.
   rmf_traffic::schedule::Database database;
   auto negotiation =
-      std::make_shared<rmf_traffic::schedule::Negotiation>(
-        database, std::vector<rmf_traffic::schedule::ParticipantId>{0, 2});
+    std::make_shared<rmf_traffic::schedule::Negotiation>(
+    database, std::vector<rmf_traffic::schedule::ParticipantId>{0, 2});
 
   std::vector<Table> submitted =
   {
@@ -144,21 +144,21 @@ SCENARIO("Submit after a rejection")
     rmf_utils::optional<rmf_traffic::schedule::Version>* version;
 
     MockResponder(
-          rmf_traffic::schedule::Negotiation::TablePtr table_,
-          bool* accepted_,
-          rmf_utils::optional<rmf_traffic::schedule::Version>* version_)
-      : table(table_),
-        accepted(accepted_),
-        version(version_)
+      rmf_traffic::schedule::Negotiation::TablePtr table_,
+      bool* accepted_,
+      rmf_utils::optional<rmf_traffic::schedule::Version>* version_)
+    : table(table_),
+      accepted(accepted_),
+      version(version_)
     {
       // Do nothing
     }
 
     void submit(
-          std::vector<rmf_traffic::Route> itinerary,
-          std::function<UpdateVersion()>) const final
+      std::vector<rmf_traffic::Route> itinerary,
+      std::function<UpdateVersion()>) const final
     {
-      *version = table->version()? *table->version() + 1 : 0;
+      *version = table->version() ? *table->version() + 1 : 0;
       *accepted = table->submit(std::move(itinerary), **version);
     }
 
@@ -168,15 +168,15 @@ SCENARIO("Submit after a rejection")
       if (parent)
         parent->reject(*parent->version());
       else
-        table->reject(table->version()? *table->version() : 0);
+        table->reject(table->version() ? *table->version() : 0);
     }
 
   };
 
   rmf_traffic::schedule::Database database;
   auto negotiation =
-      std::make_shared<rmf_traffic::schedule::Negotiation>(
-        database, std::vector<rmf_traffic::schedule::ParticipantId>{0, 1});
+    std::make_shared<rmf_traffic::schedule::Negotiation>(
+    database, std::vector<rmf_traffic::schedule::ParticipantId>{0, 1});
 
   bool accepted = false;
   rmf_utils::optional<rmf_traffic::schedule::Version> version;
@@ -191,7 +191,8 @@ SCENARIO("Submit after a rejection")
 
   accepted = false;
   version = rmf_utils::nullopt;
-  MockResponder child_responder(negotiation->table(1, {0}), &accepted, &version);
+  MockResponder child_responder(negotiation->table(1, {0}), &accepted,
+    &version);
   MockNegotiator().reject().respond(child_responder.table, child_responder);
 
   CHECK_FALSE(version);

--- a/rmf_traffic/test/unit/agv/test_Graph.cpp
+++ b/rmf_traffic/test/unit/agv/test_Graph.cpp
@@ -25,181 +25,167 @@
 #include "../utils_Trajectory.hpp"
 
 #include <iostream>
-#include<iomanip>
+#include <iomanip>
 
-void CHECK_WAYPOINT(rmf_traffic::agv::Graph::Waypoint wp,Eigen::Vector2d waypoint_location,std::string test_map_name,std::size_t index, bool holding)
-    {  
-        CHECK((wp.get_location()-waypoint_location).norm() ==Approx(0));
-        CHECK(wp.get_map_name()==test_map_name);
-        CHECK(wp.index()==index);
-        CHECK(wp.is_holding_point()==holding);
+void CHECK_WAYPOINT(rmf_traffic::agv::Graph::Waypoint wp,
+  Eigen::Vector2d waypoint_location,
+  std::string test_map_name, std::size_t index, bool holding)
+{
+  CHECK((wp.get_location()-waypoint_location).norm() == Approx(0));
+  CHECK(wp.get_map_name() == test_map_name);
+  CHECK(wp.index() == index);
+  CHECK(wp.is_holding_point() == holding);
+}
 
-    }
-
-void CHECK_LANE(rmf_traffic::agv::Graph::Lane lane, std::size_t lane_index, rmf_traffic::agv::Graph::Lane::Node entry_node,rmf_traffic::agv::Graph::Lane::Node exit_node)
-    {
-        CHECK(lane.index()==lane_index);
-        CHECK(lane.entry().waypoint_index()==entry_node.waypoint_index());
-        CHECK(lane.exit().waypoint_index()==exit_node.waypoint_index());
-
-    }
+void CHECK_LANE(rmf_traffic::agv::Graph::Lane lane, std::size_t lane_index,
+  rmf_traffic::agv::Graph::Lane::Node entry_node,
+  rmf_traffic::agv::Graph::Lane::Node exit_node)
+{
+  CHECK(lane.index() == lane_index);
+  CHECK(lane.entry().waypoint_index() == entry_node.waypoint_index());
+  CHECK(lane.exit().waypoint_index() == exit_node.waypoint_index());
+}
 
 SCENARIO("Tests for Graph API")
 {
 
-using namespace std::chrono_literals;
+  using namespace std::chrono_literals;
 
 //rmf_traffic::Time time= std::chrono::steady_clock::now();
-rmf_traffic::agv::Graph graph;
-REQUIRE(graph.num_waypoints()==0);
-REQUIRE(graph.num_lanes()==0);
+  rmf_traffic::agv::Graph graph;
+  REQUIRE(graph.num_waypoints() == 0);
+  REQUIRE(graph.num_lanes() == 0);
 
+  const std::string test_map_name = "test_map";
 
-const std::string test_map_name="test_map";
+  WHEN("Graph is empty")
+  {
+    // perhaps this function can accept an \[out] Waypoint parameter and return bool
+    CHECK_THROWS(graph.get_waypoint(0));
+  }
 
-WHEN("Graph is empty")
-    {
-        // perhaps this function can accept an \[out] Waypoint parameter and return bool
-        CHECK_THROWS(graph.get_waypoint(0));
-        
+  WHEN("A non-holding waypoint is added")
+  {
+    Eigen::Vector2d waypoint_location = Eigen::Vector2d{0, 0};
+    auto& wp1 = graph.add_waypoint(test_map_name, waypoint_location);
+    CHECK(graph.num_waypoints() == 1);
+    CHECK_WAYPOINT(wp1, waypoint_location, test_map_name, 0, false);
 
-    }
-WHEN("A non-holding waypoint is added")
-    {
-        Eigen::Vector2d waypoint_location=Eigen::Vector2d{0,0};
-        auto& wp1= graph.add_waypoint(test_map_name,waypoint_location);
-        CHECK(graph.num_waypoints()==1);
-        CHECK_WAYPOINT(wp1,waypoint_location,test_map_name,0,false);
+    wp1.set_holding_point(true);
+    wp1.set_map_name("not_test");
+    wp1.set_location(Eigen::Vector2d{1, 1});
 
-        wp1.set_holding_point(true);
-        wp1.set_map_name("not_test");
-        wp1.set_location(Eigen::Vector2d{1,1});
+    //checking values of updated waypoint
+    const auto wp = graph.get_waypoint(0);
+    CHECK_WAYPOINT(wp, Eigen::Vector2d{1, 1}, "not_test", 0, true);
 
-        //checking values of updated waypoint
-        const auto wp=graph.get_waypoint(0);
-        CHECK_WAYPOINT(wp,Eigen::Vector2d{1,1},"not_test",0,true);
-
-        WHEN("A second waypoint is added")
-        {
-
-            graph.add_waypoint(test_map_name,Eigen::Vector2d{2,2});
-            CHECK(graph.num_waypoints()==2);
-            CHECK_WAYPOINT(graph.get_waypoint(1),Eigen::Vector2d{2,2},test_map_name,1,false);
- 
-
-        }
-
-    }
-WHEN("A lane without a door is added")
-    {
-        graph.add_waypoint(test_map_name,Eigen::Vector2d{0,0});
-        graph.add_waypoint(test_map_name,Eigen::Vector2d{10,10});
-
-        rmf_traffic::agv::Graph::Lane::Node entry_node{0};
-        CHECK(entry_node.waypoint_index()==0);
-        CHECK(entry_node.velocity_constraint()==nullptr);
-        CHECK(entry_node.orientation_constraint()==nullptr);
-
-        std::vector<double> acceptable_orientations {0,M_PI};
-        
-        rmf_traffic::agv::Graph::Lane::Node exit_node{
-            1, nullptr,
-            rmf_traffic::agv::Graph::OrientationConstraint::make(acceptable_orientations),
-            };
-
-        CHECK(exit_node.waypoint_index()==1);
-        CHECK(exit_node.velocity_constraint()==nullptr);
-        CHECK(exit_node.orientation_constraint()!=nullptr);
-
-
-        auto& lane1=graph.add_lane(entry_node, exit_node);
-        CHECK(graph.num_lanes()==1);
-        CHECK_LANE(lane1,0,entry_node,exit_node);
-        CHECK_LANE(graph.get_lane(0),0,entry_node,exit_node);
-
-
-
-        auto& lane2=graph.add_lane(exit_node, entry_node);
-        CHECK(graph.num_lanes()==2);
-        CHECK_LANE(lane2,1,exit_node,entry_node);
-        CHECK_LANE(graph.get_lane(1),1,exit_node,entry_node);
-
-
-    }
-
-WHEN("A lane with a door is added")
+    WHEN("A second waypoint is added")
     {
 
-        graph.add_waypoint(test_map_name,Eigen::Vector2d{0,0});
-        graph.add_waypoint(test_map_name,Eigen::Vector2d{10,10});
-
-        //Door not implemented yet
-        // auto door =rmf_traffic::agv::Graph::Door();
-        // graph.add_lane({1},{2},door);
-        // CHECK(graph.num_doors()==1);
-        // auto& _door=graph.get_door(0);
-        // CHECK(_door.index()==0);
-        
-
+      graph.add_waypoint(test_map_name, Eigen::Vector2d{2, 2});
+      CHECK(graph.num_waypoints() == 2);
+      CHECK_WAYPOINT(graph.get_waypoint(
+          1), Eigen::Vector2d{2, 2}, test_map_name, 1, false);
     }
+  }
 
-WHEN("Adding N waypoints to graph")
+  WHEN("A lane without a door is added")
+  {
+    graph.add_waypoint(test_map_name, Eigen::Vector2d{0, 0});
+    graph.add_waypoint(test_map_name, Eigen::Vector2d{10, 10});
+
+    rmf_traffic::agv::Graph::Lane::Node entry_node{0};
+    CHECK(entry_node.waypoint_index() == 0);
+    CHECK(entry_node.velocity_constraint() == nullptr);
+    CHECK(entry_node.orientation_constraint() == nullptr);
+
+    std::vector<double> acceptable_orientations {0, M_PI};
+
+    rmf_traffic::agv::Graph::Lane::Node exit_node{
+      1, nullptr,
+      rmf_traffic::agv::Graph::OrientationConstraint::make(
+        acceptable_orientations),
+    };
+
+    CHECK(exit_node.waypoint_index() == 1);
+    CHECK(exit_node.velocity_constraint() == nullptr);
+    CHECK(exit_node.orientation_constraint() != nullptr);
+
+    auto& lane1 = graph.add_lane(entry_node, exit_node);
+    CHECK(graph.num_lanes() == 1);
+    CHECK_LANE(lane1, 0, entry_node, exit_node);
+    CHECK_LANE(graph.get_lane(0), 0, entry_node, exit_node);
+
+    auto& lane2 = graph.add_lane(exit_node, entry_node);
+    CHECK(graph.num_lanes() == 2);
+    CHECK_LANE(lane2, 1, exit_node, entry_node);
+    CHECK_LANE(graph.get_lane(1), 1, exit_node, entry_node);
+  }
+
+  WHEN("A lane with a door is added")
+  {
+    graph.add_waypoint(test_map_name, Eigen::Vector2d{0, 0});
+    graph.add_waypoint(test_map_name, Eigen::Vector2d{10, 10});
+
+    //Door not implemented yet
+    // auto door =rmf_traffic::agv::Graph::Door();
+    // graph.add_lane({1},{2},door);
+    // CHECK(graph.num_doors()==1);
+    // auto& _door=graph.get_door(0);
+    // CHECK(_door.index()==0);
+  }
+
+  WHEN("Adding N waypoints to graph")
+  {
+    const std::size_t N = 100;
+
+    for (std::size_t i = 0; i < N; i++)
+      graph.add_waypoint(test_map_name, Eigen::Vector2d{std::rand(),
+          std::rand()});
+
+    CHECK(graph.num_waypoints() == N);
+
+    WHEN("Copy operator is checked")
     {
-
-        const std::size_t N = 100;
-
-        for(std::size_t i=0;i<N;i++)
-            graph.add_waypoint(test_map_name,Eigen::Vector2d{std::rand(),std::rand()});
-
-        CHECK(graph.num_waypoints()==N);
-
-        WHEN("Copy operator is checked")
-        {
-        //CHECKING for Independence 
-        rmf_traffic::agv::Graph graph2;
-        graph2=graph;
-        graph.add_waypoint(test_map_name,Eigen::Vector2d{-10,-10});
-        CHECK(graph.num_waypoints()==N+1);
-        CHECK(graph2.num_waypoints()==N);
-        }
-
-        WHEN("Copy constructor is checked")
-        {
-            rmf_traffic::agv::Graph graph2{graph};
-            graph.add_waypoint(test_map_name,Eigen::Vector2d{-10,-10});
-            CHECK(graph.num_waypoints()==N+1);
-            CHECK(graph2.num_waypoints()==N);
-            
-
-        }
-        WHEN("Move operator is checked")
-            {
-                rmf_traffic::agv::Graph moved= graph;
-                rmf_traffic::agv::Graph graph2;
-                graph2=std::move(moved);
-                moved=graph;
-                graph.add_waypoint(test_map_name,Eigen::Vector2d{-10,-10});
-
-                CHECK(graph.num_waypoints()==N+1);
-                CHECK(graph2.num_waypoints()==N);
-                CHECK(moved.num_waypoints()==N);
-
-            }
-        WHEN("Move constructor is checked")
-            {
-                rmf_traffic::agv::Graph moved= graph;
-                rmf_traffic::agv::Graph graph2=std::move(moved);
-                moved=graph;
-                graph.add_waypoint(test_map_name,Eigen::Vector2d{-10,-10});
-
-                CHECK(graph.num_waypoints()==N+1);
-                CHECK(graph2.num_waypoints()==N);
-                CHECK(moved.num_waypoints()==N);
-
-            }
-
+      //CHECKING for Independence
+      rmf_traffic::agv::Graph graph2;
+      graph2 = graph;
+      graph.add_waypoint(test_map_name, Eigen::Vector2d{-10, -10});
+      CHECK(graph.num_waypoints() == N+1);
+      CHECK(graph2.num_waypoints() == N);
     }
 
+    WHEN("Copy constructor is checked")
+    {
+      rmf_traffic::agv::Graph graph2{graph};
+      graph.add_waypoint(test_map_name, Eigen::Vector2d{-10, -10});
+      CHECK(graph.num_waypoints() == N+1);
+      CHECK(graph2.num_waypoints() == N);
+    }
 
+    WHEN("Move operator is checked")
+    {
+      rmf_traffic::agv::Graph moved = graph;
+      rmf_traffic::agv::Graph graph2;
+      graph2 = std::move(moved);
+      moved = graph;
+      graph.add_waypoint(test_map_name, Eigen::Vector2d{-10, -10});
 
+      CHECK(graph.num_waypoints() == N+1);
+      CHECK(graph2.num_waypoints() == N);
+      CHECK(moved.num_waypoints() == N);
+    }
+
+    WHEN("Move constructor is checked")
+    {
+      rmf_traffic::agv::Graph moved = graph;
+      rmf_traffic::agv::Graph graph2 = std::move(moved);
+      moved = graph;
+      graph.add_waypoint(test_map_name, Eigen::Vector2d{-10, -10});
+
+      CHECK(graph.num_waypoints() == N+1);
+      CHECK(graph2.num_waypoints() == N);
+      CHECK(moved.num_waypoints() == N);
+    }
+  }
 }

--- a/rmf_traffic/test/unit/agv/test_Interpolate.cpp
+++ b/rmf_traffic/test/unit/agv/test_Interpolate.cpp
@@ -38,11 +38,11 @@ struct PredictedTimes
 };
 
 void test_interpolation(
-    const Eigen::Vector3d& p0,
-    const Eigen::Vector3d& dir,
-    const double a_n, // nominal acceleration
-    const PredictedTimes& times,
-    const rmf_traffic::Trajectory& trajectory)
+  const Eigen::Vector3d& p0,
+  const Eigen::Vector3d& dir,
+  const double a_n, // nominal acceleration
+  const PredictedTimes& times,
+  const rmf_traffic::Trajectory& trajectory)
 {
   using namespace std::chrono_literals;
 
@@ -56,118 +56,119 @@ void test_interpolation(
   REQUIRE(dt > 0.0);
   const rmf_traffic::Time trajectory_start_time = *trajectory.start_time();
   const rmf_traffic::Time start_time =
-      rmf_traffic::time::apply_offset(trajectory_start_time, t_start);
+    rmf_traffic::time::apply_offset(trajectory_start_time, t_start);
 
   const rmf_traffic::Time finish_time =
-      rmf_traffic::time::apply_offset(trajectory_start_time, t_finish);
+    rmf_traffic::time::apply_offset(trajectory_start_time, t_finish);
 
   const Eigen::Vector3d normalized_dir = dir.normalized();
 
   const std::size_t NumTests = 50;
-  for(std::size_t i=1; i < NumTests; ++i)
+  for (std::size_t i = 1; i < NumTests; ++i)
   {
     const double u = static_cast<double>(i)/static_cast<double>(NumTests);
     const double t_rel = u*dt;
     const auto t = rmf_traffic::time::apply_offset(
-          trajectory_start_time, t_rel + t_start);
+      trajectory_start_time, t_rel + t_start);
 
     const auto it = trajectory.find(t);
     REQUIRE(it != trajectory.end());
 
     const auto motion = rmf_traffic::Motion::compute_cubic_splines(
-          --rmf_traffic::Trajectory::const_iterator(it),
-          ++rmf_traffic::Trajectory::const_iterator(it));
+      --rmf_traffic::Trajectory::const_iterator(it),
+      ++rmf_traffic::Trajectory::const_iterator(it));
 
     REQUIRE(motion != nullptr);
     CHECK(start_time - 10ns <= motion->start_time());
     CHECK(motion->finish_time() <= finish_time + 10ns);
 
-    if(t_rel <= t_a)
+    if (t_rel <= t_a)
     {
-      const double s = 0.5*a_n*pow(t_rel,2);
+      const double s = 0.5*a_n*pow(t_rel, 2);
       const Eigen::Vector3d p_expected = p0 + s*normalized_dir;
       const Eigen::Vector3d p_actual = motion->compute_position(t);
-      for(int k=0; k < 3; ++k)
+      for (int k = 0; k < 3; ++k)
         CHECK(p_actual[k] == Approx(p_expected[k]).margin(1e-8));
 
       const double v = a_n*t_rel;
       const Eigen::Vector3d v_expected = v*normalized_dir;
       const Eigen::Vector3d v_actual = motion->compute_velocity(t);
-      for(int k=0; k < 3; ++k)
+      for (int k = 0; k < 3; ++k)
         CHECK(v_actual[k] == Approx(v_expected[k]).margin(1e-8));
 
-      if(std::abs(t_rel - t_a) > 1e-8)
+      if (std::abs(t_rel - t_a) > 1e-8)
       {
         // Acceleration is discontinuous at the time t_a, so if we are very
         // very close to it, then we shouldn't make assumptions about the
         // acceleration value.
         const Eigen::Vector3d a_expected = a_n*normalized_dir;
         const Eigen::Vector3d a_actual = motion->compute_acceleration(t);
-        for(int k=0; k < 3; ++k)
+        for (int k = 0; k < 3; ++k)
           CHECK(a_actual[k] == Approx(a_expected[k]).margin(1e-8));
       }
     }
-    else if(t_rel <= t_d)
+    else if (t_rel <= t_d)
     {
       const double v = a_n * t_a;
       const double s = 0.5*a_n*pow(t_a, 2) + v * (t_rel - t_a);
       const Eigen::Vector3d p_expected = p0 + s*normalized_dir;
       const Eigen::Vector3d p_actual = motion->compute_position(t);
-      for(int k=0; k < 3; ++k)
+      for (int k = 0; k < 3; ++k)
         CHECK(p_actual[k] == Approx(p_expected[k]).margin(1e-8));
 
       const Eigen::Vector3d v_expected = v*normalized_dir;
       const Eigen::Vector3d v_actual = motion->compute_velocity(t);
-      for(int k=0; k < 3; ++k)
+      for (int k = 0; k < 3; ++k)
         CHECK(v_actual[k] == Approx(v_expected[k]).margin(1e-8));
 
-      if(std::abs(t_rel - t_d) > 1e-8)
+      if (std::abs(t_rel - t_d) > 1e-8)
       {
         // Acceleration is discontinuous at the time t_d, so if we are very
         // very close to it, then we shouldn't make assumptions about the
         // acceleration value.
         const Eigen::Vector3d a_expected = Eigen::Vector3d::Zero();
         const Eigen::Vector3d a_actual = motion->compute_acceleration(t);
-        for(int k=0; k < 3; ++k)
+        for (int k = 0; k < 3; ++k)
           CHECK(a_actual[k] == Approx(a_expected[k]).margin(1e-8));
       }
     }
-    else if(t_rel <= dt)
+    else if (t_rel <= dt)
     {
       const double v_peak = a_n*t_a;
       const double v = v_peak - a_n*(t_rel - t_d);
       const double s =
-          0.5*a_n*pow(t_a, 2) + v_peak*(t_rel - t_a) - 0.5*a_n*pow(t_rel - t_d, 2);
+        0.5*a_n*
+        pow(t_a, 2) + v_peak*(t_rel - t_a) - 0.5*a_n*pow(t_rel - t_d, 2);
 
       const Eigen::Vector3d p_expected = p0 + s*normalized_dir;
       const Eigen::Vector3d p_actual = motion->compute_position(t);
-      for(int k=0; k < 3; ++k)
+      for (int k = 0; k < 3; ++k)
         CHECK(p_actual[k] == Approx(p_expected[k]).margin(1e-8));
 
       const Eigen::Vector3d v_expected = v*normalized_dir;
       const Eigen::Vector3d v_actual = motion->compute_velocity(t);
-      for(int k=0; k < 3; ++k)
+      for (int k = 0; k < 3; ++k)
         CHECK(v_actual[k] == Approx(v_expected[k]).margin(1e-8));
 
       const Eigen::Vector3d a_expected = -a_n*normalized_dir;
       const Eigen::Vector3d a_actual = motion->compute_acceleration(t);
-      for(int k=0; k < 3; ++k)
+      for (int k = 0; k < 3; ++k)
         CHECK(a_actual[k] == Approx(a_expected[k]).margin(1e-8));
     }
   }
 }
 
 PredictedTimes compute_predicted_times(
-    const double t_start,
-    const double s, // distance to travel
-    const double v_n, // nominal velocity
-    const double a_n // nominal acceleration
-    )
+  const double t_start,
+  const double s, // distance to travel
+  const double v_n, // nominal velocity
+  const double a_n // nominal acceleration
+)
 {
   const double t_a = std::min(v_n/a_n, std::sqrt(s/a_n));
   const double v = a_n*t_a;
   const double t_d =
-      s/v - a_n*pow(t_a, 2)/(2.0*v) - v/(2.0*a_n) + t_a;
+    s/v - a_n*pow(t_a, 2)/(2.0*v) - v/(2.0*a_n) + t_a;
   const double t_finish = t_d + v/a_n;
 
   return PredictedTimes{t_start, t_a, t_d, t_finish + t_start};
@@ -181,7 +182,7 @@ SCENARIO("Test Interpolations")
   const double alpha_n = 0.25;
 
   const rmf_traffic::agv::VehicleTraits traits(
-      {v_n, a_n}, {w_n, alpha_n}, {nullptr, nullptr});
+    {v_n, a_n}, {w_n, alpha_n}, {nullptr, nullptr});
 
   GIVEN("Three distant points")
   {
@@ -190,13 +191,13 @@ SCENARIO("Test Interpolations")
     const double angle1 = 90.0*M_PI/180.0;
     const double angle2 = 45.0*M_PI/180.0;
     const std::vector<Eigen::Vector3d> positions = {
-        Eigen::Vector3d{0.0, 0.0, 0.0},
-        Eigen::Vector3d{xf, 0.0, angle1},
-        Eigen::Vector3d{xf, -xf, angle2}
-      };
+      Eigen::Vector3d{0.0, 0.0, 0.0},
+      Eigen::Vector3d{xf, 0.0, angle1},
+      Eigen::Vector3d{xf, -xf, angle2}
+    };
 
     rmf_traffic::Trajectory trajectory =
-        rmf_traffic::agv::Interpolate::positions(traits, start_time, positions);
+      rmf_traffic::agv::Interpolate::positions(traits, start_time, positions);
 
     THEN("The trajectory is correctly interpolated")
     {
@@ -204,25 +205,25 @@ SCENARIO("Test Interpolations")
 
       const PredictedTimes times1 = compute_predicted_times(0.0, xf, v_n, a_n);
       test_interpolation(
-          positions[0], Eigen::Vector3d::UnitX(), a_n, times1, trajectory);
+        positions[0], Eigen::Vector3d::UnitX(), a_n, times1, trajectory);
 
       const PredictedTimes times2 =
-          compute_predicted_times(times1.t_finish, angle1, w_n, alpha_n);
+        compute_predicted_times(times1.t_finish, angle1, w_n, alpha_n);
       test_interpolation(
-          Eigen::Vector3d{xf, 0.0, 0.0}, Eigen::Vector3d::UnitZ(),
-          alpha_n, times2, trajectory);
+        Eigen::Vector3d{xf, 0.0, 0.0}, Eigen::Vector3d::UnitZ(),
+        alpha_n, times2, trajectory);
 
       const PredictedTimes times3 =
-          compute_predicted_times(times2.t_finish, xf, v_n, a_n);
+        compute_predicted_times(times2.t_finish, xf, v_n, a_n);
       test_interpolation(
-          positions[1], -Eigen::Vector3d::UnitY(), a_n, times3, trajectory);
+        positions[1], -Eigen::Vector3d::UnitY(), a_n, times3, trajectory);
 
       const PredictedTimes times4 =
-          compute_predicted_times(
-            times3.t_finish, std::abs(angle2 - angle1), w_n, alpha_n);
+        compute_predicted_times(
+        times3.t_finish, std::abs(angle2 - angle1), w_n, alpha_n);
       test_interpolation(
-          Eigen::Vector3d{xf, -xf, angle1}, -Eigen::Vector3d::UnitZ(),
-          alpha_n, times4, trajectory);
+        Eigen::Vector3d{xf, -xf, angle1}, -Eigen::Vector3d::UnitZ(),
+        alpha_n, times4, trajectory);
     }
   }
 
@@ -243,7 +244,7 @@ SCENARIO("Test Interpolations")
     };
 
     rmf_traffic::Trajectory trajectory =
-        rmf_traffic::agv::Interpolate::positions(traits, start_time, positions);
+      rmf_traffic::agv::Interpolate::positions(traits, start_time, positions);
 
     THEN("The trajectory is correctly interpolated")
     {
@@ -251,24 +252,24 @@ SCENARIO("Test Interpolations")
 
       const PredictedTimes times1 = compute_predicted_times(0.0, pf, v_n, a_n);
       test_interpolation(
-            positions[0], -Eigen::Vector3d::UnitX(), a_n, times1, trajectory);
+        positions[0], -Eigen::Vector3d::UnitX(), a_n, times1, trajectory);
 
       const PredictedTimes times2 = compute_predicted_times(
-            times1.t_finish, angle1, w_n, alpha_n);
+        times1.t_finish, angle1, w_n, alpha_n);
       test_interpolation(
-            Eigen::Vector3d{x0 - pf, -15.0, theta0}, Eigen::Vector3d::UnitZ(),
-            alpha_n, times2, trajectory);
+        Eigen::Vector3d{x0 - pf, -15.0, theta0}, Eigen::Vector3d::UnitZ(),
+        alpha_n, times2, trajectory);
 
       const PredictedTimes times3 = compute_predicted_times(
-            times2.t_finish, pf, v_n, a_n);
+        times2.t_finish, pf, v_n, a_n);
       test_interpolation(
-            positions[1], Eigen::Vector3d::UnitY(), a_n, times3, trajectory);
+        positions[1], Eigen::Vector3d::UnitY(), a_n, times3, trajectory);
 
       const PredictedTimes times4 = compute_predicted_times(
-            times3.t_finish, std::abs(angle2 - angle1), w_n, alpha_n);
+        times3.t_finish, std::abs(angle2 - angle1), w_n, alpha_n);
       test_interpolation(
-            Eigen::Vector3d{x0 - pf, -15 + pf, theta0 + angle1},
-            -Eigen::Vector3d::UnitZ(), alpha_n, times4, trajectory);
+        Eigen::Vector3d{x0 - pf, -15 + pf, theta0 + angle1},
+        -Eigen::Vector3d::UnitZ(), alpha_n, times4, trajectory);
     }
   }
 
@@ -281,7 +282,7 @@ SCENARIO("Test Interpolations")
     };
 
     rmf_traffic::Trajectory trajectory =
-        rmf_traffic::agv::Interpolate::positions(traits, start_time, positions);
+      rmf_traffic::agv::Interpolate::positions(traits, start_time, positions);
 
     // NOTE(MXG): This test is here because a bug was found when orientations
     // were not getting changed. It's a simple test, but please do not delete

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -31,13 +31,13 @@
 
 //==============================================================================
 void print_proposal(
-    const rmf_traffic::schedule::Negotiation::Proposal& proposals)
+  const rmf_traffic::schedule::Negotiation::Proposal& proposals)
 {
   for (const auto& proposal : proposals)
   {
     std::cout << "\nparticipant " << proposal.participant << ":\n";
     const auto start_time =
-        *proposal.itinerary.front()->trajectory().start_time();
+      *proposal.itinerary.front()->trajectory().start_time();
     for (const auto& r : proposal.itinerary)
     {
       for (const auto& t : r->trajectory())
@@ -58,35 +58,35 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
 
   rmf_traffic::Profile profile{
     rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Circle>(1.0)
+      rmf_traffic::geometry::Circle>(1.0)
   };
 
   auto p1 = rmf_traffic::schedule::make_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "participant 1",
-          "test_Negotiator",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-          profile
-        },
-        database);
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 1",
+      "test_Negotiator",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
 
   auto p2 = rmf_traffic::schedule::make_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "participant 2",
-          "test_Negotiator",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-          profile
-        },
-        database);
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 2",
+      "test_Negotiator",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
 
   auto p3 = rmf_traffic::schedule::make_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "participant 3",
-          "test_Negotiator",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
-          profile
-        },
-        database);
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 3",
+      "test_Negotiator",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
+      profile
+    },
+    database);
 
   const std::string test_map_name = "test_map";
   rmf_traffic::agv::Graph graph;
@@ -118,11 +118,12 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
    *                   0
    **/
 
-  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
-  {
-    graph.add_lane(w0, w1);
-    graph.add_lane(w1, w0);
-  };
+  auto add_bidir_lane =
+    [&](const std::size_t w0, const std::size_t w1)
+    {
+      graph.add_lane(w0, w1);
+      graph.add_lane(w1, w0);
+    };
 
   add_bidir_lane(0, 1);
   add_bidir_lane(1, 2);
@@ -155,14 +156,14 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
   auto start_time = std::chrono::steady_clock::now();
 
   const auto plan_1 = planner.plan(
-        rmf_traffic::agv::Plan::Start(start_time, 3, 0.0),
-        rmf_traffic::agv::Plan::Goal(7));
+    rmf_traffic::agv::Plan::Start(start_time, 3, 0.0),
+    rmf_traffic::agv::Plan::Goal(7));
   REQUIRE(plan_1);
   p1.set(plan_1->get_itinerary());
 
   const auto plan_2 = planner.plan(
-        rmf_traffic::agv::Plan::Start(start_time, 0, 90.0*M_PI/180.0),
-        rmf_traffic::agv::Plan::Goal(10));
+    rmf_traffic::agv::Plan::Start(start_time, 0, 90.0*M_PI/180.0),
+    rmf_traffic::agv::Plan::Goal(10));
   REQUIRE(plan_2);
   p2.set(plan_2->get_itinerary());
 
@@ -172,8 +173,8 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
     for (const auto& r2 : plan_2->get_itinerary())
     {
       if (rmf_traffic::DetectConflict::between(
-            profile, r1.trajectory(),
-            profile, r2.trajectory()))
+          profile, r1.trajectory(),
+          profile, r2.trajectory()))
       {
         has_conflict = true;
         break;
@@ -189,7 +190,7 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
   WHEN("Participants Crossing Paths")
   {
     auto negotiation = std::make_shared<rmf_traffic::schedule::Negotiation>(
-          rmf_traffic::schedule::Negotiation{database, {p1.id(), p2.id()}});
+      rmf_traffic::schedule::Negotiation{database, {p1.id(), p2.id()}});
 
     REQUIRE(negotiation->table(p1.id(), {}));
     CHECK_FALSE(negotiation->table(p1.id(), {p2.id()}));
@@ -215,31 +216,31 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
     };
 
     negotiator_1.respond(
-          negotiation->table(p1.id(), {}),
-          rmf_traffic::schedule::SimpleResponder(negotiation, p1.id(), {}));
+      negotiation->table(p1.id(), {}),
+      rmf_traffic::schedule::SimpleResponder(negotiation, p1.id(), {}));
 
     REQUIRE(negotiation->table(p2.id(), {p1.id()}));
 
     negotiator_2.respond(
-          negotiation->table(p2.id(), {}),
-          rmf_traffic::schedule::SimpleResponder(negotiation, p2.id(), {}));
+      negotiation->table(p2.id(), {}),
+      rmf_traffic::schedule::SimpleResponder(negotiation, p2.id(), {}));
 
     REQUIRE(negotiation->table(p1.id(), {p2.id()}));
 
     negotiator_1.respond(
-          negotiation->table(p1.id(), {p2.id()}),
-          rmf_traffic::schedule::SimpleResponder(negotiation, p1.id(), {p2.id()}));
+      negotiation->table(p1.id(), {p2.id()}),
+      rmf_traffic::schedule::SimpleResponder(negotiation, p1.id(), {p2.id()}));
 
     CHECK(negotiation->ready());
 
     negotiator_2.respond(
-          negotiation->table(p2.id(), {p1.id()}),
-          rmf_traffic::schedule::SimpleResponder(negotiation, p2.id(), {p1.id()}));
+      negotiation->table(p2.id(), {p1.id()}),
+      rmf_traffic::schedule::SimpleResponder(negotiation, p2.id(), {p1.id()}));
 
     CHECK(negotiation->complete());
 
     auto proposals = negotiation->evaluate(
-            rmf_traffic::schedule::QuickestFinishEvaluator())->proposal();
+      rmf_traffic::schedule::QuickestFinishEvaluator())->proposal();
     REQUIRE(proposals.size() == 2);
 
     const auto& proposal_1 = proposals.at(0);
@@ -249,8 +250,8 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
       for (const auto& r2 : proposal_2.itinerary)
       {
         CHECK_FALSE(rmf_traffic::DetectConflict::between(
-                      profile, r1->trajectory(),
-                      profile, r2->trajectory()));
+            profile, r1->trajectory(),
+            profile, r2->trajectory()));
       }
     }
 
@@ -267,15 +268,15 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
     GIVEN("A third participant")
     {
       const auto plan_3 = planner.plan(
-            rmf_traffic::agv::Plan::Start(start_time, 0, 90.0*M_PI/180.0),
-            rmf_traffic::agv::Plan::Goal(10));
+        rmf_traffic::agv::Plan::Start(start_time, 0, 90.0*M_PI/180.0),
+        rmf_traffic::agv::Plan::Goal(10));
       REQUIRE(plan_3);
 
       p3.set(plan_3->get_itinerary());
     }
 
     auto negotiation = std::make_shared<rmf_traffic::schedule::Negotiation>(
-          rmf_traffic::schedule::Negotiation{database, {p1.id(), p2.id()}});
+      rmf_traffic::schedule::Negotiation{database, {p1.id(), p2.id()}});
 
     rmf_traffic::agv::SimpleNegotiator negotiator_1{
       rmf_traffic::agv::Plan::Start(start_time, 3, 0.0),
@@ -292,19 +293,19 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
     };
 
     negotiator_1.respond(
-          negotiation->table(p1.id(), {}),
-          rmf_traffic::schedule::SimpleResponder(negotiation, p1.id(), {}));
+      negotiation->table(p1.id(), {}),
+      rmf_traffic::schedule::SimpleResponder(negotiation, p1.id(), {}));
 
     negotiator_2.respond(
-          negotiation->table(p2.id(), {}),
-          rmf_traffic::schedule::SimpleResponder(negotiation, p2.id(), {}));
+      negotiation->table(p2.id(), {}),
+      rmf_traffic::schedule::SimpleResponder(negotiation, p2.id(), {}));
 
     CHECK_FALSE(negotiation->ready());
     CHECK_FALSE(negotiation->complete());
 
     negotiator_1.respond(
-          negotiation->table(p1.id(), {p2.id()}),
-          rmf_traffic::schedule::SimpleResponder(negotiation, p1.id(), {p2.id()}));
+      negotiation->table(p1.id(), {p2.id()}),
+      rmf_traffic::schedule::SimpleResponder(negotiation, p1.id(), {p2.id()}));
 
     // ready() will be false here, because the ideal itinerary for
     // participant 2 makes it impossible for participant 1 to get out of the
@@ -312,13 +313,13 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
     // CHECK(negotiation->ready());
 
     negotiator_2.respond(
-          negotiation->table(p2.id(), {p1.id()}),
-          rmf_traffic::schedule::SimpleResponder(negotiation, p2.id(), {p1.id()}));
+      negotiation->table(p2.id(), {p1.id()}),
+      rmf_traffic::schedule::SimpleResponder(negotiation, p2.id(), {p1.id()}));
 
     CHECK(negotiation->complete());
 
     auto proposals = negotiation->evaluate(
-            rmf_traffic::schedule::QuickestFinishEvaluator())->proposal();
+      rmf_traffic::schedule::QuickestFinishEvaluator())->proposal();
     REQUIRE(proposals.size() == 2);
 
     const auto& proposal_1 = proposals.at(0);
@@ -328,8 +329,8 @@ SCENARIO("Test Plan Negotiation Between Two Participants")
       for (const auto& r2 : proposal_2.itinerary)
       {
         CHECK_FALSE(rmf_traffic::DetectConflict::between(
-                      profile, r1->trajectory(),
-                      profile, r2->trajectory()));
+            profile, r1->trajectory(),
+            profile, r2->trajectory()));
       }
     }
 
@@ -357,13 +358,13 @@ public:
   using Intentions = std::unordered_map<ParticipantId, Intention>;
 
   NegotiationRoom(
-      const rmf_traffic::schedule::Viewer& viewer,
-      Intentions intentions,
-      const bool print_failures_ = false)
-    : negotiators(make_negotiations(intentions)),
-      negotiation(std::make_shared<Negotiation>(
-                    viewer, get_participants(intentions))),
-      print_failures(print_failures_)
+    const rmf_traffic::schedule::Viewer& viewer,
+    Intentions intentions,
+    const bool print_failures_ = false)
+  : negotiators(make_negotiations(intentions)),
+    negotiation(std::make_shared<Negotiation>(
+        viewer, get_participants(intentions))),
+    print_failures(print_failures_)
   {
     // Do nothing
   }
@@ -391,8 +392,8 @@ public:
         if (respond_to)
         {
           negotiator.respond(
-                respond_to,
-                Responder(negotiation, respond_to->sequence()));
+            respond_to,
+            Responder(negotiation, respond_to->sequence()));
           if (print_failures && !respond_to->submission())
           {
             std::cout << "Failed to make a submission for [";
@@ -410,11 +411,11 @@ public:
       return rmf_utils::nullopt;
 
     return negotiation->evaluate(
-          rmf_traffic::schedule::QuickestFinishEvaluator())->proposal();
+      rmf_traffic::schedule::QuickestFinishEvaluator())->proposal();
   }
 
   static std::unordered_map<ParticipantId, Negotiator> make_negotiations(
-      const std::unordered_map<ParticipantId, Intention>& intentions)
+    const std::unordered_map<ParticipantId, Intention>& intentions)
   {
     std::unordered_map<ParticipantId, Negotiator> negotiators;
     for (const auto& entry : intentions)
@@ -422,17 +423,17 @@ public:
       const auto participant = entry.first;
       const auto& intention = entry.second;
       negotiators.insert(
-            std::make_pair(
-              participant,
-              rmf_traffic::agv::SimpleNegotiator(
-                intention.start, intention.goal, intention.configuration)));
+        std::make_pair(
+          participant,
+          rmf_traffic::agv::SimpleNegotiator(
+            intention.start, intention.goal, intention.configuration)));
     }
 
     return negotiators;
   }
 
   static std::vector<ParticipantId> get_participants(
-      const std::unordered_map<ParticipantId, Intention>& intentions)
+    const std::unordered_map<ParticipantId, Intention>& intentions)
   {
     std::vector<ParticipantId> participants;
     participants.reserve(intentions.size());
@@ -456,44 +457,44 @@ SCENARIO("Multi-participant negotiation")
 
   rmf_traffic::Profile profile{
     rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Circle>(1.0)
+      rmf_traffic::geometry::Circle>(1.0)
   };
 
   auto p1 = rmf_traffic::schedule::make_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "participant 1",
-          "test_Negotiator",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-          profile
-        },
-        database);
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 1",
+      "test_Negotiator",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
 
   auto p2 = rmf_traffic::schedule::make_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "participant 2",
-          "test_Negotiator",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-          profile
-        },
-        database);
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 2",
+      "test_Negotiator",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
 
   auto p3 = rmf_traffic::schedule::make_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "participant 3",
-          "test_Negotiator",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-          profile
-        },
-        database);
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 3",
+      "test_Negotiator",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
 
   const std::string test_map_name = "test_map";
   rmf_traffic::agv::Graph graph;
   graph.add_waypoint(test_map_name, { 0.0, -5.0}, true); // 0
-  graph.add_waypoint(test_map_name, {-5.0,  0.0}, true); // 1
-  graph.add_waypoint(test_map_name, { 0.0,  0.0}, true); // 2
+  graph.add_waypoint(test_map_name, {-5.0, 0.0}, true); // 1
+  graph.add_waypoint(test_map_name, { 0.0, 0.0}, true); // 2
 //  graph.add_waypoint(test_map_name, { 5.0,  0.0}, true); // 3 // TODO(MXG): This edge case needs to be dealt with
-  graph.add_waypoint(test_map_name, { 14.0,  0.0}, true); // 3
-  graph.add_waypoint(test_map_name, { 0.0,  5.0}, true); // 4
+  graph.add_waypoint(test_map_name, { 14.0, 0.0}, true); // 3
+  graph.add_waypoint(test_map_name, { 0.0, 5.0}, true); // 4
 
   /*
    *         4
@@ -505,11 +506,12 @@ SCENARIO("Multi-participant negotiation")
    *         0
    */
 
-  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
-  {
-    graph.add_lane(w0, w1);
-    graph.add_lane(w1, w0);
-  };
+  auto add_bidir_lane =
+    [&](const std::size_t w0, const std::size_t w1)
+    {
+      graph.add_lane(w0, w1);
+      graph.add_lane(w1, w0);
+    };
 
   add_bidir_lane(0, 2);
   add_bidir_lane(1, 2);
@@ -528,11 +530,11 @@ SCENARIO("Multi-participant negotiation")
 
   NegotiationRoom::Intentions intentions;
   intentions.insert({0, NegotiationRoom::Intention{
-                       {time, 1, 0.0}, 3, configuration}});
+        {time, 1, 0.0}, 3, configuration}});
   intentions.insert({1, NegotiationRoom::Intention{
-                       {time, 4, M_PI/2.0}, 0, configuration}});
+        {time, 4, M_PI/2.0}, 0, configuration}});
   intentions.insert({2, NegotiationRoom::Intention{
-                       {time, 3, 0.0}, 1, configuration}});
+        {time, 3, 0.0}, 1, configuration}});
 
 
   auto proposal = NegotiationRoom(database, intentions).solve();
@@ -542,10 +544,6 @@ SCENARIO("Multi-participant negotiation")
 }
 
 
-
-
-
-
 // (BH): Proposed Test Additions
 //==============================================================================
 
@@ -553,12 +551,14 @@ SCENARIO("Multi-participant negotiation")
 //==============================================================================
 using VertexId = std::string;
 using IsHoldingSpot = bool;
-using VertexMap = std::unordered_map<VertexId, std::pair<Eigen::Vector2d, IsHoldingSpot>>;
+using VertexMap = std::unordered_map<VertexId, std::pair<Eigen::Vector2d,
+    IsHoldingSpot>>;
 
 using EdgeId = std::string;
 using EdgeVertices = std::pair<VertexId, VertexId>;
 using IsBidirectional = bool;
-using EdgeMap = std::unordered_map<EdgeId, std::pair<EdgeVertices, IsBidirectional>>;
+using EdgeMap = std::unordered_map<EdgeId, std::pair<EdgeVertices,
+    IsBidirectional>>;
 
 using VertexIdtoIdxMap = std::unordered_map<VertexId, size_t>;
 
@@ -568,7 +568,7 @@ using ParticipantIndex = size_t;
 struct ParticipantConfig
 {
   const rmf_traffic::Profile profile;
-  const rmf_traffic::agv::VehicleTraits traits; 
+  const rmf_traffic::agv::VehicleTraits traits;
   const rmf_traffic::schedule::ParticipantDescription description;
 };
 
@@ -576,15 +576,16 @@ struct ParticipantConfig
 //==============================================================================
 // Makes graph using text ids, and returns bookkeeping that maps ids to indices
 // TODO(BH): Perhaps some sort of book keeping can be introduced in Graph itself?
-std::pair<rmf_traffic::agv::Graph, VertexIdtoIdxMap> 
-generate_test_graph_data(std::string map_name, VertexMap vertices, EdgeMap edges)
+std::pair<rmf_traffic::agv::Graph, VertexIdtoIdxMap>
+generate_test_graph_data(std::string map_name, VertexMap vertices,
+  EdgeMap edges)
 {
   rmf_traffic::agv::Graph graph;
   // Maps vertex id to its corresponding id in the rmf_traffic::agv::Graph
   VertexIdtoIdxMap vertex_id_to_idx;
   size_t current_idx = 0; // vertex idxes are added in monotonic increments
 
-  for(auto it = vertices.cbegin(); it != vertices.cend(); it++)
+  for (auto it = vertices.cbegin(); it != vertices.cend(); it++)
   {
     // Adding to rmf_traffic::agv::Graph
     graph.add_waypoint(map_name, it->second.first, it->second.second);
@@ -594,7 +595,7 @@ generate_test_graph_data(std::string map_name, VertexMap vertices, EdgeMap edges
     current_idx++;
   }
 
-  for(auto it = edges.cbegin(); it != edges.cend(); it++)
+  for (auto it = edges.cbegin(); it != edges.cend(); it++)
   {
     auto source_vtx = vertex_id_to_idx[it->second.first.first];
     auto sink_vtx = vertex_id_to_idx[it->second.first.second];
@@ -604,12 +605,13 @@ generate_test_graph_data(std::string map_name, VertexMap vertices, EdgeMap edges
       graph.add_lane(sink_vtx, source_vtx);
     }
   }
-  return std::pair<rmf_traffic::agv::Graph, VertexIdtoIdxMap>(graph, vertex_id_to_idx);
+  return std::pair<rmf_traffic::agv::Graph, VertexIdtoIdxMap>(graph,
+      vertex_id_to_idx);
 }
 
 rmf_utils::optional<rmf_traffic::schedule::Itinerary> get_participant_itinerary(
-    rmf_traffic::schedule::Negotiation::Proposal proposal, 
-    rmf_traffic::schedule::ParticipantId participant_id)
+  rmf_traffic::schedule::Negotiation::Proposal proposal,
+  rmf_traffic::schedule::ParticipantId participant_id)
 {
   for (auto submission : proposal)
   {
@@ -644,7 +646,7 @@ const rmf_traffic::schedule::ParticipantDescription a0_description = {
 };
 
 const ParticipantConfig a0_config = {
- a0_profile, a0_traits, a0_description
+  a0_profile, a0_traits, a0_description
 };
 
 // a1
@@ -667,7 +669,7 @@ const rmf_traffic::schedule::ParticipantDescription a1_description = {
 };
 
 const ParticipantConfig a1_config = {
- a1_profile, a1_traits, a1_description
+  a1_profile, a1_traits, a1_description
 };
 
 // a2 - A slower version of a0 / a1
@@ -690,7 +692,7 @@ const rmf_traffic::schedule::ParticipantDescription a2_description = {
 };
 
 const ParticipantConfig a2_config = {
- a2_profile, a2_traits, a2_description
+  a2_profile, a2_traits, a2_description
 };
 
 // Tests
@@ -698,7 +700,7 @@ const ParticipantConfig a2_config = {
 SCENARIO("A Single Lane, hold anywhere")
 {
   using namespace std::chrono_literals;
-  rmf_traffic::schedule::Database database; 
+  rmf_traffic::schedule::Database database;
   const std::string test_map_name = "test_single_lane";
   VertexMap vertices;
   EdgeMap edges;
@@ -724,12 +726,14 @@ SCENARIO("A Single Lane, hold anywhere")
 
   GIVEN("1 Participant")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[p0(A->D)]")
     {
       const auto time = std::chrono::steady_clock::now();
-      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
 
       NegotiationRoom::Intentions intentions;
       intentions.insert({
@@ -739,48 +743,56 @@ SCENARIO("A Single Lane, hold anywhere")
             vertex_id_to_idx["D"], // Goal Vertex
             p0_planner_config // Planner Configuration ( Preset )
           }
-      });
+        });
 
       THEN("Valid Proposal is found")
       {
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
       }
     }
   }
 
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
-    auto p2 = rmf_traffic::schedule::make_participant(a2_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
+    auto p2 = rmf_traffic::schedule::make_participant(a2_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[p0(A->B), p1(D->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -788,36 +800,44 @@ SCENARIO("A Single Lane, hold anywhere")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["B"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["B"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[p0(A->B), p1(A->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("No Proposal is found")
@@ -829,27 +849,29 @@ SCENARIO("A Single Lane, hold anywhere")
 
     WHEN("Schedule:[], Negotiation:[p0(A->B), p1(B->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid proposal is found.")
@@ -857,36 +879,44 @@ SCENARIO("A Single Lane, hold anywhere")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["B"].first);
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["B"].first);
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
-    
+
     WHEN("Schedule:[], Negotiation:[p0(A->B), p2(B->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p2_planner_config{graph, a2_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p2_planner_config{graph,
+        a2_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p2.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p2_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p2.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p2_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid proposal is found.")
@@ -894,40 +924,48 @@ SCENARIO("A Single Lane, hold anywhere")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["B"].first);
-        auto p2_itinerary = get_participant_itinerary(*proposal, p2.id()).value();
-        REQUIRE(p2_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["B"].first);
+        auto p2_itinerary =
+          get_participant_itinerary(*proposal, p2.id()).value();
+        REQUIRE(p2_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
 
     WHEN("Schedule:[p0(A->B)], Negotiation:[p1(D->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        rmf_traffic::agv::Planner a0_planner{
-          p0_planner_config, 
-          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
-        };
+      rmf_traffic::agv::Planner a0_planner{
+        p0_planner_config,
+        rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+      };
 
-        const auto a0_plan_0 = a0_planner.plan(
-            {time, vertex_id_to_idx["A"], 0.0},
-            {vertex_id_to_idx["B"]}
-            );
+      const auto a0_plan_0 = a0_planner.plan(
+        {time, vertex_id_to_idx["A"], 0.0},
+        {vertex_id_to_idx["B"]}
+      );
 
-        p0.set(a0_plan_0->get_itinerary());
+      p0.set(a0_plan_0->get_itinerary());
 
-        NegotiationRoom::Intentions intentions;
-        
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found.")
@@ -935,40 +973,45 @@ SCENARIO("A Single Lane, hold anywhere")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
-    
+
     // TODO(BH): A proposal is found here because once p0 arrives at C, it drops off the schedule, allowing p1 to pass.
-    // Should this be expected behavior? 
+    // Should this be expected behavior?
     WHEN("Schedule:[p0(A->C)], Negotiation:[p1(D->B)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        rmf_traffic::agv::Planner a0_planner{
-          p0_planner_config, 
-          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
-        };
+      rmf_traffic::agv::Planner a0_planner{
+        p0_planner_config,
+        rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+      };
 
-        const auto a0_plan_0 = a0_planner.plan(
-            {time, vertex_id_to_idx["A"], 0.0},
-            {vertex_id_to_idx["C"]}
-            );
+      const auto a0_plan_0 = a0_planner.plan(
+        {time, vertex_id_to_idx["A"], 0.0},
+        {vertex_id_to_idx["C"]}
+      );
 
-        p0.set(a0_plan_0->get_itinerary());
+      p0.set(a0_plan_0->get_itinerary());
 
-        NegotiationRoom::Intentions intentions;
-        
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("No Proposal is found.")
@@ -980,46 +1023,51 @@ SCENARIO("A Single Lane, hold anywhere")
 
     WHEN("Schedule:[p0(A->C->A)], Negotiation:[p1(D->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        rmf_traffic::agv::Planner a0_planner{
-          p0_planner_config, 
-          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
-        };
+      rmf_traffic::agv::Planner a0_planner{
+        p0_planner_config,
+        rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+      };
 
-        const auto a0_plan_0 = a0_planner.plan(
-            {time, vertex_id_to_idx["A"], 0.0},
-            {vertex_id_to_idx["C"]}
-            );
+      const auto a0_plan_0 = a0_planner.plan(
+        {time, vertex_id_to_idx["A"], 0.0},
+        {vertex_id_to_idx["C"]}
+      );
 
-        p0.set(a0_plan_0->get_itinerary());
+      p0.set(a0_plan_0->get_itinerary());
 
-        const auto a0_plan_1 = a0_planner.plan(
-            {time + 8s, vertex_id_to_idx["C"], 0.0},
-            {vertex_id_to_idx["A"]}
-            );
+      const auto a0_plan_1 = a0_planner.plan(
+        {time + 8s, vertex_id_to_idx["C"], 0.0},
+        {vertex_id_to_idx["A"]}
+      );
 
-        p0.extend(a0_plan_1->get_itinerary());
+      p0.extend(a0_plan_1->get_itinerary());
 
-        NegotiationRoom::Intentions intentions;
-        
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found.")
       {
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
   }
@@ -1028,7 +1076,7 @@ SCENARIO("A Single Lane, hold anywhere")
 SCENARIO("A single lane, limited holding spaces")
 {
   using namespace std::chrono_literals;
-  rmf_traffic::schedule::Database database; 
+  rmf_traffic::schedule::Database database;
   const std::string test_map_name = "test_single_lane";
   VertexMap vertices;
   EdgeMap edges;
@@ -1054,36 +1102,41 @@ SCENARIO("A single lane, limited holding spaces")
 
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
-    auto p2 = rmf_traffic::schedule::make_participant(a2_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
+    auto p2 = rmf_traffic::schedule::make_participant(a2_config.description,
+        database);
 
     // TODO(BH): A is not a holding area, however, 3 seconds after start time, the p0 is still in A
     // It is technically spinning in place and thus not "holding": but is this cheating?
     // I would expect p0 to move to B and wait there instead.
     WHEN("Schedule:[], Negotiation:[pO(A->C), p2(B->D)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p2_planner_config{graph, a2_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p2_planner_config{graph,
+        a2_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p2.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p2_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p2.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p2_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1091,11 +1144,17 @@ SCENARIO("A single lane, limited holding spaces")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p2_itinerary = get_participant_itinerary(*proposal, p2.id()).value();
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p2_itinerary =
+          get_participant_itinerary(*proposal, p2.id()).value();
         //REQUIRE(p0_itinerary.front()->trajectory().find(rmf_traffic::Time(time + 3s))->position().segment(0, 2) != vertices["A"].first);
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
-        REQUIRE(p2_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
+        REQUIRE(p2_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
       }
     }
 
@@ -1104,30 +1163,32 @@ SCENARIO("A single lane, limited holding spaces")
     // I would expect p0 to move to B and wait there instead.
     WHEN("Schedule:[p2(B->D)], Negotiation:[pO(A->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p2_planner_config{graph, a2_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p2_planner_config{graph,
+        a2_config.traits};
 
-        rmf_traffic::agv::Planner a2_planner{
-          p2_planner_config, 
-          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
-        };
+      rmf_traffic::agv::Planner a2_planner{
+        p2_planner_config,
+        rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+      };
 
-        const auto a2_plan = a2_planner.plan(
-            {time, vertex_id_to_idx["B"], 0.0},
-            {vertex_id_to_idx["D"]}
-            );
+      const auto a2_plan = a2_planner.plan(
+        {time, vertex_id_to_idx["B"], 0.0},
+        {vertex_id_to_idx["D"]}
+      );
 
-        p2.set(a2_plan->get_itinerary());
+      p2.set(a2_plan->get_itinerary());
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1135,9 +1196,12 @@ SCENARIO("A single lane, limited holding spaces")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
         //REQUIRE(p0_itinerary.front()->trajectory().find(rmf_traffic::Time(time + 3s))->position().segment(0, 2) != vertices["A"].first);
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
   }
@@ -1147,7 +1211,7 @@ SCENARIO("A single lane, limited holding spaces")
 SCENARIO("A single loop")
 {
   using namespace std::chrono_literals;
-  rmf_traffic::schedule::Database database; 
+  rmf_traffic::schedule::Database database;
   const std::string test_map_name = "test_single_loop";
   VertexMap vertices;
   EdgeMap edges;
@@ -1176,32 +1240,36 @@ SCENARIO("A single loop")
 
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[pO(A->C), p1(B->D)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1209,36 +1277,44 @@ SCENARIO("A single loop")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[pO(C->B), p1(D->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1246,10 +1322,16 @@ SCENARIO("A single loop")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["B"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["B"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
 
@@ -1260,7 +1342,7 @@ SCENARIO("A single loop")
 SCENARIO("A single lane with an alcove holding space")
 {
   using namespace std::chrono_literals;
-  rmf_traffic::schedule::Database database; 
+  rmf_traffic::schedule::Database database;
   const std::string test_map_name = "test_single_lane_with_alcove";
   VertexMap vertices;
   EdgeMap edges;
@@ -1294,32 +1376,36 @@ SCENARIO("A single lane with an alcove holding space")
 
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[p0(A->E), p1(D->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["E"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["E"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1327,36 +1413,44 @@ SCENARIO("A single lane with an alcove holding space")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["E"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["A"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["E"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["A"].first);
       }
     }
-    
+
     WHEN("Schedule:[], Negotiation:[p0(E->D), p1(D->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1364,36 +1458,44 @@ SCENARIO("A single lane with an alcove holding space")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["A"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["A"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[p0(B->D), p1(D->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1401,39 +1503,47 @@ SCENARIO("A single lane with an alcove holding space")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["A"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["A"].first);
       }
     }
 
-    // TODO(BH): I would expect that p0(A->E), holds at E while p1(D->A), then p0(E->D). 
-    // Previous tests show that individually, the plans are feasible, but 
+    // TODO(BH): I would expect that p0(A->E), holds at E while p1(D->A), then p0(E->D).
+    // Previous tests show that individually, the plans are feasible, but
     // When not when expressed directly as in this test.
     WHEN("Schedule:[], Negotiation:[p0(A->D), p1(D->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1450,27 +1560,29 @@ SCENARIO("A single lane with an alcove holding space")
 
     WHEN("Schedule:[], Negotiation:[p0(A->D), p1(E->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1478,39 +1590,47 @@ SCENARIO("A single lane with an alcove holding space")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["A"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["A"].first);
       }
     }
 
     WHEN("Schedule:[p1(D->A)], Negotiation:[p0(B->D)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        rmf_traffic::agv::Planner a1_planner{
-          p1_planner_config, 
-          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
-        };
+      rmf_traffic::agv::Planner a1_planner{
+        p1_planner_config,
+        rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+      };
 
-        const auto a1_plan = a1_planner.plan(
-            {time, vertex_id_to_idx["D"], 0.0},
-            {vertex_id_to_idx["A"]}
-            );
+      const auto a1_plan = a1_planner.plan(
+        {time, vertex_id_to_idx["D"], 0.0},
+        {vertex_id_to_idx["A"]}
+      );
 
-        p1.set(a1_plan->get_itinerary());
+      p1.set(a1_plan->get_itinerary());
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1518,37 +1638,42 @@ SCENARIO("A single lane with an alcove holding space")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
       }
     }
 
     WHEN("Schedule:[p1(A->D)], Negotiation:[p0(E->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        rmf_traffic::agv::Planner a1_planner{
-          p1_planner_config, 
-          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
-        };
+      rmf_traffic::agv::Planner a1_planner{
+        p1_planner_config,
+        rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+      };
 
-        const auto a1_plan = a1_planner.plan(
-            {time, vertex_id_to_idx["A"], 0.0},
-            {vertex_id_to_idx["D"]}
-            );
+      const auto a1_plan = a1_planner.plan(
+        {time, vertex_id_to_idx["A"], 0.0},
+        {vertex_id_to_idx["D"]}
+      );
 
-        p1.set(a1_plan->get_itinerary());
+      p1.set(a1_plan->get_itinerary());
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1556,44 +1681,49 @@ SCENARIO("A single lane with an alcove holding space")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
 
     WHEN("Schedule:[p1(D->A->D)], Negotiation:[p0(E->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        rmf_traffic::agv::Planner a1_planner{
-          p1_planner_config, 
-          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
-        };
+      rmf_traffic::agv::Planner a1_planner{
+        p1_planner_config,
+        rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+      };
 
-        const auto a1_plan_0 = a1_planner.plan(
-            {time, vertex_id_to_idx["D"], 0.0},
-            {vertex_id_to_idx["A"]}
-            );
+      const auto a1_plan_0 = a1_planner.plan(
+        {time, vertex_id_to_idx["D"], 0.0},
+        {vertex_id_to_idx["A"]}
+      );
 
-        p1.set(a1_plan_0->get_itinerary());
+      p1.set(a1_plan_0->get_itinerary());
 
-        const auto a1_plan_1 = a1_planner.plan(
-            {time + 16s, vertex_id_to_idx["A"], 0.0},
-            {vertex_id_to_idx["D"]}
-            );
+      const auto a1_plan_1 = a1_planner.plan(
+        {time + 16s, vertex_id_to_idx["A"], 0.0},
+        {vertex_id_to_idx["D"]}
+      );
 
-        p1.extend(a1_plan_1->get_itinerary());
+      p1.extend(a1_plan_1->get_itinerary());
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1601,40 +1731,45 @@ SCENARIO("A single lane with an alcove holding space")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
 
-    // TODO(BH): I would expect that p0(A->E), holds at E while p1(D->A), then p0(E->D). 
-    // Previous tests show that individually, the plans are feasible, but 
+    // TODO(BH): I would expect that p0(A->E), holds at E while p1(D->A), then p0(E->D).
+    // Previous tests show that individually, the plans are feasible, but
     // When not when expressed directly as in this test.
     WHEN("Schedule:[p1(A->D)], Negotiation:[p0(D->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        rmf_traffic::agv::Planner a1_planner{
-          p1_planner_config, 
-          rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
-        };
+      rmf_traffic::agv::Planner a1_planner{
+        p1_planner_config,
+        rmf_traffic::agv::Planner::Options{nullptr, 1s} // No route validator, holding time 1s
+      };
 
-        const auto a1_plan = a1_planner.plan(
-            {time, vertex_id_to_idx["A"], 0.0},
-            {vertex_id_to_idx["D"]}
-            );
+      const auto a1_plan = a1_planner.plan(
+        {time, vertex_id_to_idx["A"], 0.0},
+        {vertex_id_to_idx["D"]}
+      );
 
-        p1.set(a1_plan->get_itinerary());
+      p1.set(a1_plan->get_itinerary());
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1646,15 +1781,16 @@ SCENARIO("A single lane with an alcove holding space")
         //REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["A"].first);
       }
     }
-}
+  }
 
 }
 
 SCENARIO("A single lane with a alternate one way path")
 {
   using namespace std::chrono_literals;
-  rmf_traffic::schedule::Database database; 
-  const std::string test_map_name = "test_single_lane_with_alternate one-way path";
+  rmf_traffic::schedule::Database database;
+  const std::string test_map_name =
+    "test_single_lane_with_alternate one-way path";
   VertexMap vertices;
   EdgeMap edges;
 
@@ -1689,31 +1825,35 @@ SCENARIO("A single lane with a alternate one way path")
 
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
     WHEN("Schedule:[], Negotiation:[p0(A->D), p1(C->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1721,37 +1861,45 @@ SCENARIO("A single lane with a alternate one way path")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["A"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["A"].first);
       }
     }
 
     // TODO(BH): Was expecting this to pass, since  the test Schedule:[], Negotiation:[p0(A->D), p1(C->A)] passed
     WHEN("Schedule:[], Negotiation:[p0(A->D), p1(D->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1772,8 +1920,9 @@ SCENARIO("A single lane with a alternate one way path")
 SCENARIO("A single lane with a alternate two way path")
 {
   using namespace std::chrono_literals;
-  rmf_traffic::schedule::Database database; 
-  const std::string test_map_name = "test_single_lane_with_alternate_two_way_path";
+  rmf_traffic::schedule::Database database;
+  const std::string test_map_name =
+    "test_single_lane_with_alternate_two_way_path";
   VertexMap vertices;
   EdgeMap edges;
 
@@ -1808,31 +1957,35 @@ SCENARIO("A single lane with a alternate two way path")
 
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
     WHEN("Schedule:[], Negotiation:[p0(A->D), p1(C->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1840,37 +1993,45 @@ SCENARIO("A single lane with a alternate two way path")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["A"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["A"].first);
       }
     }
 
     // TODO(BH): Was expecting this to pass, since  the test Schedule:[], Negotiation:[p0(A->D), p1(C->A)] passed
     WHEN("Schedule:[], Negotiation:[p0(A->D), p1(D->A)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["A"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["A"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1891,7 +2052,7 @@ SCENARIO("A single lane with a alternate two way path")
 SCENARIO("A single loop with alcoves at each vertex")
 {
   using namespace std::chrono_literals;
-  rmf_traffic::schedule::Database database; 
+  rmf_traffic::schedule::Database database;
   const std::string test_map_name = "test_single_loop";
   VertexMap vertices;
   EdgeMap edges;
@@ -1935,32 +2096,36 @@ SCENARIO("A single loop with alcoves at each vertex")
 
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[pO(A'->C'), p1(B'->D')]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C'"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C'"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D'"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D'"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -1968,36 +2133,44 @@ SCENARIO("A single loop with alcoves at each vertex")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C'"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D'"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C'"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D'"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[pO(A'->C'), p1(D'->B')]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C'"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C'"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B'"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B'"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -2005,36 +2178,44 @@ SCENARIO("A single loop with alcoves at each vertex")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C'"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["B'"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C'"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["B'"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[pO(B'->D'), p1(D'->B')]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D'"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D'"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B'"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B'"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -2042,10 +2223,16 @@ SCENARIO("A single loop with alcoves at each vertex")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["D'"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["B'"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["D'"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["B'"].first);
       }
     }
 
@@ -2054,43 +2241,49 @@ SCENARIO("A single loop with alcoves at each vertex")
   // TODO(BH): Solver takes quite long to terminate
   GIVEN("3 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
-    auto p2 = rmf_traffic::schedule::make_participant(a2_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
+    auto p2 = rmf_traffic::schedule::make_participant(a2_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[pO(A'->C'), p1(B'->D'), p2(D'->B')]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
-        rmf_traffic::agv::Planner::Configuration p2_planner_config{graph, a2_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
+      rmf_traffic::agv::Planner::Configuration p2_planner_config{graph,
+        a2_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C'"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C'"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["B'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["D'"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["B'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["D'"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p2.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["D'"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["B'"], // Goal Vertex
-              p2_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p2.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["D'"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["B'"], // Goal Vertex
+            p2_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -2114,7 +2307,7 @@ SCENARIO("A single loop with alcoves at each vertex")
 SCENARIO("fan-in-fan-out bottleneck")
 {
   using namespace std::chrono_literals;
-  rmf_traffic::schedule::Database database; 
+  rmf_traffic::schedule::Database database;
   const std::string test_map_name = "test_fan_in_fan_out";
   VertexMap vertices;
   EdgeMap edges;
@@ -2203,12 +2396,14 @@ SCENARIO("fan-in-fan-out bottleneck")
 
   GIVEN("1 Participant")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[p0(A->Z)]")
     {
       const auto time = std::chrono::steady_clock::now();
-      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
 
       NegotiationRoom::Intentions intentions;
       intentions.insert({
@@ -2218,22 +2413,26 @@ SCENARIO("fan-in-fan-out bottleneck")
             vertex_id_to_idx["Z"], // Goal Vertex
             p0_planner_config // Planner Configuration ( Preset )
           }
-      });
+        });
 
       THEN("Valid Proposal is found")
       {
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["Z"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["Z"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[p0(X->C)]")
     {
       const auto time = std::chrono::steady_clock::now();
-      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
 
       NegotiationRoom::Intentions intentions;
       intentions.insert({
@@ -2243,47 +2442,54 @@ SCENARIO("fan-in-fan-out bottleneck")
             vertex_id_to_idx["C"], // Goal Vertex
             p0_planner_config // Planner Configuration ( Preset )
           }
-      });
+        });
 
       THEN("Valid Proposal is found")
       {
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
   }
 
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[p0(A->Z), p1(E->V)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["Z"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["Z"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["V"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["V"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -2291,36 +2497,44 @@ SCENARIO("fan-in-fan-out bottleneck")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["Z"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["V"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["Z"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["V"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[p0(A->Z), p1(V->E)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["Z"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["Z"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["V"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["E"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["V"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["E"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -2328,36 +2542,44 @@ SCENARIO("fan-in-fan-out bottleneck")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["Z"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["E"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["Z"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["E"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[p0(A->X), p1(V->Z)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["X"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["X"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["V"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["Z"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["V"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["Z"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -2365,36 +2587,44 @@ SCENARIO("fan-in-fan-out bottleneck")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["X"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["Z"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["X"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["Z"].first);
       }
     }
 
     WHEN("Schedule:[], Negotiation:[p0(A->Z), p1(X->C)")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["Z"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["Z"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["X"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["X"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
       THEN("Valid Proposal is found")
@@ -2402,53 +2632,65 @@ SCENARIO("fan-in-fan-out bottleneck")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["Z"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["C"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["Z"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["C"].first);
       }
     }
   }
 
   GIVEN("3 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
-    auto p2 = rmf_traffic::schedule::make_participant(a2_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
+    auto p2 = rmf_traffic::schedule::make_participant(a2_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[p0(A->Z), p1(E->V), p2(C->X)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
-        rmf_traffic::agv::Planner::Configuration p2_planner_config{graph, a2_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
+      rmf_traffic::agv::Planner::Configuration p2_planner_config{graph,
+        a2_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["Z"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["Z"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["V"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["V"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p2.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["X"], // Goal Vertex
-              p2_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p2.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["C"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["X"], // Goal Vertex
+            p2_planner_config // Planner Configuration ( Preset )
+          }
         });
 
 
@@ -2457,49 +2699,61 @@ SCENARIO("fan-in-fan-out bottleneck")
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        auto p1_itinerary = get_participant_itinerary(*proposal, p1.id()).value();
-        auto p2_itinerary = get_participant_itinerary(*proposal, p2.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["Z"].first);
-        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["V"].first);
-        REQUIRE(p2_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["X"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        auto p1_itinerary =
+          get_participant_itinerary(*proposal, p1.id()).value();
+        auto p2_itinerary =
+          get_participant_itinerary(*proposal, p2.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["Z"].first);
+        REQUIRE(p1_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["V"].first);
+        REQUIRE(p2_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["X"].first);
       }
     }
 
     // TODO(BH): Solver doesn't terminate
     WHEN("Schedule:[], Negotiation:[p0(A->Z), p1(E->V), p2(X->C)]")
     {
-        const auto time = std::chrono::steady_clock::now();
-        rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-        rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
-        rmf_traffic::agv::Planner::Configuration p2_planner_config{graph, a2_config.traits};
+      const auto time = std::chrono::steady_clock::now();
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
+      rmf_traffic::agv::Planner::Configuration p2_planner_config{graph,
+        a2_config.traits};
 
-        NegotiationRoom::Intentions intentions;
-        intentions.insert({
-            p0.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["Z"], // Goal Vertex
-              p0_planner_config // Planner Configuration ( Preset )
-            }
+      NegotiationRoom::Intentions intentions;
+      intentions.insert({
+          p0.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["A"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["Z"], // Goal Vertex
+            p0_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p1.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["V"], // Goal Vertex
-              p1_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p1.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["E"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["V"], // Goal Vertex
+            p1_planner_config // Planner Configuration ( Preset )
+          }
         });
 
-        intentions.insert({
-            p2.id(),
-            NegotiationRoom::Intention{
-              {time, vertex_id_to_idx["X"], 0.0},  // Time, Start Vertex, Initial Orientation
-              vertex_id_to_idx["C"], // Goal Vertex
-              p2_planner_config // Planner Configuration ( Preset )
-            }
+      intentions.insert({
+          p2.id(),
+          NegotiationRoom::Intention{
+            {time, vertex_id_to_idx["X"], 0.0},  // Time, Start Vertex, Initial Orientation
+            vertex_id_to_idx["C"], // Goal Vertex
+            p2_planner_config // Planner Configuration ( Preset )
+          }
         });
 
 
@@ -2521,7 +2775,7 @@ SCENARIO("fan-in-fan-out bottleneck")
 
 SCENARIO("Fully connected graph of 10 vertices")
 {
-  rmf_traffic::schedule::Database database; 
+  rmf_traffic::schedule::Database database;
   const std::string test_map_name = "test_fully_connected_graph_10_vertices";
   VertexMap vertices;
   EdgeMap edges;
@@ -2538,15 +2792,17 @@ SCENARIO("Fully connected graph of 10 vertices")
   vertices.insert({"J", {{27.0, 0.0}, IsHoldingSpot(true)}});
 
   std::string vtxs = "ABCDEFGHIJ";
-  for(char&v_source : vtxs)
+  for (char& v_source : vtxs)
   {
-    for(char&v_dest : vtxs)
+    for (char& v_dest : vtxs)
     {
-      if (v_source == v_dest) continue;
+      if (v_source == v_dest)
+        continue;
       std::string v_source_str(1, v_source);
       std::string v_dest_str(1, v_dest);
       // Bidirectional is set to false since we double add anyway
-      edges.insert({v_source_str + v_dest_str, {{v_source_str, v_dest_str}, IsBidirectional(false)}});
+      edges.insert({v_source_str + v_dest_str, {{v_source_str, v_dest_str}, IsBidirectional(
+              false)}});
     }
   }
 
@@ -2556,12 +2812,14 @@ SCENARIO("Fully connected graph of 10 vertices")
 
   GIVEN("1 Participant")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[p0(A->J)]")
     {
       const auto time = std::chrono::steady_clock::now();
-      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
 
       NegotiationRoom::Intentions intentions;
       intentions.insert({
@@ -2571,15 +2829,18 @@ SCENARIO("Fully connected graph of 10 vertices")
             vertex_id_to_idx["J"], // Goal Vertex
             p0_planner_config // Planner Configuration ( Preset )
           }
-      });
+        });
 
       THEN("Valid Proposal is found")
       {
         auto proposal = NegotiationRoom(database, intentions).solve();
         REQUIRE(proposal);
 
-        auto p0_itinerary = get_participant_itinerary(*proposal, p0.id()).value();
-        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0, 2) == vertices["J"].first);
+        auto p0_itinerary =
+          get_participant_itinerary(*proposal, p0.id()).value();
+        REQUIRE(p0_itinerary.back()->trajectory().back().position().segment(0,
+          2) ==
+          vertices["J"].first);
       }
     }
   }
@@ -2587,14 +2848,18 @@ SCENARIO("Fully connected graph of 10 vertices")
   // Proposal not found.
   GIVEN("2 Participants")
   {
-    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description, database);
-    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description, database);
+    auto p0 = rmf_traffic::schedule::make_participant(a0_config.description,
+        database);
+    auto p1 = rmf_traffic::schedule::make_participant(a1_config.description,
+        database);
 
     WHEN("Schedule:[], Negotiation:[p0(A->J), p1(J->A)]")
     {
       const auto time = std::chrono::steady_clock::now();
-      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph, a0_config.traits};
-      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph, a1_config.traits};
+      rmf_traffic::agv::Planner::Configuration p0_planner_config{graph,
+        a0_config.traits};
+      rmf_traffic::agv::Planner::Configuration p1_planner_config{graph,
+        a1_config.traits};
 
       NegotiationRoom::Intentions intentions;
       intentions.insert({
@@ -2604,7 +2869,7 @@ SCENARIO("Fully connected graph of 10 vertices")
             vertex_id_to_idx["J"], // Goal Vertex
             p0_planner_config // Planner Configuration ( Preset )
           }
-      });
+        });
 
       intentions.insert({
           p1.id(),
@@ -2613,7 +2878,7 @@ SCENARIO("Fully connected graph of 10 vertices")
             vertex_id_to_idx["A"], // Goal Vertex
             p1_planner_config // Planner Configuration ( Preset )
           }
-      });
+        });
 
       THEN("Valid Proposal is found")
       {

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -32,7 +32,7 @@
 // TODO(MXG): Move performance testing content into a performance test folder
 const bool test_performance = false;
 // const bool test_performance = true;
-const std::size_t N = test_performance? 10 : 1;
+const std::size_t N = test_performance ? 10 : 1;
 
 void print_timing(const std::chrono::steady_clock::time_point& start_time)
 {
@@ -47,19 +47,19 @@ void print_timing(const std::chrono::steady_clock::time_point& start_time)
 
 rmf_utils::clone_ptr<rmf_traffic::agv::ScheduleRouteValidator>
 make_test_schedule_validator(
-    const rmf_traffic::schedule::Viewer& viewer,
-    rmf_traffic::Profile profile)
+  const rmf_traffic::schedule::Viewer& viewer,
+  rmf_traffic::Profile profile)
 {
   return rmf_utils::make_clone<rmf_traffic::agv::ScheduleRouteValidator>(
-        viewer,
-        std::numeric_limits<rmf_traffic::schedule::ParticipantId>::max(),
-        std::move(profile));
+    viewer,
+    std::numeric_limits<rmf_traffic::schedule::ParticipantId>::max(),
+    std::move(profile));
 }
 
 void display_path(const rmf_traffic::agv::Plan& plan)
 {
   std::vector<std::size_t> plan_indices;
-  for (const auto &wp : plan.get_waypoints())
+  for (const auto& wp : plan.get_waypoints())
   {
     if (wp.graph_index())
       plan_indices.push_back(*wp.graph_index());
@@ -70,58 +70,58 @@ void display_path(const rmf_traffic::agv::Plan& plan)
   for (auto it = plan_indices.begin(); it != plan_indices.end(); it++)
   {
     std::cout<<*it;
-    if(it != --plan_indices.end())
+    if (it != --plan_indices.end())
       std::cout<<"-> ";
   }
   std::cout<<std::endl;
 }
 
 void print_trajectory_info(
-    const rmf_traffic::agv::Plan& plan,
-    rmf_traffic::Time time)
+  const rmf_traffic::agv::Plan& plan,
+  rmf_traffic::Time time)
 {
   int count = 1;
   const auto& r = plan.get_itinerary().front();
   const auto& t = r.trajectory();
   std::cout<<"Trajectory in: "
-      << r.map()
-      <<" with "<< t.size()
-      <<" segments\n";
+           << r.map()
+           <<" with "<< t.size()
+           <<" segments\n";
   display_path(plan);
   for (auto it = t.begin(); it != t.end(); it++)
-    {
-      auto position=it->position();
-      std::cout<<"Waypoint "<<count<<": {"<<position[0]<<","<<position[1]
-          <<","<<position[2]<<"} "
-          <<rmf_traffic::time::to_seconds(it->time() - time)<<"s"
-          <<std::endl;
-      count++;
-    }
+  {
+    auto position = it->position();
+    std::cout<<"Waypoint "<<count<<": {"<<position[0]<<","<<position[1]
+             <<","<<position[2]<<"} "
+             <<rmf_traffic::time::to_seconds(it->time() - time)<<"s"
+             <<std::endl;
+    count++;
+  }
   std::cout<<"__________________\n";
 }
 
 rmf_traffic::Trajectory test_with_obstacle(
-    const std::string& parent,
-    const rmf_traffic::agv::Plan& original_plan,
-    rmf_traffic::schedule::Database& database,
-    const std::vector<rmf_traffic::Trajectory>& obstacles,
-    const std::size_t hold_index,
-    const rmf_traffic::Time time,
-    const bool expect_conflict=true,
-    const bool check_holding=true,
-    const bool print_info=false)
+  const std::string& parent,
+  const rmf_traffic::agv::Plan& original_plan,
+  rmf_traffic::schedule::Database& database,
+  const std::vector<rmf_traffic::Trajectory>& obstacles,
+  const std::size_t hold_index,
+  const rmf_traffic::Time time,
+  const bool expect_conflict = true,
+  const bool check_holding = true,
+  const bool print_info = false)
 {
   const rmf_traffic::Profile profile = create_test_profile(UnitCircle);
 
   rmf_traffic::Trajectory t_obs;
   const rmf_traffic::schedule::ParticipantId p_obs =
-      database.register_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "obstacle",
-          "test_Planner",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
-          create_test_profile(UnitCircle)
-        });
+    database.register_participant(
+    rmf_traffic::schedule::ParticipantDescription{
+      "obstacle",
+      "test_Planner",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
+      create_test_profile(UnitCircle)
+    });
 
   rmf_traffic::RouteId rid = 0;
   rmf_traffic::schedule::ItineraryVersion iv = 0;
@@ -152,32 +152,33 @@ rmf_traffic::Trajectory test_with_obstacle(
 
   REQUIRE(plan->get_itinerary().size() == 1);
   t_obs = plan->get_itinerary().front().trajectory();
-  const Eigen::Vector2d initial_position = [&]() -> Eigen::Vector2d
-  {
-    if (original_plan.get_start().location())
-      return *original_plan.get_start().location();
+  const Eigen::Vector2d initial_position =
+    [&]() -> Eigen::Vector2d
+    {
+      if (original_plan.get_start().location())
+        return *original_plan.get_start().location();
 
-    const std::size_t start_index = original_plan.get_start().waypoint();
-    return graph.get_waypoint(start_index).get_location();
-  }();
+      const std::size_t start_index = original_plan.get_start().waypoint();
+      return graph.get_waypoint(start_index).get_location();
+    } ();
 
 
   const std::size_t goal_index = original_plan.get_goal().waypoint();
   const auto goal_position = graph.get_waypoint(goal_index).get_location();
 
   const Eigen::Vector2d p_initial =
-      t_obs.front().position().block<2,1>(0,0);
+    t_obs.front().position().block<2, 1>(0, 0);
   CHECK( (p_initial - initial_position).norm() == Approx(0.0) );
 
   const Eigen::Vector2d p_final =
-      t_obs.back().position().block<2,1>(0,0);
+    t_obs.back().position().block<2, 1>(0, 0);
   CHECK( (p_final - goal_position).norm() == Approx(0.0) );
-  
+
   const auto& original_trajectory =
-      original_plan.get_itinerary().front().trajectory();
+    original_plan.get_itinerary().front().trajectory();
   if (expect_conflict)
   {
-    CHECK( original_trajectory.duration() < t_obs.duration() );
+    CHECK(original_trajectory.duration() < t_obs.duration() );
   }
   else
   {
@@ -192,7 +193,7 @@ rmf_traffic::Trajectory test_with_obstacle(
   {
     const auto& p_obs = database.get_participant(entry.participant)->profile();
     CHECK(!rmf_traffic::DetectConflict::between(
-            profile, t_obs, p_obs, entry.route.trajectory()));
+        profile, t_obs, p_obs, entry.route.trajectory()));
   }
 
   // Confirm that the vehicle pulled into holding point in order to avoid
@@ -224,14 +225,14 @@ rmf_traffic::Trajectory test_with_obstacle(
 }
 
 void test_ignore_obstacle(
-    const rmf_traffic::agv::Plan& original_plan,
-    const rmf_traffic::schedule::Version database_version)
+  const rmf_traffic::agv::Plan& original_plan,
+  const rmf_traffic::schedule::Version database_version)
 {
   REQUIRE(database_version > 0);
   const auto& start = original_plan.get_start();
   rmf_traffic::agv::Plan::Options options = original_plan.get_options();
   std::unordered_set<rmf_traffic::schedule::ParticipantId> ignore_ids;
-  for (rmf_traffic::schedule::Version v=0; v <= database_version; ++v)
+  for (rmf_traffic::schedule::Version v = 0; v <= database_version; ++v)
     ignore_ids.insert(v);
 
   options.validator(nullptr);
@@ -241,12 +242,12 @@ void test_ignore_obstacle(
   // The new plan which ignores the conflicts should be the same as the original
   REQUIRE(new_plan->get_itinerary().size() == 1);
   CHECK(new_plan->get_itinerary().front().trajectory().duration()
-        == original_plan.get_itinerary().front().trajectory().duration());
+    == original_plan.get_itinerary().front().trajectory().duration());
 
   REQUIRE(new_plan->get_waypoints().size()
-          == original_plan.get_waypoints().size());
+    == original_plan.get_waypoints().size());
 
-  for (std::size_t i=0; i < new_plan->get_waypoints().size(); ++i)
+  for (std::size_t i = 0; i < new_plan->get_waypoints().size(); ++i)
   {
     const auto& new_wp = new_plan->get_waypoints()[i];
     const auto& old_wp = original_plan.get_waypoints()[i];
@@ -262,75 +263,75 @@ void test_ignore_obstacle(
 
     const Eigen::Vector3d new_p = new_wp.position();
     const Eigen::Vector3d old_p = old_wp.position();
-    CHECK( (new_p.block<2,1>(0,0) - old_p.block<2,1>(0,0)).norm()
-           == Approx(0.0) );
+    CHECK( (new_p.block<2, 1>(0, 0) - old_p.block<2, 1>(0, 0)).norm()
+      == Approx(0.0) );
     CHECK(rmf_utils::wrap_to_pi(new_p[2] - old_p[2]) == Approx(0.0) );
   }
 }
 
 inline void CHECK_TRAITS(
-      const rmf_traffic::agv::VehicleTraits& t1,
-      const rmf_traffic::agv::VehicleTraits& t2)
+  const rmf_traffic::agv::VehicleTraits& t1,
+  const rmf_traffic::agv::VehicleTraits& t2)
 {
   CHECK((t1.get_differential()->get_forward()
-      - t2.get_differential()->get_forward()).norm()
-      == Approx(0).margin(1e-6));
+    - t2.get_differential()->get_forward()).norm()
+    == Approx(0).margin(1e-6));
   CHECK(t1.get_differential()->is_reversible()
-      == t2.get_differential()->is_reversible());
+    == t2.get_differential()->is_reversible());
   CHECK(t1.linear().get_nominal_acceleration()
-      == t2.linear().get_nominal_acceleration());
+    == t2.linear().get_nominal_acceleration());
   CHECK(t1.linear().get_nominal_velocity()
-      == t2.linear().get_nominal_velocity());
+    == t2.linear().get_nominal_velocity());
   CHECK(t1.rotational().get_nominal_acceleration()
-      == t2.rotational().get_nominal_acceleration());
+    == t2.rotational().get_nominal_acceleration());
   CHECK(t1.rotational().get_nominal_velocity()
-      == t2.rotational().get_nominal_velocity());
+    == t2.rotational().get_nominal_velocity());
 }
 
 inline void CHECK_INTERPOLATION(
-      const rmf_traffic::agv::Interpolate::Options& o1,
-      const rmf_traffic::agv::Interpolate::Options& o2)
+  const rmf_traffic::agv::Interpolate::Options& o1,
+  const rmf_traffic::agv::Interpolate::Options& o2)
 {
   CHECK(o1.always_stop() == o2.always_stop());
   CHECK((o1.get_translation_threshold()-
-      o2.get_translation_threshold())
-          == Approx(0).margin(1e-6));
+    o2.get_translation_threshold())
+    == Approx(0).margin(1e-6));
   CHECK((o1.get_rotation_threshold()-
-      o2.get_rotation_threshold())
-          == Approx(0).margin(1e-6));
+    o2.get_rotation_threshold())
+    == Approx(0).margin(1e-6));
   CHECK((o1.get_corner_angle_threshold()-
-      o2.get_corner_angle_threshold())
-          == Approx(0).margin(1e-6));
+    o2.get_corner_angle_threshold())
+    == Approx(0).margin(1e-6));
 }
 
 inline void CHECK_PLAN(
-    rmf_utils::optional<rmf_traffic::agv::Plan> plan,
-    const Eigen::Vector2d first_location,
-    const double first_orientation,
-    const Eigen::Vector2d last_location,
-    const std::vector<std::size_t> wp_indices,
-    const double* last_orientation = nullptr)
+  rmf_utils::optional<rmf_traffic::agv::Plan> plan,
+  const Eigen::Vector2d first_location,
+  const double first_orientation,
+  const Eigen::Vector2d last_location,
+  const std::vector<std::size_t> wp_indices,
+  const double* last_orientation = nullptr)
 {
   REQUIRE(plan);
   REQUIRE(plan->get_itinerary().size() > 0);
   auto t = plan->get_itinerary().front().trajectory();
   // check locations
-  CHECK((t.front().position().block<2,1>(0,0)
-      - first_location).norm() == Approx(0.0).margin(1e-6));
-  CHECK((t.back().position().block<2,1>(0, 0)
-      - last_location).norm()  == Approx(0.0).margin(1e-6));
+  CHECK((t.front().position().block<2, 1>(0, 0)
+    - first_location).norm() == Approx(0.0).margin(1e-6));
+  CHECK((t.back().position().block<2, 1>(0, 0)
+    - last_location).norm()  == Approx(0.0).margin(1e-6));
   // check orientations
   CHECK((t.front().position()[2] - first_orientation)
-      == Approx(0.0).margin(1e-6));
+    == Approx(0.0).margin(1e-6));
   if (last_orientation != nullptr)
     CHECK((t.back().position()[2] - *last_orientation)
-        == Approx(0.0).margin(1e-6));
+      == Approx(0.0).margin(1e-6));
   // check waypoints
   const auto& wps = plan->get_waypoints();
   // removing consecutive duplicates of waypoints
   // when robot is waiting at holdign point
   std::vector<std::size_t> plan_indices;
-  for( const auto &wp : wps)
+  for (const auto& wp : wps)
   {
     if (wp.graph_index())
       plan_indices.push_back(*wp.graph_index());
@@ -339,10 +340,10 @@ inline void CHECK_PLAN(
   auto ip = std::unique(plan_indices.begin(), plan_indices.end());
   plan_indices.resize(std::distance(plan_indices.begin(), ip));
   REQUIRE(plan_indices.size() == wp_indices.size());
-  for( const auto &i : plan_indices)
+  for (const auto& i : plan_indices)
     CHECK(std::find(
         wp_indices.begin(), wp_indices.end(), i)
-        != wp_indices.end());
+      != wp_indices.end());
 }
 // ____________________________________________________________________________
 
@@ -357,10 +358,10 @@ SCENARIO("Test Configuration", "[config]")
   const std::string test_map_name = "test_map";
   Graph graph;
   graph.add_waypoint(test_map_name, {0, -5}); // 0
-  REQUIRE(graph.num_waypoints()==1);
+  REQUIRE(graph.num_waypoints() == 1);
 
   const VehicleTraits traits(
-      {0.7, 0.3}, {1.0, 0.45}, create_test_profile(UnitCircle));
+    {0.7, 0.3}, {1.0, 0.45}, create_test_profile(UnitCircle));
 
   const Interpolate::Options options = Interpolate::Options();
   Planner::Configuration config(graph, traits, options);
@@ -368,11 +369,11 @@ SCENARIO("Test Configuration", "[config]")
   WHEN("Get the graph in config")
   {
     Graph& graph_ = config.graph();
-    REQUIRE(graph_.num_waypoints()==graph.num_waypoints());
+    REQUIRE(graph_.num_waypoints() == graph.num_waypoints());
     for (std::size_t i = 0; i < graph.num_waypoints(); i++)
       CHECK((graph.get_waypoint(i).get_location() -
-          graph_.get_waypoint(i).get_location()).norm()
-              == Approx(0).margin(1e-6));
+        graph_.get_waypoint(i).get_location()).norm()
+        == Approx(0).margin(1e-6));
   }
 
   WHEN("Set the graph")
@@ -382,7 +383,7 @@ SCENARIO("Test Configuration", "[config]")
     REQUIRE(graph_.num_waypoints() == graph.num_waypoints() + 1);
     REQUIRE(config.graph().num_waypoints() == graph.num_waypoints() + 1);
     CHECK((config.graph().get_waypoint(graph.num_waypoints()).get_location()
-        - Eigen::Vector2d{5, 5}).norm() == Approx(0).margin(1e-6));
+      - Eigen::Vector2d{5, 5}).norm() == Approx(0).margin(1e-6));
   }
 
   WHEN("Get the vechile_traits")
@@ -395,7 +396,7 @@ SCENARIO("Test Configuration", "[config]")
   {
     VehicleTraits& traits_ = config.vehicle_traits();
     VehicleTraits traits_new(
-        {1.0, 0.5}, {1.0, 0.6}, create_test_profile(UnitCircle));
+      {1.0, 0.5}, {1.0, 0.6}, create_test_profile(UnitCircle));
     traits_ = traits_new;
     CHECK_TRAITS(config.vehicle_traits(), traits_);
   }
@@ -410,7 +411,7 @@ SCENARIO("Test Configuration", "[config]")
   {
     Interpolate::Options& options_ = config.interpolation();
     options_ = Interpolate::Options(
-        true, 1e-2, 5.0 * M_PI/180.0, 5.0 * M_PI/180.0);
+      true, 1e-2, 5.0 * M_PI/180.0, 5.0 * M_PI/180.0);
     CHECK_INTERPOLATION(config.interpolation(), options_);
   }
 }
@@ -429,16 +430,16 @@ SCENARIO("Test Options", "[options]")
   {
     CHECK(rmf_traffic::time::to_seconds(
         default_options.minimum_holding_time()- hold_time)
-            == Approx(0).margin(1e-6));
+      == Approx(0).margin(1e-6));
   }
 
   WHEN("Set the minimum_holding_time")
   {
-    Duration hold_time_ = std::chrono::seconds(5);  
+    Duration hold_time_ = std::chrono::seconds(5);
     default_options.minimum_holding_time(hold_time_);
     CHECK(rmf_traffic::time::to_seconds(
         default_options.minimum_holding_time()- hold_time_)
-            == Approx(0).margin(1e-6));   
+      == Approx(0).margin(1e-6));
   }
 
   WHEN("Get the interrupt_flag")
@@ -460,7 +461,7 @@ SCENARIO("Test Start")
   using Planner = rmf_traffic::agv::Planner;
 
   auto start_time = std::chrono::steady_clock::now();
-  
+
   Planner::Start start(
     start_time,
     1,
@@ -470,7 +471,7 @@ SCENARIO("Test Start")
   CHECK_FALSE(start.location());
 
   CHECK(rmf_traffic::time::to_seconds(start.time()-start_time)
-      == Approx(0.0).margin(1e-12));
+    == Approx(0.0).margin(1e-12));
   CHECK(start.waypoint() == 1);
   CHECK((start.orientation() - 0.0) == Approx(0.0).margin(1e-6));
 
@@ -497,7 +498,7 @@ SCENARIO("Test Goal")
   CHECK((*goal.orientation() - M_PI_2) == Approx(0.0));
 
   goal = Planner::Goal{3, 0.0};
-  CHECK(goal.waypoint() ==3);
+  CHECK(goal.waypoint() == 3);
   CHECK((*goal.orientation() - 0.0) == Approx(0.0));
 }
 
@@ -511,22 +512,23 @@ SCENARIO("Test planning")
   graph.add_waypoint(test_map_name, { 0, -5}); // 1
   graph.add_waypoint(test_map_name, { 5, -5}); // 2
   graph.add_waypoint(test_map_name, {10, -5}); // 3
-  graph.add_waypoint(test_map_name, {-5,  0}, true); // 4
-  graph.add_waypoint(test_map_name, { 0,  0}, true); // 5
-  graph.add_waypoint(test_map_name, { 5,  0}, true); // 6
-  graph.add_waypoint(test_map_name, {10,  0}); // 7
-  graph.add_waypoint(test_map_name, {10,  4}); // 8
-  graph.add_waypoint(test_map_name, { 0,  8}); // 9
-  graph.add_waypoint(test_map_name, { 5,  8}); // 10
+  graph.add_waypoint(test_map_name, {-5, 0}, true); // 4
+  graph.add_waypoint(test_map_name, { 0, 0}, true); // 5
+  graph.add_waypoint(test_map_name, { 5, 0}, true); // 6
+  graph.add_waypoint(test_map_name, {10, 0}); // 7
+  graph.add_waypoint(test_map_name, {10, 4}); // 8
+  graph.add_waypoint(test_map_name, { 0, 8}); // 9
+  graph.add_waypoint(test_map_name, { 5, 8}); // 10
   graph.add_waypoint(test_map_name, {10, 12}); // 11
   graph.add_waypoint(test_map_name, {12, 12}); // 12
-  REQUIRE(graph.num_waypoints()==13);
+  REQUIRE(graph.num_waypoints() == 13);
 
-  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
-  {
-    graph.add_lane(w0, w1);
-    graph.add_lane(w1, w0);
-  };
+  auto add_bidir_lane =
+    [&](const std::size_t w0, const std::size_t w1)
+    {
+      graph.add_lane(w0, w1);
+      graph.add_lane(w1, w0);
+    };
 
   add_bidir_lane(0, 1);
   add_bidir_lane(1, 2);
@@ -541,12 +543,12 @@ SCENARIO("Test planning")
 
   const rmf_traffic::Profile profile = create_test_profile(UnitCircle);
   const rmf_traffic::agv::VehicleTraits traits(
-      {0.7, 0.3}, {1.0, 0.45}, profile);
+    {0.7, 0.3}, {1.0, 0.45}, profile);
 
   rmf_traffic::schedule::Database database;
 
   const auto default_options = rmf_traffic::agv::Planner::Options{
-        make_test_schedule_validator(database, profile)};
+    make_test_schedule_validator(database, profile)};
 
   rmf_traffic::agv::Planner planner{
     rmf_traffic::agv::Planner::Configuration{graph, traits},
@@ -561,19 +563,19 @@ SCENARIO("Test planning")
   //   auto plan = planner.plan(
   //       rmf_traffic::agv::Planner::Start(start_time, 3, 0.0),
   //       rmf_traffic::agv::Planner::Goal(9));
-  // } 
+  // }
 
   WHEN("initial conditions satisfy the goals")
   {
     const rmf_traffic::Time start_time = std::chrono::steady_clock::now();
 
     auto plan = planner.plan(
-          rmf_traffic::agv::Planner::Start(start_time, 3, 0.0),
-          rmf_traffic::agv::Planner::Goal(3, 0.0));
+      rmf_traffic::agv::Planner::Start(start_time, 3, 0.0),
+      rmf_traffic::agv::Planner::Goal(3, 0.0));
 
     REQUIRE(plan);
-    CHECK(plan->get_itinerary().size()==1);
-    CHECK(plan->get_itinerary().front().trajectory().size()==0);
+    CHECK(plan->get_itinerary().size() == 1);
+    CHECK(plan->get_itinerary().front().trajectory().size() == 0);
   }
 
   WHEN("initial and goal waypoints are same but goal_orientation is different")
@@ -583,17 +585,17 @@ SCENARIO("Test planning")
     const double goal_orientation = M_PI/2.0;
     const rmf_traffic::Time start_time = std::chrono::steady_clock::now();
 
-    for(std::size_t i = 0; i < N; ++i)
+    for (std::size_t i = 0; i < N; ++i)
     {
       plan = planner.plan(
-          rmf_traffic::agv::Planner::Start{start_time, 3, 0.0},
-          rmf_traffic::agv::Planner::Goal{3, goal_orientation});
+        rmf_traffic::agv::Planner::Start{start_time, 3, 0.0},
+        rmf_traffic::agv::Planner::Goal{3, goal_orientation});
 
       REQUIRE(plan);
     }
 
     const auto end_time = std::chrono::steady_clock::now();
-    if(test_performance)
+    if (test_performance)
     {
       const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
       std::cout << "\nUnconstrained" << std::endl;
@@ -601,10 +603,10 @@ SCENARIO("Test planning")
       std::cout << "Per run: " << sec/N << std::endl;
     }
 
-    CHECK(plan->get_itinerary().size()==1);
+    CHECK(plan->get_itinerary().size() == 1);
     REQUIRE(plan->get_itinerary().front().trajectory().size() > 0);
     const auto t = plan->get_itinerary().front().trajectory();
-    const auto final_p = t.front().position().block<2,1>(0,0);
+    const auto final_p = t.front().position().block<2, 1>(0, 0);
     const auto err = (final_p - Eigen::Vector2d(10, -5)).norm();
     CHECK(err == Approx(0.0) );
     CHECK(t.back().position()[2] - goal_orientation == Approx(0));
@@ -618,16 +620,16 @@ SCENARIO("Test planning")
     const double goal_orientation = M_PI;
     const rmf_traffic::Time start_time = std::chrono::steady_clock::now();
 
-    for(std::size_t i = 0; i < N; ++i)
+    for (std::size_t i = 0; i < N; ++i)
     {
       plan = planner.plan(
-            rmf_traffic::agv::Planner::Start{start_time, 3, M_PI},
-            rmf_traffic::agv::Planner::Goal{2, goal_orientation});
+        rmf_traffic::agv::Planner::Start{start_time, 3, M_PI},
+        rmf_traffic::agv::Planner::Goal{2, goal_orientation});
       REQUIRE(plan);
     }
 
     const auto end_time = std::chrono::steady_clock::now();
-    if(test_performance)
+    if (test_performance)
     {
       const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
       std::cout << "\nUnconstrained" << std::endl;
@@ -636,19 +638,20 @@ SCENARIO("Test planning")
     }
 
     const auto expected_t = rmf_traffic::agv::Interpolate::positions(
-          traits, start_time, {{10.0, -5.0, M_PI}, {5.0, -5.0, M_PI}});
+      traits, start_time, {{10.0, -5.0, M_PI}, {5.0, -5.0, M_PI}});
 
-    REQUIRE(plan->get_itinerary().size()==1);
-    const rmf_traffic::Trajectory t = plan->get_itinerary().front().trajectory();
+    REQUIRE(plan->get_itinerary().size() == 1);
+    const rmf_traffic::Trajectory t =
+      plan->get_itinerary().front().trajectory();
     REQUIRE(t.size() == expected_t.size());
 
-    const Eigen::Vector2d initial_p = t.front().position().block<2,1>(0, 0);
+    const Eigen::Vector2d initial_p = t.front().position().block<2, 1>(0, 0);
     CHECK((initial_p - Eigen::Vector2d(10, -5)).norm() == Approx(0.0) );
 
-    const Eigen::Vector2d final_p = t.back().position().block<2,1>(0, 0);
+    const Eigen::Vector2d final_p = t.back().position().block<2, 1>(0, 0);
     CHECK((final_p - Eigen::Vector2d(5, -5)).norm() == Approx(0.0));
 
-    CHECK(t.back().position()[2] - goal_orientation==Approx(0));
+    CHECK(t.back().position()[2] - goal_orientation == Approx(0));
     CHECK(t.back().time() > start_time);
   }
 
@@ -662,17 +665,17 @@ SCENARIO("Test planning")
 
     rmf_traffic::Trajectory obstacle;
     obstacle.insert(
-          time + 19s,
-          {0.0, 8.0, 0.0},
-          {0.0, 0.0, 0.0});
+      time + 19s,
+      {0.0, 8.0, 0.0},
+      {0.0, 0.0, 0.0});
     obstacle.insert(
-          time + 40s,
-          {5.0, 8.0, 0.0},
-          {0.0, 0.0, 0.0});
+      time + 40s,
+      {5.0, 8.0, 0.0},
+      {0.0, 0.0, 0.0});
     obstacle.insert(
-          time + 50s,
-          {10.0, 12.0, 0.0},
-          {0.0, 0.0, 0.0});
+      time + 50s,
+      {10.0, 12.0, 0.0},
+      {0.0, 0.0, 0.0});
     REQUIRE(obstacle.size() == 3);
     obstacles.push_back(obstacle);
 
@@ -682,21 +685,21 @@ SCENARIO("Test planning")
       add_bidir_lane(11, 12);
 
       planner = rmf_traffic::agv::Planner{
-          rmf_traffic::agv::Planner::Configuration{graph, traits},
-          default_options
+        rmf_traffic::agv::Planner::Configuration{graph, traits},
+        default_options
       };
 
       rmf_utils::optional<rmf_traffic::agv::Plan> plan;
       const auto start_time = std::chrono::steady_clock::now();
 
-      for(std::size_t i = 0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
       {
         plan = planner.plan(start, goal);
         REQUIRE(plan);
       }
 
       const auto end_time = std::chrono::steady_clock::now();
-      if(test_performance)
+      if (test_performance)
       {
         const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
         std::cout << "\nUnconstrained 12->5" << std::endl;
@@ -707,16 +710,16 @@ SCENARIO("Test planning")
       REQUIRE(plan->get_itinerary().size() == 1);
       const auto t = plan->get_itinerary().front().trajectory();
 
-      const Eigen::Vector2d initial_p = t.front().position().block<2,1>(0, 0);
+      const Eigen::Vector2d initial_p = t.front().position().block<2, 1>(0, 0);
       CHECK( (initial_p - Eigen::Vector2d(12, 12)).norm() == Approx(0.0) );
 
-      const Eigen::Vector2d final_p = t.back().position().block<2,1>(0, 0);
+      const Eigen::Vector2d final_p = t.back().position().block<2, 1>(0, 0);
       CHECK( (final_p - Eigen::Vector2d(0, 0)).norm() == Approx(0.0) );
 
       WHEN("An obstacle is introduced")
       {
         test_with_obstacle(
-              "Unconstrained 12->5", *plan, database, obstacles, 6, time);
+          "Unconstrained 12->5", *plan, database, obstacles, 6, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
       }
@@ -730,20 +733,20 @@ SCENARIO("Test planning")
       graph.add_lane({5, Graph::OrientationConstraint::make({M_PI_2})}, 9);
 
       planner = rmf_traffic::agv::Planner{
-          rmf_traffic::agv::Planner::Configuration{graph, traits},
-          default_options
+        rmf_traffic::agv::Planner::Configuration{graph, traits},
+        default_options
       };
 
       rmf_utils::optional<rmf_traffic::agv::Plan> plan;
       const auto start_time = std::chrono::steady_clock::now();
-      for(std::size_t i=0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
       {
         plan = planner.plan(start, goal);
         REQUIRE(plan);
       }
- 
+
       const auto end_time = std::chrono::steady_clock::now();
-      if(test_performance)
+      if (test_performance)
       {
         const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
         std::cout << "\nConstrained to 0.0  12->5" << std::endl;
@@ -754,17 +757,17 @@ SCENARIO("Test planning")
       REQUIRE(plan->get_itinerary().size() == 1);
       const auto& t = plan->get_itinerary().front().trajectory();
 
-      const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
+      const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
       CHECK( (p_initial - Eigen::Vector2d(12, 12)).norm() == Approx(0.0) );
 
-      const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
+      const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
       CHECK( (p_final - Eigen::Vector2d(0, 0)).norm() == Approx(0.0) );
-      CHECK( t.back().position()[2] == Approx(M_PI/2.0) );
+      CHECK(t.back().position()[2] == Approx(M_PI/2.0) );
 
-     WHEN("An obstacle is introduced")
+      WHEN("An obstacle is introduced")
       {
         test_with_obstacle(
-              "Constrained to 0.0  12->5", *plan, database, obstacles, 6, time);
+          "Constrained to 0.0  12->5", *plan, database, obstacles, 6, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
       }
@@ -782,17 +785,17 @@ SCENARIO("Test planning")
 
     rmf_traffic::Trajectory obstacle;
     obstacle.insert(
-          time + 24s,
-          {0.0, 8.0, 0.0},
-          {0.0, 0.0, 0.0});
+      time + 24s,
+      {0.0, 8.0, 0.0},
+      {0.0, 0.0, 0.0});
     obstacle.insert(
-          time + 50s,
-          {0.0, 0.0, 0.0},
-          {0.0, 0.0, 0.0});
+      time + 50s,
+      {0.0, 0.0, 0.0},
+      {0.0, 0.0, 0.0});
     obstacle.insert(
-          time + 70s,
-          {0.0, -5.0, 0.0},
-          {0.0, 0.0, 0.0});
+      time + 70s,
+      {0.0, -5.0, 0.0},
+      {0.0, 0.0, 0.0});
     obstacles.push_back(obstacle);
 
     WHEN("Docking is not constrained")
@@ -801,21 +804,21 @@ SCENARIO("Test planning")
       add_bidir_lane(11, 12);
 
       planner = rmf_traffic::agv::Planner{
-          rmf_traffic::agv::Planner::Configuration{graph, traits},
-          default_options
+        rmf_traffic::agv::Planner::Configuration{graph, traits},
+        default_options
       };
 
       rmf_utils::optional<rmf_traffic::agv::Plan> plan;
       const auto start_time = std::chrono::steady_clock::now();
 
-      for(std::size_t i=0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
       {
         plan = planner.plan(start, goal);
         REQUIRE(plan);
       }
 
       const auto end_time = std::chrono::steady_clock::now();
-      if(test_performance)
+      if (test_performance)
       {
         const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
         std::cout << "\nUnconstrained 2->12" << std::endl;
@@ -826,16 +829,16 @@ SCENARIO("Test planning")
       REQUIRE(plan->get_itinerary().size() == 1);
       const auto t = plan->get_itinerary().front().trajectory();
 
-      const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
+      const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
       CHECK( (p_initial - Eigen::Vector2d(5, -5)).norm() == Approx(0.0) );
 
-      const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
+      const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
       CHECK( (p_final - Eigen::Vector2d(12, 12)).norm() == Approx(0.0) );
 
       WHEN("An obstacle is introduced")
       {
         test_with_obstacle(
-              "Unconstrained  2->12", *plan, database, obstacles, 4, time);
+          "Unconstrained  2->12", *plan, database, obstacles, 4, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
       }
@@ -848,21 +851,21 @@ SCENARIO("Test planning")
       graph.add_lane({12, Graph::OrientationConstraint::make({0.0})}, 11);
 
       planner = rmf_traffic::agv::Planner{
-          rmf_traffic::agv::Planner::Configuration{graph, traits},
-          default_options
+        rmf_traffic::agv::Planner::Configuration{graph, traits},
+        default_options
       };
 
       rmf_utils::optional<rmf_traffic::agv::Plan> plan;
       const auto start_time = std::chrono::steady_clock::now();
 
-      for(std::size_t i=0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
       {
         plan = planner.plan(start, goal);
         REQUIRE(plan);
       }
 
       const auto end_time = std::chrono::steady_clock::now();
-      if(test_performance)
+      if (test_performance)
       {
         const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
         std::cout << "\nConstrained to 0.0  2->12" << std::endl;
@@ -873,17 +876,17 @@ SCENARIO("Test planning")
       REQUIRE(plan->get_itinerary().size() == 1);
       const auto& t = plan->get_itinerary().front().trajectory();
 
-      const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
+      const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
       CHECK( (p_initial - Eigen::Vector2d(5, -5)).norm() == Approx(0.0) );
 
-      const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
+      const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
       CHECK( (p_final - Eigen::Vector2d(12, 12)).norm() == Approx(0.0) );
-      CHECK( t.back().position()[2] == Approx(0.0) );
+      CHECK(t.back().position()[2] == Approx(0.0) );
 
       WHEN("An obstacle is introduced")
       {
         test_with_obstacle(
-              "Constrained to 0.0  2->12", *plan, database, obstacles, 4, time);
+          "Constrained to 0.0  2->12", *plan, database, obstacles, 4, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
       }
@@ -896,20 +899,20 @@ SCENARIO("Test planning")
       graph.add_lane({12, Graph::OrientationConstraint::make({M_PI})}, 11);
 
       planner = rmf_traffic::agv::Planner{
-          rmf_traffic::agv::Planner::Configuration{graph, traits},
-          default_options
+        rmf_traffic::agv::Planner::Configuration{graph, traits},
+        default_options
       };
 
       rmf_utils::optional<rmf_traffic::agv::Plan> plan;
       const auto start_time = std::chrono::steady_clock::now();
-      for(std::size_t i=0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
       {
         plan = planner.plan(start, goal);
         REQUIRE(plan);
       }
 
       const auto end_time = std::chrono::steady_clock::now();
-      if(test_performance)
+      if (test_performance)
       {
         const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
         std::cout << "\nConstrained to 180.0  2->12" << std::endl;
@@ -920,27 +923,26 @@ SCENARIO("Test planning")
       REQUIRE(plan->get_itinerary().size() == 1);
       const auto& t = plan->get_itinerary().front().trajectory();
 
-      const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
+      const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
       CHECK( (p_initial - Eigen::Vector2d(5, -5)).norm() == Approx(0.0) );
 
-      const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
+      const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
       CHECK( (p_final - Eigen::Vector2d(12, 12)).norm() == Approx(0.0) );
 
       const double err = rmf_utils::wrap_to_pi(
-            t.back().position()[2] - M_PI);
+        t.back().position()[2] - M_PI);
       CHECK(err == Approx(0.0) );
 
       WHEN("An obstacle is introduced")
       {
         test_with_obstacle(
-              "Constrained to 180.0  2->12",
-              *plan, database, obstacles, 4, time);
+          "Constrained to 180.0  2->12",
+          *plan, database, obstacles, 4, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
       }
     }
   } //end of GIVEN
-
 
 
   GIVEN("Goal from 12->0 and two obstacles : 9->11 and 1->9")
@@ -957,17 +959,17 @@ SCENARIO("Test planning")
 
     rmf_traffic::Trajectory obstacle_1;
     obstacle_1.insert(
-         time + 19s,
-         {0.0, 8.0, 0.0},
-         {0.0, 0.0, 0.0});
+      time + 19s,
+      {0.0, 8.0, 0.0},
+      {0.0, 0.0, 0.0});
     obstacle_1.insert(
-         time + 40s,
-         {5.0, 8.0, 0.0},
-         {0.0, 0.0, 0.0});
+      time + 40s,
+      {5.0, 8.0, 0.0},
+      {0.0, 0.0, 0.0});
     obstacle_1.insert(
-         time + 50s,
-         {10.0, 12.0, 0.0},
-         {0.0, 0.0, 0.0});
+      time + 50s,
+      {10.0, 12.0, 0.0},
+      {0.0, 0.0, 0.0});
     REQUIRE(obstacle_1.size() == 3);
 
     WHEN("Docking is not constrained")
@@ -981,14 +983,14 @@ SCENARIO("Test planning")
       rmf_utils::optional<rmf_traffic::agv::Plan> plan;
 
       const auto start_time = std::chrono::steady_clock::now();
-      for(std::size_t i=0; i < N; ++i)
+      for (std::size_t i = 0; i < N; ++i)
       {
         plan = planner.plan(start, goal);
         REQUIRE(plan);
       }
 
       const auto end_time = std::chrono::steady_clock::now();
-      if(test_performance)
+      if (test_performance)
       {
         const double sec = rmf_traffic::time::to_seconds(end_time - start_time);
         std::cout << "\nUnconstrained  12->0" << std::endl;
@@ -999,22 +1001,24 @@ SCENARIO("Test planning")
       REQUIRE(plan->get_itinerary().size() == 1);
       const auto t = plan->get_itinerary().front().trajectory();
 
-      const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
-      const Eigen::Vector2d p_initial_g = graph.get_waypoint(start_index).get_location();
+      const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
+      const Eigen::Vector2d p_initial_g =
+        graph.get_waypoint(start_index).get_location();
       CHECK( (p_initial - p_initial_g).norm() == Approx(0.0) );
 
-      const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
-      const Eigen::Vector2d p_final_g = graph.get_waypoint(goal_index).get_location();
+      const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
+      const Eigen::Vector2d p_final_g =
+        graph.get_waypoint(goal_index).get_location();
       CHECK( (p_final - p_final_g).norm() == Approx(0.0) );
 
       WHEN("First obstacle is introduced")
       {
         CHECK(rmf_traffic::DetectConflict::between(
-                profile, t, profile, obstacle_1));
+            profile, t, profile, obstacle_1));
         obstacles.push_back(obstacle_1);
 
         test_with_obstacle(
-              "Unconstrained (1)  12->0", *plan, database, obstacles, 6, time);
+          "Unconstrained (1)  12->0", *plan, database, obstacles, 6, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
       }
@@ -1024,26 +1028,26 @@ SCENARIO("Test planning")
         REQUIRE(graph.get_waypoint(4).is_holding_point());
         rmf_traffic::Trajectory obstacle_2;
         obstacle_2.insert(
-              time + 49s,
-              {0.0, -5.0, M_PI_2},
-              {0.0, 0.0, 0.0});
+          time + 49s,
+          {0.0, -5.0, M_PI_2},
+          {0.0, 0.0, 0.0});
         obstacle_2.insert(
-              time + 60s,
-              {0.0, 0.0, M_PI_2},
-              {0.0, 0.0, 0.0});
+          time + 60s,
+          {0.0, 0.0, M_PI_2},
+          {0.0, 0.0, 0.0});
         obstacle_2.insert(
-              time + 87s,
-              {0.0, 8.0, M_PI_2},
-              {0.0, 0.0, 0.0});
-        REQUIRE(obstacle_2.size()==3);
+          time + 87s,
+          {0.0, 8.0, M_PI_2},
+          {0.0, 0.0, 0.0});
+        REQUIRE(obstacle_2.size() == 3);
         REQUIRE_FALSE(rmf_traffic::DetectConflict::between(
-                  profile, obstacle_1, profile, obstacle_2));
+            profile, obstacle_1, profile, obstacle_2));
         CHECK(rmf_traffic::DetectConflict::between(
-                profile, t, profile, obstacle_2));
+            profile, t, profile, obstacle_2));
 
         obstacles.push_back(obstacle_2);
         test_with_obstacle(
-              "Unconstrained (2)  12->0", *plan, database, obstacles, 4, time);
+          "Unconstrained (2)  12->0", *plan, database, obstacles, 4, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
       }
@@ -1052,23 +1056,23 @@ SCENARIO("Test planning")
       {
         rmf_traffic::Trajectory obstacle_2;
         obstacle_2.insert(
-              time + 81s,
-              {0.0, -5.0, 0.0},
-              {0.0, 0.0, 0.0});
+          time + 81s,
+          {0.0, -5.0, 0.0},
+          {0.0, 0.0, 0.0});
         obstacle_2.insert(
-              time + 92s,
-              {0.0, 0.0, 0.0},
-              {0.0, 0.0, 0.0});
+          time + 92s,
+          {0.0, 0.0, 0.0},
+          {0.0, 0.0, 0.0});
         obstacle_2.insert(
-              time + 110s,
-              {0.0, 8.0, 0.0},
-              {0.0, 0.0, 0.0});
-        REQUIRE(obstacle_2.size()==3);
+          time + 110s,
+          {0.0, 8.0, 0.0},
+          {0.0, 0.0, 0.0});
+        REQUIRE(obstacle_2.size() == 3);
         obstacles.push_back(obstacle_1);
         obstacles.push_back(obstacle_2);
 
         test_with_obstacle(
-              "Unconstrained (3)  12->0", *plan, database, obstacles, 6, time);
+          "Unconstrained (3)  12->0", *plan, database, obstacles, 6, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
       }
@@ -1087,43 +1091,44 @@ SCENARIO("DP1 Graph")
   graph.add_waypoint(test_map_name, {18, -12}, true); // 1
   graph.add_waypoint(test_map_name, {-10, -8});       // 2
   graph.add_waypoint(test_map_name, {-2, -8}, true);  // 3
-  graph.add_waypoint(test_map_name, { 3,  -8});       // 4
-  graph.add_waypoint(test_map_name, {12,  -8});       // 5
-  graph.add_waypoint(test_map_name, {18,  -8}, true); // 6
-  graph.add_waypoint(test_map_name, {-15,  -4},true); // 7
-  graph.add_waypoint(test_map_name, {-10,  -4});      // 8
-  graph.add_waypoint(test_map_name, { -2,  -4},true); // 9
-  graph.add_waypoint(test_map_name, { 3,  -4});       // 10
+  graph.add_waypoint(test_map_name, { 3, -8});       // 4
+  graph.add_waypoint(test_map_name, {12, -8});       // 5
+  graph.add_waypoint(test_map_name, {18, -8}, true); // 6
+  graph.add_waypoint(test_map_name, {-15, -4}, true); // 7
+  graph.add_waypoint(test_map_name, {-10, -4});      // 8
+  graph.add_waypoint(test_map_name, { -2, -4}, true); // 9
+  graph.add_waypoint(test_map_name, { 3, -4});       // 10
   graph.add_waypoint(test_map_name, {6, -4});         // 11
   graph.add_waypoint(test_map_name, {9, -4});         // 12
-  graph.add_waypoint(test_map_name, {-15,  0});       // 13
-  graph.add_waypoint(test_map_name, {-10,  0});       // 14
-  graph.add_waypoint(test_map_name, { 0,  0});        // 15 DOOR (not implemented)
-  graph.add_waypoint(test_map_name, { 3,  0});        // 16
+  graph.add_waypoint(test_map_name, {-15, 0});       // 13
+  graph.add_waypoint(test_map_name, {-10, 0});       // 14
+  graph.add_waypoint(test_map_name, { 0, 0});        // 15 DOOR (not implemented)
+  graph.add_waypoint(test_map_name, { 3, 0});        // 16
   graph.add_waypoint(test_map_name, {6, 0});          // 17
   graph.add_waypoint(test_map_name, {9, 0});          // 18
-  graph.add_waypoint(test_map_name, {15,  0},true);   // 19
-  graph.add_waypoint(test_map_name, {18,  0},true);   // 20
-  graph.add_waypoint(test_map_name, { -2,  4},true);  // 21
-  graph.add_waypoint(test_map_name, { 3,  4});        // 22
+  graph.add_waypoint(test_map_name, {15, 0}, true);   // 19
+  graph.add_waypoint(test_map_name, {18, 0}, true);   // 20
+  graph.add_waypoint(test_map_name, { -2, 4}, true);  // 21
+  graph.add_waypoint(test_map_name, { 3, 4});        // 22
   graph.add_waypoint(test_map_name, {6, 4});          // 23
   graph.add_waypoint(test_map_name, {9, 4});          // 24
-  graph.add_waypoint(test_map_name, {15,  4});        // 25
-  graph.add_waypoint(test_map_name, {18,  4});        // 26
-  graph.add_waypoint(test_map_name, { -15,  8},true); // 27
-  graph.add_waypoint(test_map_name, {-10,  8},true);  // 28
+  graph.add_waypoint(test_map_name, {15, 4});        // 25
+  graph.add_waypoint(test_map_name, {18, 4});        // 26
+  graph.add_waypoint(test_map_name, { -15, 8}, true); // 27
+  graph.add_waypoint(test_map_name, {-10, 8}, true);  // 28
   graph.add_waypoint(test_map_name, {3, 8}, true);    // 29
   graph.add_waypoint(test_map_name, {6, 8}, true);    // 30
-  graph.add_waypoint(test_map_name, {15,  8}, true);  // 31
-  graph.add_waypoint(test_map_name, {18,  8}, true);  // 32
+  graph.add_waypoint(test_map_name, {15, 8}, true);  // 31
+  graph.add_waypoint(test_map_name, {18, 8}, true);  // 32
 
-  REQUIRE(graph.num_waypoints()==33);
+  REQUIRE(graph.num_waypoints() == 33);
 
-  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
-  {
-    graph.add_lane(w0, w1);
-    graph.add_lane(w1, w0);
-  };
+  auto add_bidir_lane =
+    [&](const std::size_t w0, const std::size_t w1)
+    {
+      graph.add_lane(w0, w1);
+      graph.add_lane(w1, w0);
+    };
   //horizontal lates
   add_bidir_lane(0, 1);
   add_bidir_lane(2, 3);
@@ -1170,16 +1175,16 @@ SCENARIO("DP1 Graph")
   const rmf_traffic::Profile profile = create_test_profile(UnitCircle);
   rmf_traffic::schedule::Database database;
   const rmf_traffic::agv::VehicleTraits traits{
-      {1.0, 0.4},
-      {1.0, 0.5},
-      profile
+    {1.0, 0.4},
+    {1.0, 0.5},
+    profile
   };
   const rmf_traffic::Time time = std::chrono::steady_clock::now();
   bool interrupt_flag = false;
   const rmf_traffic::agv::Planner::Options default_options{
-      make_test_schedule_validator(database, profile),
-      std::chrono::seconds(5),
-      &interrupt_flag};
+    make_test_schedule_validator(database, profile),
+    std::chrono::seconds(5),
+    &interrupt_flag};
 
   rmf_traffic::agv::Planner planner{
     rmf_traffic::agv::Planner::Configuration{graph, traits},
@@ -1191,7 +1196,7 @@ SCENARIO("DP1 Graph")
   using rmf_traffic::DetectConflict;
 
   WHEN("Robot moves from 1->30 given multiple non-conflicting "
-       "obstacles that partially overlap in time")
+    "obstacles that partially overlap in time")
   {
     const std::size_t start_index = 1;
     const auto start = rmf_traffic::agv::Plan::Start{time, start_index, 0.0};
@@ -1204,42 +1209,44 @@ SCENARIO("DP1 Graph")
     print_timing(start_time);
 
     CHECK(plan->get_itinerary().size() == 1);
-    const auto t= plan->get_itinerary().front().trajectory();
+    const auto t = plan->get_itinerary().front().trajectory();
 
-    const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
-    const Eigen::Vector2d p_initial_g = graph.get_waypoint(start_index).get_location();
-    CHECK( (p_initial - p_initial_g).norm()==Approx(0.0));
+    const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d p_initial_g =
+      graph.get_waypoint(start_index).get_location();
+    CHECK( (p_initial - p_initial_g).norm() == Approx(0.0));
 
-    const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
-    const Eigen::Vector2d p_final_g = graph.get_waypoint(goal_index).get_location();
+    const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d p_final_g =
+      graph.get_waypoint(goal_index).get_location();
     CHECK( (p_final - p_final_g).norm() == Approx(0.0) );
 
     WHEN("Obstacle 28->3 that partially overlaps in time")
     {
       rmf_traffic::Trajectory obstacle_1;
       obstacle_1.insert(
-            time,
-            Eigen::Vector3d{-10,8,-M_PI_2},
-            Eigen::Vector3d{0,0,0});
+        time,
+        Eigen::Vector3d{-10, 8, -M_PI_2},
+        Eigen::Vector3d{0, 0, 0});
       obstacle_1.insert(
-            time + 20s,
-            Eigen::Vector3d{-10,-8,-M_PI_2},
-            Eigen::Vector3d{0,0,0});
+        time + 20s,
+        Eigen::Vector3d{-10, -8, -M_PI_2},
+        Eigen::Vector3d{0, 0, 0});
       obstacle_1.insert(
-            time + 25s,
-            Eigen::Vector3d{-10,-8,0},
-            Eigen::Vector3d{0,0,0});
+        time + 25s,
+        Eigen::Vector3d{-10, -8, 0},
+        Eigen::Vector3d{0, 0, 0});
       obstacle_1.insert(
-            time + 35s,
-            Eigen::Vector3d{-2,-8,0},
-            Eigen::Vector3d{0,0,0});
+        time + 35s,
+        Eigen::Vector3d{-2, -8, 0},
+        Eigen::Vector3d{0, 0, 0});
 
       REQUIRE_FALSE(rmf_traffic::DetectConflict::between(
-                profile, obstacle_1, profile, t));
+          profile, obstacle_1, profile, t));
       obstacles.push_back(obstacle_1);
 
       test_with_obstacle(
-            "Partial 28->3", *plan, database, obstacles, 0, time, false);
+        "Partial 28->3", *plan, database, obstacles, 0, time, false);
 
       test_ignore_obstacle(*plan, database.latest_version());
 
@@ -1247,26 +1254,26 @@ SCENARIO("DP1 Graph")
       {
         rmf_traffic::Trajectory obstacle_2;
         obstacle_2.insert(
-              time+20s,
-              Eigen::Vector3d{3,0,M_PI_2},
-              Eigen::Vector3d{0,0,0});
+          time+20s,
+          Eigen::Vector3d{3, 0, M_PI_2},
+          Eigen::Vector3d{0, 0, 0});
         obstacle_2.insert(
-              time+30s,
-              Eigen::Vector3d{3,8,M_PI_2},
-              Eigen::Vector3d{0,0,0});
+          time+30s,
+          Eigen::Vector3d{3, 8, M_PI_2},
+          Eigen::Vector3d{0, 0, 0});
 
         const auto view = database.query(rmf_traffic::schedule::query_all());
-        for(const auto& _t : view)
+        for (const auto& _t : view)
         {
           REQUIRE_FALSE(DetectConflict::between(
-                          profile, obstacle_2, profile, _t.route.trajectory()));
+              profile, obstacle_2, profile, _t.route.trajectory()));
         }
 
         REQUIRE_FALSE(DetectConflict::between(profile, obstacle_2, profile, t));
         obstacles.push_back(obstacle_2);
         test_with_obstacle(
-              "Partial 28->3, 16-29",
-              *plan, database, obstacles, 0, time, false);
+          "Partial 28->3, 16-29",
+          *plan, database, obstacles, 0, time, false);
 
         test_ignore_obstacle(*plan, database.latest_version());
 
@@ -1274,29 +1281,29 @@ SCENARIO("DP1 Graph")
         {
           rmf_traffic::Trajectory obstacle_3;
           obstacle_3.insert(
-                time+40s,
-                Eigen::Vector3d{9,4, 0},
-                Eigen::Vector3d{0,0,0});
+            time+40s,
+            Eigen::Vector3d{9, 4, 0},
+            Eigen::Vector3d{0, 0, 0});
           obstacle_3.insert(
-                time+60s,
-                Eigen::Vector3d{18,4,0},
-                Eigen::Vector3d{0,0,0});
+            time+60s,
+            Eigen::Vector3d{18, 4, 0},
+            Eigen::Vector3d{0, 0, 0});
 
           const auto view =
-              database.query(rmf_traffic::schedule::query_all());
-          for(const auto& _t : view)
+            database.query(rmf_traffic::schedule::query_all());
+          for (const auto& _t : view)
           {
             REQUIRE_FALSE(DetectConflict::between(
-                      profile, obstacle_3, profile, _t.route.trajectory()));
+                profile, obstacle_3, profile, _t.route.trajectory()));
           }
 
           REQUIRE_FALSE(DetectConflict::between(
-                          profile, obstacle_3, profile, t));
+              profile, obstacle_3, profile, t));
           obstacles.push_back(obstacle_3);
 
           test_with_obstacle(
-                "Partial 28->3, 16-29, 24->26", *plan, database,
-                obstacles, 0, time, false);
+            "Partial 28->3, 16-29, 24->26", *plan, database,
+            obstacles, 0, time, false);
 
           test_ignore_obstacle(*plan, database.latest_version());
 
@@ -1304,68 +1311,68 @@ SCENARIO("DP1 Graph")
           {
             rmf_traffic::Trajectory obstacle_4;
             obstacle_4.insert(
-                  time + 10s,
-                  Eigen::Vector3d{-2, -4, 0},
-                  Eigen::Vector3d{0, 0, 0});
+              time + 10s,
+              Eigen::Vector3d{-2, -4, 0},
+              Eigen::Vector3d{0, 0, 0});
             obstacle_4.insert(
-                  time + 20s,
-                  Eigen::Vector3d{3, 4, 0},
-                  Eigen::Vector3d{0, 0, 0});
+              time + 20s,
+              Eigen::Vector3d{3, 4, 0},
+              Eigen::Vector3d{0, 0, 0});
 
             const auto view =
-                database.query(rmf_traffic::schedule::query_all());
-            for(const auto& _t : view)
+              database.query(rmf_traffic::schedule::query_all());
+            for (const auto& _t : view)
               REQUIRE_FALSE(DetectConflict::between(
-                        profile, obstacle_4, profile, _t.route.trajectory()));
+                  profile, obstacle_4, profile, _t.route.trajectory()));
 
             REQUIRE_FALSE(DetectConflict::between(
-                            profile, obstacle_4, profile, t));
+                profile, obstacle_4, profile, t));
             obstacles.push_back(obstacle_4);
 
             rmf_traffic::Trajectory obstacle_5;
             obstacle_5.insert(
-                  time + 15s,
-                  Eigen::Vector3d{-15, 0, 0},
-                  Eigen::Vector3d{0, 0, 0});
+              time + 15s,
+              Eigen::Vector3d{-15, 0, 0},
+              Eigen::Vector3d{0, 0, 0});
 
             obstacle_5.insert(
-                  time + 45s,
-                  Eigen::Vector3d{-10, 0, 0},
-                  Eigen::Vector3d{0, 0, 0});
+              time + 45s,
+              Eigen::Vector3d{-10, 0, 0},
+              Eigen::Vector3d{0, 0, 0});
 
-            for(const auto& _t : view)
+            for (const auto& _t : view)
             {
               REQUIRE_FALSE(DetectConflict::between(
-                        profile, obstacle_5, profile, _t.route.trajectory()));
+                  profile, obstacle_5, profile, _t.route.trajectory()));
             }
 
             REQUIRE_FALSE(DetectConflict::between(
-                      profile, obstacle_5, profile, t));
+                profile, obstacle_5, profile, t));
             obstacles.push_back(obstacle_5);
 
             rmf_traffic::Trajectory obstacle_6;
             obstacle_6.insert(
-                  time + 60s,
-                  Eigen::Vector3d{-12, -8, 0},
-                  Eigen::Vector3d{0, 0, 0});
+              time + 60s,
+              Eigen::Vector3d{-12, -8, 0},
+              Eigen::Vector3d{0, 0, 0});
             obstacle_6.insert(
-                  time + 75s,
-                  Eigen::Vector3d{-18, -8, 0},
-                  Eigen::Vector3d{0, 0, 0});
+              time + 75s,
+              Eigen::Vector3d{-18, -8, 0},
+              Eigen::Vector3d{0, 0, 0});
 
-            for(const auto& _t : view)
+            for (const auto& _t : view)
             {
               REQUIRE_FALSE(DetectConflict::between(
-                        profile, obstacle_6, profile, _t.route.trajectory()));
+                  profile, obstacle_6, profile, _t.route.trajectory()));
             }
 
             REQUIRE_FALSE(DetectConflict::between(
-                            profile, obstacle_6, profile, t));
+                profile, obstacle_6, profile, t));
             obstacles.push_back(obstacle_6);
 
             test_with_obstacle(
-                  "Partial 28->3, 16-29, 24->26, 21->22, 13->14, 5->6",
-                  *plan, database, obstacles, 0, time, false);
+              "Partial 28->3, 16-29, 24->26, 21->22, 13->14, 5->6",
+              *plan, database, obstacles, 0, time, false);
 
             test_ignore_obstacle(*plan, database.latest_version());
           }
@@ -1374,7 +1381,9 @@ SCENARIO("DP1 Graph")
     }
   }
 
-  WHEN("Robot moves from 1->30 given multiple non-conflicting obstacles that fully overlap in time")
+  WHEN(
+    "Robot moves from 1->30 given multiple non-conflicting obstacles
+    that fully overlap in time")
   {
     const auto time = std::chrono::steady_clock::now();
     const std::size_t start_index = 1;
@@ -1388,41 +1397,43 @@ SCENARIO("DP1 Graph")
     REQUIRE(plan);
     print_timing(start_time);
 
-    CHECK(plan->get_itinerary().size()==1);
+    CHECK(plan->get_itinerary().size() == 1);
     auto t = plan->get_itinerary().front().trajectory();
 
-    const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
-    const Eigen::Vector2d p_initial_g = graph.get_waypoint(start_index).get_location();
+    const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d p_initial_g =
+      graph.get_waypoint(start_index).get_location();
     CHECK( (p_initial - p_initial_g).norm() == Approx(0.0) );
 
-    const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
-    const Eigen::Vector2d p_final_g = graph.get_waypoint(goal_index).get_location();
-    CHECK( (p_final - p_final_g).norm()==Approx(0.0) );
+    const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d p_final_g =
+      graph.get_waypoint(goal_index).get_location();
+    CHECK( (p_final - p_final_g).norm() == Approx(0.0) );
 
     WHEN("Obstacle 28->3 that partially overlaps in time")
     {
       rmf_traffic::Trajectory obstacle_1;
       obstacle_1.insert(
-            time,
-            Eigen::Vector3d{-10,8,-M_PI_2},
-            Eigen::Vector3d{0,0,0});
+        time,
+        Eigen::Vector3d{-10, 8, -M_PI_2},
+        Eigen::Vector3d{0, 0, 0});
       obstacle_1.insert(
-            time + 30s,
-            Eigen::Vector3d{-10,-8,-M_PI_2},
-            Eigen::Vector3d{0,0,0});
+        time + 30s,
+        Eigen::Vector3d{-10, -8, -M_PI_2},
+        Eigen::Vector3d{0, 0, 0});
       obstacle_1.insert(
-            time + 50s,
-            Eigen::Vector3d{-10,-8,0},
-            Eigen::Vector3d{0,0,0});
+        time + 50s,
+        Eigen::Vector3d{-10, -8, 0},
+        Eigen::Vector3d{0, 0, 0});
       obstacle_1.insert(
-            time + 76s,
-            Eigen::Vector3d{-2,-8,0},
-            Eigen::Vector3d{0,0,0});
+        time + 76s,
+        Eigen::Vector3d{-2, -8, 0},
+        Eigen::Vector3d{0, 0, 0});
 
       REQUIRE_FALSE(DetectConflict::between(profile, obstacle_1, profile, t));
       obstacles.push_back(obstacle_1);
       test_with_obstacle(
-            "Full 28->3", *plan, database, obstacles, 0, time, false);
+        "Full 28->3", *plan, database, obstacles, 0, time, false);
 
       test_ignore_obstacle(*plan, database.latest_version());
 
@@ -1430,25 +1441,25 @@ SCENARIO("DP1 Graph")
       {
         rmf_traffic::Trajectory obstacle_2;
         obstacle_2.insert(
-           time,
-           Eigen::Vector3d{3,0,M_PI_2},
-           Eigen::Vector3d{0,0,0});
+          time,
+          Eigen::Vector3d{3, 0, M_PI_2},
+          Eigen::Vector3d{0, 0, 0});
         obstacle_2.insert(
-           time+76s,
-           Eigen::Vector3d{3,8,M_PI_2},
-           Eigen::Vector3d{0,0,0});
+          time+76s,
+          Eigen::Vector3d{3, 8, M_PI_2},
+          Eigen::Vector3d{0, 0, 0});
 
         const auto view = database.query(rmf_traffic::schedule::query_all());
-        for(const auto& _t : view)
+        for (const auto& _t : view)
         {
           REQUIRE_FALSE(DetectConflict::between(
-                          profile, obstacle_2, profile, _t.route.trajectory()));
+              profile, obstacle_2, profile, _t.route.trajectory()));
         }
 
         REQUIRE_FALSE(DetectConflict::between(profile, obstacle_2, profile, t));
         obstacles.push_back(obstacle_2);
         test_with_obstacle(
-              "Full 28->3, 16-29", *plan, database, obstacles, 0, time, false);
+          "Full 28->3, 16-29", *plan, database, obstacles, 0, time, false);
 
         test_ignore_obstacle(*plan, database.latest_version());
 
@@ -1456,28 +1467,28 @@ SCENARIO("DP1 Graph")
         {
           rmf_traffic::Trajectory obstacle_3;
           obstacle_3.insert(
-                time,
-                Eigen::Vector3d{9,4, 0},
-                Eigen::Vector3d{0,0,0});
+            time,
+            Eigen::Vector3d{9, 4, 0},
+            Eigen::Vector3d{0, 0, 0});
           obstacle_3.insert(
-                time + 76s,
-                Eigen::Vector3d{18,4,0},
-                Eigen::Vector3d{0,0,0});
+            time + 76s,
+            Eigen::Vector3d{18, 4, 0},
+            Eigen::Vector3d{0, 0, 0});
 
           const auto view = database.query(rmf_traffic::schedule::query_all());
-          for(const auto& _t : view)
+          for (const auto& _t : view)
           {
             REQUIRE_FALSE(DetectConflict::between(
-                      profile, obstacle_3, profile, _t.route.trajectory()));
+                profile, obstacle_3, profile, _t.route.trajectory()));
           }
 
           REQUIRE_FALSE(DetectConflict::between(
-                          profile, obstacle_3, profile, t));
+              profile, obstacle_3, profile, t));
           obstacles.push_back(obstacle_3);
 
           test_with_obstacle(
-                "Full 28->3, 16-29, 24->26",
-                *plan, database, obstacles, 0, time, false);
+            "Full 28->3, 16-29, 24->26",
+            *plan, database, obstacles, 0, time, false);
 
           test_ignore_obstacle(*plan, database.latest_version());
 
@@ -1485,69 +1496,69 @@ SCENARIO("DP1 Graph")
           {
             rmf_traffic::Trajectory obstacle_4;
             obstacle_4.insert(
-                 time,
-                 Eigen::Vector3d{-2, 4, 0},
-                 Eigen::Vector3d{0, 0, 0});
+              time,
+              Eigen::Vector3d{-2, 4, 0},
+              Eigen::Vector3d{0, 0, 0});
             obstacle_4.insert(
-                 time + 76s,
-                 Eigen::Vector3d{3, 4, 0},
-                 Eigen::Vector3d{0, 0, 0});
+              time + 76s,
+              Eigen::Vector3d{3, 4, 0},
+              Eigen::Vector3d{0, 0, 0});
 
             const auto view =
-                database.query(rmf_traffic::schedule::query_all());
-            for(const auto& _t : view)
+              database.query(rmf_traffic::schedule::query_all());
+            for (const auto& _t : view)
             {
               REQUIRE_FALSE(DetectConflict::between(
-                        profile, obstacle_4, profile, _t.route.trajectory()));
+                  profile, obstacle_4, profile, _t.route.trajectory()));
             }
 
             REQUIRE_FALSE(DetectConflict::between(
-                            profile, obstacle_4, profile, t));
+                profile, obstacle_4, profile, t));
             obstacles.push_back(obstacle_4);
 
             rmf_traffic::Trajectory obstacle_5;
             obstacle_5.insert(
-                  time,
-                  Eigen::Vector3d{-15,0, 0},
-                  Eigen::Vector3d{0,0,0});
+              time,
+              Eigen::Vector3d{-15, 0, 0},
+              Eigen::Vector3d{0, 0, 0});
             obstacle_5.insert(
-                  time + 76s,
-                  Eigen::Vector3d{-10,0,0},
-                  Eigen::Vector3d{0,0,0});
+              time + 76s,
+              Eigen::Vector3d{-10, 0, 0},
+              Eigen::Vector3d{0, 0, 0});
 
-            for(const auto& _t : view)
+            for (const auto& _t : view)
             {
               REQUIRE_FALSE(DetectConflict::between(
-                        profile, obstacle_5, profile, _t.route.trajectory()));
+                  profile, obstacle_5, profile, _t.route.trajectory()));
             }
 
             REQUIRE_FALSE(DetectConflict::between(
-                            profile, obstacle_5, profile, t));
+                profile, obstacle_5, profile, t));
             obstacles.push_back(obstacle_5);
 
             rmf_traffic::Trajectory obstacle_6;
             obstacle_6.insert(
-               time,
-               Eigen::Vector3d{-12,-8, 0},
-               Eigen::Vector3d{0,0,0});
+              time,
+              Eigen::Vector3d{-12, -8, 0},
+              Eigen::Vector3d{0, 0, 0});
             obstacle_6.insert(
-               time + 76s,
-               Eigen::Vector3d{-18,-8,0},
-               Eigen::Vector3d{0,0,0});
+              time + 76s,
+              Eigen::Vector3d{-18, -8, 0},
+              Eigen::Vector3d{0, 0, 0});
 
-            for(const auto& _t : view)
+            for (const auto& _t : view)
             {
               REQUIRE_FALSE(DetectConflict::between(
-                        profile, obstacle_6, profile, _t.route.trajectory()));
+                  profile, obstacle_6, profile, _t.route.trajectory()));
             }
 
             REQUIRE_FALSE(DetectConflict::between(
-                            profile, obstacle_6, profile, t));
+                profile, obstacle_6, profile, t));
             obstacles.push_back(obstacle_6);
 
             test_with_obstacle(
-                  "Full 28->3, 16-29, 24->26, 2->3, 13->14, 5->6",
-                  *plan, database, obstacles, 0, time, false);
+              "Full 28->3, 16-29, 24->26, 2->3, 13->14, 5->6",
+              *plan, database, obstacles, 0, time, false);
 
             test_ignore_obstacle(*plan, database.latest_version());
           }
@@ -1574,36 +1585,38 @@ SCENARIO("DP1 Graph")
     CHECK(plan->get_itinerary().size() == 1);
     const auto t = plan->get_itinerary().front().trajectory();
 
-    const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
-    const Eigen::Vector2d p_initial_g = graph.get_waypoint(start_index).get_location();
+    const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d p_initial_g =
+      graph.get_waypoint(start_index).get_location();
     CHECK( (p_initial - p_initial_g).norm() == Approx(0.0) );
 
-    const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
-    const Eigen::Vector2d p_final_g = graph.get_waypoint(goal_index).get_location();
+    const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d p_final_g =
+      graph.get_waypoint(goal_index).get_location();
     CHECK( (p_final - p_final_g).norm() == Approx(0.0) );
 
     rmf_traffic::Trajectory obstacle;
     obstacle.insert(
-          time + 6s,
-          Eigen::Vector3d{6,4,0},
-          Eigen::Vector3d{0,0,0});
+      time + 6s,
+      Eigen::Vector3d{6, 4, 0},
+      Eigen::Vector3d{0, 0, 0});
     obstacle.insert(
-          time + 16s,
-          Eigen::Vector3d{18,4,0},
-          Eigen::Vector3d{0,0,0});
+      time + 16s,
+      Eigen::Vector3d{18, 4, 0},
+      Eigen::Vector3d{0, 0, 0});
     obstacle.insert(
-          time + 26s,
-          Eigen::Vector3d{18,0,0},
-          Eigen::Vector3d{0,0,0});
+      time + 26s,
+      Eigen::Vector3d{18, 0, 0},
+      Eigen::Vector3d{0, 0, 0});
 
     WHEN("First obstacle is introduced")
     {
-       REQUIRE_FALSE(!rmf_traffic::DetectConflict::between(
-                       profile, obstacle, profile, t));
-       obstacles.push_back(obstacle);
-       test_with_obstacle("Unconstrained", *plan, database, obstacles, 32, time);
+      REQUIRE_FALSE(!rmf_traffic::DetectConflict::between(
+          profile, obstacle, profile, t));
+      obstacles.push_back(obstacle);
+      test_with_obstacle("Unconstrained", *plan, database, obstacles, 32, time);
 
-       test_ignore_obstacle(*plan, database.latest_version());
+      test_ignore_obstacle(*plan, database.latest_version());
     }
   }
 
@@ -1621,30 +1634,32 @@ SCENARIO("DP1 Graph")
     CHECK(plan);
     print_timing(start_time);
 
-    CHECK(plan->get_itinerary().size()==1);
+    CHECK(plan->get_itinerary().size() == 1);
     auto t = plan->get_itinerary().front().trajectory();
 
-    const Eigen::Vector2d p_initial = t.front().position().block<2,1>(0,0);
-    const Eigen::Vector2d p_initial_g = graph.get_waypoint(start_index).get_location();
+    const Eigen::Vector2d p_initial = t.front().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d p_initial_g =
+      graph.get_waypoint(start_index).get_location();
     CHECK( (p_initial - p_initial_g).norm() == Approx(0.0) );
 
-    const Eigen::Vector2d p_final = t.back().position().block<2,1>(0,0);
-    const Eigen::Vector2d p_final_g = graph.get_waypoint(goal_index).get_location();
+    const Eigen::Vector2d p_final = t.back().position().block<2, 1>(0, 0);
+    const Eigen::Vector2d p_final_g =
+      graph.get_waypoint(goal_index).get_location();
     CHECK( (p_final - p_final_g).norm() == Approx(0.0) );
 
     rmf_traffic::Trajectory obstacle_1;
     obstacle_1.insert(
-          time,
-          Eigen::Vector3d{-10, 8, -M_PI/2.0},
-          Eigen::Vector3d{0, 0, 0});
+      time,
+      Eigen::Vector3d{-10, 8, -M_PI/2.0},
+      Eigen::Vector3d{0, 0, 0});
     obstacle_1.insert(
-          time + 25s,
-          Eigen::Vector3d{-10, 0, -M_PI/2.0},
-          Eigen::Vector3d{0,0,0});
+      time + 25s,
+      Eigen::Vector3d{-10, 0, -M_PI/2.0},
+      Eigen::Vector3d{0, 0, 0});
     obstacle_1.insert(
-          time + 50s,
-          Eigen::Vector3d{-10, -8, -M_PI/2.0},
-          Eigen::Vector3d{0, 0, 0});
+      time + 50s,
+      Eigen::Vector3d{-10, -8, -M_PI/2.0},
+      Eigen::Vector3d{0, 0, 0});
 
     REQUIRE(obstacle_1.size() == 3);
     REQUIRE(DetectConflict::between(profile, t, profile, obstacle_1));
@@ -1659,21 +1674,21 @@ SCENARIO("DP1 Graph")
 
       rmf_utils::optional<rmf_traffic::agv::Plan> plan;
       auto plan_thread = std::thread(
-          [&]()
-      {
-        plan = planner.plan(start, goal);
-      });
+        [&]()
+        {
+          plan = planner.plan(start, goal);
+        });
       interrupt_flag = true;
       plan_thread.join();
       CHECK_FALSE(plan);
     }
-    
+
     WHEN("Obstacle 28->2")
     {
       obstacles.push_back(obstacle_1);
 
       const auto t_obs1 = test_with_obstacle(
-            "Obstacle 28->2", *plan, database, obstacles, 27, time);
+        "Obstacle 28->2", *plan, database, obstacles, 27, time);
 
       test_ignore_obstacle(*plan, database.latest_version());
 
@@ -1682,25 +1697,25 @@ SCENARIO("DP1 Graph")
         //robot waits 10s at 27 and then rotates on the spot at 13 for another 5s
         rmf_traffic::Trajectory obstacle_2;
         obstacle_2.insert(
-              time,
-              Eigen::Vector3d{3, 8,-M_PI_2},
-              Eigen::Vector3d{0,0,0});
+          time,
+          Eigen::Vector3d{3, 8, -M_PI_2},
+          Eigen::Vector3d{0, 0, 0});
         obstacle_2.insert(
-              time + 53s,
-              Eigen::Vector3d{3, 0,-M_PI_2},
-              Eigen::Vector3d{0,0,0});
+          time + 53s,
+          Eigen::Vector3d{3, 0, -M_PI_2},
+          Eigen::Vector3d{0, 0, 0});
         obstacle_2.insert(
-              time + 60s,
-              Eigen::Vector3d{3,-4,-M_PI_2},
-              Eigen::Vector3d{0,0,0});
+          time + 60s,
+          Eigen::Vector3d{3, -4, -M_PI_2},
+          Eigen::Vector3d{0, 0, 0});
 
         CHECK(obstacle_2.size() == 3);
         CHECK(DetectConflict::between(profile, t_obs1, profile, obstacle_2));
 
         obstacles.push_back(obstacle_2);
 
-        const auto t_obs2=test_with_obstacle(
-               "Obstacle 28->2 , 29->4", *plan, database, obstacles, 27, time);
+        const auto t_obs2 = test_with_obstacle(
+          "Obstacle 28->2 , 29->4", *plan, database, obstacles, 27, time);
 
         test_ignore_obstacle(*plan, database.latest_version());
 
@@ -1710,17 +1725,17 @@ SCENARIO("DP1 Graph")
 
           rmf_traffic::Trajectory obstacle_3;
           obstacle_3.insert(
-                time + 50s,
-                Eigen::Vector3d{6, 4, 0},
-                Eigen::Vector3d{0, 0, 0});
+            time + 50s,
+            Eigen::Vector3d{6, 4, 0},
+            Eigen::Vector3d{0, 0, 0});
           obstacle_3.insert(
-                time + 85s,
-                Eigen::Vector3d{9, 4, 0},
-                Eigen::Vector3d{0, 0, 0});
+            time + 85s,
+            Eigen::Vector3d{9, 4, 0},
+            Eigen::Vector3d{0, 0, 0});
           obstacle_3.insert(
-                time + 95s,
-                Eigen::Vector3d{18, 4, 0},
-                Eigen::Vector3d{0 , 0 , 0});
+            time + 95s,
+            Eigen::Vector3d{18, 4, 0},
+            Eigen::Vector3d{0, 0, 0});
           CHECK(obstacle_3.size() == 3);
           CHECK(DetectConflict::between(profile, t_obs2, profile, obstacle_3));
 
@@ -1728,8 +1743,8 @@ SCENARIO("DP1 Graph")
           //std::cout<<"Obstacle Size: "<<obstacles.size()<<std::endl;
 
           test_with_obstacle(
-                "Obstacle 28->2 , 29->4, 23->26",
-                *plan, database, obstacles, 27, time);
+            "Obstacle 28->2 , 29->4, 23->26",
+            *plan, database, obstacles, 27, time);
 
           test_ignore_obstacle(*plan, database.latest_version());
         }
@@ -1741,9 +1756,9 @@ SCENARIO("DP1 Graph")
 std::size_t count_events(const rmf_traffic::agv::Plan& plan)
 {
   std::size_t count = 0;
-  for(const auto& wp : plan.get_waypoints())
+  for (const auto& wp : plan.get_waypoints())
   {
-    if(wp.event())
+    if (wp.event())
       ++count;
   }
 
@@ -1816,13 +1831,13 @@ private:
 };
 
 bool has_event(
-    ExpectEvent::Expectation expectation,
-    const rmf_traffic::agv::Plan& plan)
+  ExpectEvent::Expectation expectation,
+  const rmf_traffic::agv::Plan& plan)
 {
   ExpectEvent executor(expectation);
-  for(const auto& wp : plan.get_waypoints())
+  for (const auto& wp : plan.get_waypoints())
   {
-    if(wp.event() && wp.event()->execute(executor).result())
+    if (wp.event() && wp.event()->execute(executor).result())
       return true;
   }
 
@@ -1849,17 +1864,17 @@ SCENARIO("Graph with door", "[door]")
   graph.add_lane(0, 3);
   graph.add_lane({1, Event::make(DoorOpen("door", 5s))}, 3);
   graph.add_lane(
-      {2, Event::make(DoorOpen("door", 4s))},
-      {3, Event::make(DoorClose("door", 4s))});
+    {2, Event::make(DoorOpen("door", 4s))},
+    {3, Event::make(DoorClose("door", 4s))});
   graph.add_lane(3, 4);
 
   const rmf_traffic::agv::VehicleTraits traits(
-      {0.7, 0.3}, {1.0, 0.45}, create_test_profile(UnitCircle));
+    {0.7, 0.3}, {1.0, 0.45}, create_test_profile(UnitCircle));
 
   rmf_traffic::schedule::Database database;
 
   const auto default_options = rmf_traffic::agv::Planner::Options{
-      make_test_schedule_validator(database, traits.profile())};
+    make_test_schedule_validator(database, traits.profile())};
 
   rmf_traffic::agv::Planner planner{
     rmf_traffic::agv::Planner::Configuration{graph, traits},
@@ -1869,38 +1884,38 @@ SCENARIO("Graph with door", "[door]")
   const rmf_traffic::Time start_time = std::chrono::steady_clock::now();
 
   const auto plan_no_door = planner.plan(
-        rmf_traffic::agv::Planner::Start(start_time, 0, 0.0),
-        rmf_traffic::agv::Planner::Goal(4));
+    rmf_traffic::agv::Planner::Start(start_time, 0, 0.0),
+    rmf_traffic::agv::Planner::Goal(4));
   REQUIRE(plan_no_door);
   REQUIRE(plan_no_door->get_itinerary().size() == 1);
   CHECK(count_events(*plan_no_door) == 0);
 
   const auto plan_with_door_open = planner.plan(
-        rmf_traffic::agv::Planner::Start(start_time, 1, 0.0),
-        rmf_traffic::agv::Planner::Goal(4));
+    rmf_traffic::agv::Planner::Start(start_time, 1, 0.0),
+    rmf_traffic::agv::Planner::Goal(4));
   REQUIRE(plan_with_door_open);
   REQUIRE(plan_with_door_open->get_itinerary().size() == 1);
   CHECK(count_events(*plan_with_door_open) == 1);
   CHECK(has_event(ExpectEvent::DoorOpen, *plan_with_door_open));
 
   const auto t_with_door_open =
-      plan_with_door_open->get_itinerary().front().trajectory().duration();
+    plan_with_door_open->get_itinerary().front().trajectory().duration();
   const auto t_no_door =
-      plan_no_door->get_itinerary().front().trajectory().duration();
+    plan_no_door->get_itinerary().front().trajectory().duration();
   CHECK(rmf_traffic::time::to_seconds(t_with_door_open - t_no_door)
-        == Approx(5.0).margin(1e-12));
+    == Approx(5.0).margin(1e-12));
 
   const auto plan_with_door_open_close = planner.plan(
-        rmf_traffic::agv::Planner::Start(start_time, 2, 0.0),
-        rmf_traffic::agv::Planner::Goal(4));
+    rmf_traffic::agv::Planner::Start(start_time, 2, 0.0),
+    rmf_traffic::agv::Planner::Goal(4));
   REQUIRE(plan_with_door_open_close);
   REQUIRE(plan_with_door_open_close->get_itinerary().size() == 1);
   CHECK(count_events(*plan_with_door_open_close) == 2);
 
   const auto t_with_door_open_close =
-      plan_with_door_open_close->get_itinerary().front().trajectory().duration();
+    plan_with_door_open_close->get_itinerary().front().trajectory().duration();
   CHECK(rmf_traffic::time::to_seconds(t_with_door_open_close - t_no_door)
-        > rmf_traffic::time::to_seconds(8s));
+    > rmf_traffic::time::to_seconds(8s));
   CHECK(has_event(ExpectEvent::DoorOpen, *plan_with_door_open_close));
   CHECK(has_event(ExpectEvent::DoorClose, *plan_with_door_open_close));
 }
@@ -1923,11 +1938,11 @@ SCENARIO("Test planner with various start conditions")
   graph.add_waypoint(test_map_name, {0, 5}, true); // 4
   REQUIRE(graph.num_waypoints() == 5);
 
-  graph.add_lane(0 ,2); // 0
+  graph.add_lane(0, 2); // 0
   graph.add_lane(2, 0); // 1
   // added within tests for testing with orientation constraints
-  // graph.add_lane(1, 2); 
-  // graph.add_lane(2, 1); 
+  // graph.add_lane(1, 2);
+  // graph.add_lane(2, 1);
   graph.add_lane(3, 2); // 2
   graph.add_lane(2, 3); // 3
   graph.add_lane(4, 2); // 4
@@ -1935,28 +1950,28 @@ SCENARIO("Test planner with various start conditions")
 
   const auto profile = create_test_profile(UnitCircle);
   const VehicleTraits traits{
-      {1.0, 0.4},
-      {1.0, 0.5},
-      profile};
+    {1.0, 0.4},
+    {1.0, 0.5},
+    profile};
 
   rmf_traffic::schedule::Database database;
   const rmf_traffic::schedule::ParticipantId p_obs =
-      database.register_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "obstacles",
-          "test_Planner",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
-          profile
-        });
+    database.register_participant(
+    rmf_traffic::schedule::ParticipantDescription{
+      "obstacles",
+      "test_Planner",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
+      profile
+    });
   rmf_traffic::schedule::ItineraryVersion iv_o = 0;
   rmf_traffic::RouteId ri_o = 0;
 
   bool interrupt_flag = false;
   Duration hold_time = std::chrono::seconds(6);
   const rmf_traffic::agv::Planner::Options default_options{
-      make_test_schedule_validator(database, profile),
-      hold_time,
-      &interrupt_flag};
+    make_test_schedule_validator(database, profile),
+    hold_time,
+    &interrupt_flag};
 
   Planner planner{
     Planner::Configuration{graph, traits},
@@ -1970,19 +1985,20 @@ SCENARIO("Test planner with various start conditions")
     graph.add_lane(2, 1); // 7
     planner = Planner{Planner::Configuration{graph, traits}, default_options};
 
-    rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-5.0, 0};
+    rmf_utils::optional<Eigen::Vector2d> initial_location =
+      Eigen::Vector2d{-5.0, 0};
 
     Planner::Start start1 = Planner::Start{
-        initial_time,
-        1,
-        0.0};
+      initial_time,
+      1,
+      0.0};
     CHECK_FALSE(start1.location());
 
     Planner::Start start2 = Planner::Start{
-        initial_time,
-        1,
-        0.0,
-        std::move(initial_location)};
+      initial_time,
+      1,
+      0.0,
+      std::move(initial_location)};
     CHECK(start2.location());
 
     Planner::Goal goal{3};
@@ -1990,11 +2006,13 @@ SCENARIO("Test planner with various start conditions")
     const auto plan1 = planner.plan(start1, goal);
     REQUIRE(plan1);
     CHECK_PLAN(plan1, {-5.0, 0}, 0.0, {5.0, 0}, {1, 3});
-    const auto duration1 = plan1->get_itinerary().front().trajectory().duration();
+    const auto duration1 =
+      plan1->get_itinerary().front().trajectory().duration();
     const auto plan2 = plan1->replan(start2);
     REQUIRE(plan2);
     CHECK_PLAN(plan2, {-5.0, 0}, 0.0, {5.0, 0}, {1, 3});
-    const auto duration2 = plan2->get_itinerary().front().trajectory().duration();
+    const auto duration2 =
+      plan2->get_itinerary().front().trajectory().duration();
     CHECK((duration1 - duration2).count() == Approx(0.0));
     CHECK(plan1->get_itinerary().size() == plan2->get_itinerary().size());
 
@@ -2003,23 +2021,26 @@ SCENARIO("Test planner with various start conditions")
     const auto plan = plan1->replan(starts);
     REQUIRE(plan);
     CHECK_PLAN(plan, {-5.0, 0}, 0.0, {5.0, 0}, {1, 3});
-    CHECK((plan->get_itinerary().front().trajectory().duration() - duration1).count() == Approx(0.));
+    CHECK(
+      (plan->get_itinerary().front().trajectory().duration() - duration1).count() == Approx(
+        0.));
     CHECK(plan->get_itinerary().size() == plan1->get_itinerary().size());
   }
 
   WHEN("Start initial_location is not on an initial_waypoint")
-  { 
+  {
     graph.add_lane(1, 2); // 6
     graph.add_lane(2, 1); // 7
     planner = Planner{Planner::Configuration{graph, traits}, default_options};
 
-    rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-2.5, 0};
+    rmf_utils::optional<Eigen::Vector2d> initial_location =
+      Eigen::Vector2d{-2.5, 0};
 
     Planner::Start start = Planner::Start{
-        initial_time,
-        1,
-        0.0,
-        std::move(initial_location)};
+      initial_time,
+      1,
+      0.0,
+      std::move(initial_location)};
 
     CHECK(start.location());
     CHECK_FALSE(start.lane());
@@ -2043,23 +2064,23 @@ SCENARIO("Test planner with various start conditions")
       std::vector<rmf_traffic::Trajectory> obstacles;
       rmf_traffic::Trajectory obstacle;
       obstacle.insert(
-          initial_time,
-          Eigen::Vector3d{0, 0, 0},
-          Eigen::Vector3d{0, 0, 0});
+        initial_time,
+        Eigen::Vector3d{0, 0, 0},
+        Eigen::Vector3d{0, 0, 0});
 
       obstacle.insert(
-          initial_time + 60s,
-          Eigen::Vector3d{0, 0, 0},
-          Eigen::Vector3d{0, 0, 0});
+        initial_time + 60s,
+        Eigen::Vector3d{0, 0, 0},
+        Eigen::Vector3d{0, 0, 0});
 
       CHECK(DetectConflict::between(
-                profile, obstacle, profile,
-                plan->get_itinerary().front().trajectory()));
+          profile, obstacle, profile,
+          plan->get_itinerary().front().trajectory()));
       obstacles.push_back(obstacle);
 
       test_with_obstacle(
-          "Obstace 4->0 overlaps",
-          *plan, database, obstacles, 1, initial_time, true);
+        "Obstace 4->0 overlaps",
+        *plan, database, obstacles, 1, initial_time, true);
 
       // Note: Waypoint 2 will be skipped because the robot does not need to
       // stop or turn there. It moves directly from waypoint 1 to waypoint 3.
@@ -2068,10 +2089,11 @@ SCENARIO("Test planner with various start conditions")
   }
 
   WHEN("Start contains initial_location and initial_lane")
-  { 
+  {
 
     Planner::Goal goal{3};
-    rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-2.5, 0};
+    rmf_utils::optional<Eigen::Vector2d> initial_location =
+      Eigen::Vector2d{-2.5, 0};
 
     WHEN("initial_lane is not constrained")
     {
@@ -2082,11 +2104,11 @@ SCENARIO("Test planner with various start conditions")
       rmf_utils::optional<std::size_t> initial_lane = std::size_t{7};
 
       Planner::Start start{
-          initial_time,
-          1,
-          0.0,
-          std::move(initial_location),
-          std::move(initial_lane)};
+        initial_time,
+        1,
+        0.0,
+        std::move(initial_location),
+        std::move(initial_lane)};
 
       CHECK(start.location());
       CHECK(start.lane());
@@ -2106,15 +2128,16 @@ SCENARIO("Test planner with various start conditions")
     graph.add_lane(2, 1); // 7
     planner = Planner{Planner::Configuration{graph, traits}, default_options};
 
-    rmf_utils::optional<Eigen::Vector2d> initial_location = Eigen::Vector2d{-4.99, 0};
+    rmf_utils::optional<Eigen::Vector2d> initial_location =
+      Eigen::Vector2d{-4.99, 0};
     rmf_utils::optional<std::size_t> initial_lane = 6;
 
     Planner::Start start = Planner::Start{
-        initial_time,
-        2,
-        0.0,
-        std::move(initial_location),
-        std::move(initial_lane)};
+      initial_time,
+      2,
+      0.0,
+      std::move(initial_location),
+      std::move(initial_lane)};
 
     CHECK(start.location());
     CHECK(start.lane());
@@ -2159,32 +2182,34 @@ SCENARIO("Test planner with various start conditions")
       std::vector<rmf_traffic::Trajectory> obstacles;
       rmf_traffic::Trajectory obstacle;
       obstacle.insert(
-          initial_time,
-          Eigen::Vector3d{0, 0, 0},
-          Eigen::Vector3d{0, 0, 0});
+        initial_time,
+        Eigen::Vector3d{0, 0, 0},
+        Eigen::Vector3d{0, 0, 0});
 
       obstacle.insert(
-          initial_time + 60s,
-          Eigen::Vector3d{0, 0, 0},
-          Eigen::Vector3d{0, 0, 0});
+        initial_time + 60s,
+        Eigen::Vector3d{0, 0, 0},
+        Eigen::Vector3d{0, 0, 0});
       auto t = plan->get_itinerary().front().trajectory();
       REQUIRE(DetectConflict::between(profile, obstacle, profile, t));
       obstacles.push_back(obstacle);
 
-      for(auto& obstacle : obstacles)
+      for (auto& obstacle : obstacles)
       {
         const auto r = std::make_shared<rmf_traffic::Route>(
-              "test_map", obstacle);
+          "test_map", obstacle);
         database.extend(p_obs, {{ri_o++, r}}, iv_o++);
       }
 
       const auto result1 = plan->replan(start1);
-      const auto duration1 = result1->get_itinerary().front().trajectory().duration();
+      const auto duration1 =
+        result1->get_itinerary().front().trajectory().duration();
       const auto result2 = plan->replan(start2);
-      const auto duration2 = result2->get_itinerary().front().trajectory().duration();
+      const auto duration2 =
+        result2->get_itinerary().front().trajectory().duration();
 
-      const auto best_start = duration1 < duration2?
-            result1->get_start() : result2->get_start();
+      const auto best_start = duration1 < duration2 ?
+        result1->get_start() : result2->get_start();
 
       plan = planner.plan(starts, goal);
       CHECK_PLAN(plan, {-5, 0}, best_start.orientation(), {5.0, 0}, {1, 3});
@@ -2212,15 +2237,19 @@ SCENARIO("Test planner with various start conditions")
     const auto duration = plan->get_itinerary().front().trajectory().duration();
 
     const auto result1 = plan->replan(start1);
-    const auto duration1 = result1->get_itinerary().front().trajectory().duration();
+    const auto duration1 =
+      result1->get_itinerary().front().trajectory().duration();
     const auto result2 = plan->replan(start2);
-    const auto duration2 = result2->get_itinerary().front().trajectory().duration();
+    const auto duration2 =
+      result2->get_itinerary().front().trajectory().duration();
     CHECK(duration2 < duration1);
     CHECK(duration < duration1);
-    CHECK((duration - duration2).count() ==Approx(0.0).margin(1e-9));
+    CHECK((duration - duration2).count() == Approx(0.0).margin(1e-9));
   }
 
-  WHEN("Startset with same initial_location and initial_waypoints but different initial_orientations")
+  WHEN(
+    "Startset with same initial_location and initial_waypoints but different
+    initial_orientations")
   {
     // lane with exit orientation constraint
     graph.add_lane(1, {2, Graph::OrientationConstraint::make({0})}); // 6
@@ -2242,17 +2271,19 @@ SCENARIO("Test planner with various start conditions")
     CHECK_PLAN(plan, {-2.5, 0}, 0.0, {0, 5}, {2, 4});
     const auto duration = plan->get_itinerary().front().trajectory().duration();
     const auto result1 = plan->replan(start1);
-    const auto duration1 = result1->get_itinerary().front().trajectory().duration();
+    const auto duration1 =
+      result1->get_itinerary().front().trajectory().duration();
     const auto result2 = plan->replan(start2);
-    const auto duration2 = result2->get_itinerary().front().trajectory().duration();
+    const auto duration2 =
+      result2->get_itinerary().front().trajectory().duration();
 
 //    print_trajectory_info(*result1, initial_time);
 //    print_trajectory_info(*result2, initial_time);
     CHECK(duration1 < duration2);
     CHECK(duration < duration2);
-    CHECK((duration - duration1).count() ==Approx(0.0).margin(1e-9));
+    CHECK((duration - duration1).count() == Approx(0.0).margin(1e-9));
   }
-} 
+}
 
 SCENARIO("Test starts using graph with non-colinear waypoints")
 {
@@ -2271,7 +2302,7 @@ SCENARIO("Test starts using graph with non-colinear waypoints")
   graph.add_waypoint(test_map_name, {4, 15}, true); // 4
   REQUIRE(graph.num_waypoints() == 5);
 
-  graph.add_lane(0 ,1); // 0
+  graph.add_lane(0, 1); // 0
   graph.add_lane(1, 0); // 1
   graph.add_lane(0, 2); // 2
   graph.add_lane(2, 0); // 3
@@ -2281,21 +2312,21 @@ SCENARIO("Test starts using graph with non-colinear waypoints")
   REQUIRE(graph.num_lanes() == 7);
 
   const VehicleTraits traits{
-      {1.0, 0.4},
-      {1.0, 0.5},
-      create_test_profile(UnitCircle)};
+    {1.0, 0.4},
+    {1.0, 0.5},
+    create_test_profile(UnitCircle)};
 
   rmf_traffic::schedule::Database database;
   bool interrupt_flag = false;
   Duration hold_time = std::chrono::seconds(1);
   const rmf_traffic::agv::Planner::Options default_options{
-      make_test_schedule_validator(database, traits.profile()),
-      hold_time,
-      &interrupt_flag};
+    make_test_schedule_validator(database, traits.profile()),
+    hold_time,
+    &interrupt_flag};
 
   Planner planner{
-      Planner::Configuration{graph, traits},
-      default_options};
+    Planner::Configuration{graph, traits},
+    default_options};
 
   const rmf_traffic::Time initial_time = std::chrono::steady_clock::now();
 
@@ -2318,28 +2349,34 @@ SCENARIO("Test starts using graph with non-colinear waypoints")
 
     // starts where robot has initial_locations displace from waypoint 1
     // Displaced 0.5m along lane 5
-    rmf_utils::optional<Eigen::Vector2d> start_location1 = Eigen::Vector2d{-4, 3.5};
+    rmf_utils::optional<Eigen::Vector2d> start_location1 =
+      Eigen::Vector2d{-4, 3.5};
 
     Planner::Start start3{initial_time, 1, -M_PI_2, start_location1};
     // Displaced 0.5m along lane 1
-    rmf_utils::optional<Eigen::Vector2d> start_location2 = Eigen::Vector2d{-3.6, 2.7};
+    rmf_utils::optional<Eigen::Vector2d> start_location2 =
+      Eigen::Vector2d{-3.6, 2.7};
     Planner::Start start4{initial_time, 1, -0.64, start_location1};
 
     std::vector<Planner::Start> starts{start1, start2, start3, start4};
     REQUIRE(starts.size() == 4);
 
     auto result1 = planner.plan(start1, goal);
-    const auto duration1 = result1->get_itinerary().front().trajectory().duration();
+    const auto duration1 =
+      result1->get_itinerary().front().trajectory().duration();
     auto result2 = result1->replan(start2);
-    const auto duration2 = result2->get_itinerary().front().trajectory().duration();
+    const auto duration2 =
+      result2->get_itinerary().front().trajectory().duration();
     auto result3 = result2->replan(start3);
-    const auto duration3 = result3->get_itinerary().front().trajectory().duration();
+    const auto duration3 =
+      result3->get_itinerary().front().trajectory().duration();
     auto result4 = result3->replan(start4);
-    const auto duration4 = result3->get_itinerary().front().trajectory().duration();
+    const auto duration4 =
+      result3->get_itinerary().front().trajectory().duration();
 
     std::vector<rmf_traffic::Duration> durations{
-          duration1, duration2, duration3, duration4};
-    
+      duration1, duration2, duration3, duration4};
+
     auto best_duration_it = durations.begin();
 
     for (auto it = durations.begin(); it != durations.end(); it++)
@@ -2354,17 +2391,19 @@ SCENARIO("Test starts using graph with non-colinear waypoints")
     Planner::Start best_start = starts[best_index];
 
     const auto plan = planner.plan(starts, goal);
-    const auto plan_duration = plan->get_itinerary().front().trajectory().duration();
-    const auto start_position = best_start.location() ? best_start.location().value()
-        : graph.get_waypoint(best_start.waypoint()).get_location();
+    const auto plan_duration =
+      plan->get_itinerary().front().trajectory().duration();
+    const auto start_position =
+      best_start.location() ? best_start.location().value() :
+      graph.get_waypoint(best_start.waypoint()).get_location();
     CHECK_PLAN(
-        plan,
-        start_position,
-        best_start.orientation(),
-        {4,15},
-        {1, 0, 2, 4},
-        &goal_orientaion);
-    for(const auto duration : durations)
+      plan,
+      start_position,
+      best_start.orientation(),
+      {4, 15},
+      {1, 0, 2, 4},
+      &goal_orientaion);
+    for (const auto duration : durations)
     {
       CHECK(plan_duration <= duration);
     }

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -152,8 +152,7 @@ rmf_traffic::Trajectory test_with_obstacle(
 
   REQUIRE(plan->get_itinerary().size() == 1);
   t_obs = plan->get_itinerary().front().trajectory();
-  const Eigen::Vector2d initial_position =
-    [&]() -> Eigen::Vector2d
+  const Eigen::Vector2d initial_position = [&]() -> Eigen::Vector2d
     {
       if (original_plan.get_start().location())
         return *original_plan.get_start().location();
@@ -523,8 +522,7 @@ SCENARIO("Test planning")
   graph.add_waypoint(test_map_name, {12, 12}); // 12
   REQUIRE(graph.num_waypoints() == 13);
 
-  auto add_bidir_lane =
-    [&](const std::size_t w0, const std::size_t w1)
+  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
     {
       graph.add_lane(w0, w1);
       graph.add_lane(w1, w0);
@@ -1123,8 +1121,7 @@ SCENARIO("DP1 Graph")
 
   REQUIRE(graph.num_waypoints() == 33);
 
-  auto add_bidir_lane =
-    [&](const std::size_t w0, const std::size_t w1)
+  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
     {
       graph.add_lane(w0, w1);
       graph.add_lane(w1, w0);
@@ -1382,8 +1379,7 @@ SCENARIO("DP1 Graph")
   }
 
   WHEN(
-    "Robot moves from 1->30 given multiple non-conflicting obstacles
-    that fully overlap in time")
+    "Robot moves from 1->30 given multiple non-conflicting obstacles that fully overlap in time")
   {
     const auto time = std::chrono::steady_clock::now();
     const std::size_t start_index = 1;
@@ -2248,8 +2244,7 @@ SCENARIO("Test planner with various start conditions")
   }
 
   WHEN(
-    "Startset with same initial_location and initial_waypoints but different
-    initial_orientations")
+    "Startset with same initial_location and initial_waypoints but different initial_orientations")
   {
     // lane with exit orientation constraint
     graph.add_lane(1, {2, Graph::OrientationConstraint::make({0})}); // 6

--- a/rmf_traffic/test/unit/agv/test_VehicleTraits.cpp
+++ b/rmf_traffic/test/unit/agv/test_VehicleTraits.cpp
@@ -20,8 +20,8 @@
 #include <rmf_utils/catch.hpp>
 
 void test_independence(
-    rmf_traffic::agv::VehicleTraits& original,
-    rmf_traffic::agv::VehicleTraits& copy)
+  rmf_traffic::agv::VehicleTraits& original,
+  rmf_traffic::agv::VehicleTraits& copy)
 {
   // Check that the copy has the same properties as the original
   CHECK(copy.linear().get_nominal_velocity() == Approx(0.1));
@@ -31,12 +31,12 @@ void test_independence(
   CHECK(!copy.get_differential()->is_reversible());
 
   copy.linear()
-      .set_nominal_velocity(1.0)
-      .set_nominal_acceleration(2.0);
+  .set_nominal_velocity(1.0)
+  .set_nominal_acceleration(2.0);
 
   copy.rotational()
-      .set_nominal_velocity(3.0)
-      .set_nominal_acceleration(4.0);
+  .set_nominal_velocity(3.0)
+  .set_nominal_acceleration(4.0);
 
   copy.get_differential()->set_reversible(true);
 
@@ -55,12 +55,12 @@ void test_independence(
   CHECK(!original.get_differential()->is_reversible());
 
   original.linear()
-      .set_nominal_velocity(10.0)
-      .set_nominal_acceleration(20.0);
+  .set_nominal_velocity(10.0)
+  .set_nominal_acceleration(20.0);
 
   original.rotational()
-      .set_nominal_velocity(30.0)
-      .set_nominal_acceleration(40.0);
+  .set_nominal_velocity(30.0)
+  .set_nominal_acceleration(40.0);
 
   original.get_differential()->set_reversible(true);
 
@@ -82,7 +82,7 @@ void test_independence(
 SCENARIO("Test VehicleTraits")
 {
   rmf_traffic::agv::VehicleTraits original(
-      {0.0, 0.0}, {0.0, 0.0}, {nullptr, nullptr});
+    {0.0, 0.0}, {0.0, 0.0}, {nullptr, nullptr});
 
   // Check that the initial properties are all zero
   CHECK(original.linear().get_nominal_velocity() == Approx(0.0));
@@ -92,12 +92,12 @@ SCENARIO("Test VehicleTraits")
   CHECK(original.get_differential()->is_reversible());
 
   original.linear()
-      .set_nominal_velocity(0.1)
-      .set_nominal_acceleration(0.2);
+  .set_nominal_velocity(0.1)
+  .set_nominal_acceleration(0.2);
 
   original.rotational()
-      .set_nominal_velocity(0.3)
-      .set_nominal_acceleration(0.4);
+  .set_nominal_velocity(0.3)
+  .set_nominal_acceleration(0.4);
 
   original.get_differential()->set_reversible(false);
 
@@ -117,7 +117,7 @@ SCENARIO("Test VehicleTraits")
   SECTION("Copy operator")
   {
     rmf_traffic::agv::VehicleTraits copy(
-        {0.0, 0.0}, {0.0, 0.0}, {nullptr, nullptr});
+      {0.0, 0.0}, {0.0, 0.0}, {nullptr, nullptr});
 
     copy = original;
     test_independence(original, copy);
@@ -135,7 +135,7 @@ SCENARIO("Test VehicleTraits")
   {
     rmf_traffic::agv::VehicleTraits moved = original;
     rmf_traffic::agv::VehicleTraits copy(
-        {0.0, 0.0}, {0.0, 0.0}, {nullptr, nullptr});
+      {0.0, 0.0}, {0.0, 0.0}, {nullptr, nullptr});
 
     copy = std::move(moved);
     moved = original;

--- a/rmf_traffic/test/unit/agv/test_compute_plan_starts.cpp
+++ b/rmf_traffic/test/unit/agv/test_compute_plan_starts.cpp
@@ -34,7 +34,7 @@ SCENARIO("Test computing Starts from coordinates")
   double min_lane_length = 1e-8;
 
   WHEN("Location is on a waypoint, that is part of both a unidirectional and "
-      "bidirectional lane")
+    "bidirectional lane")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {0.05, 0.05}); // 1
@@ -49,11 +49,12 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {0, 0, 0};
 
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc,  initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
 
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 1);
@@ -63,7 +64,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is near a waypoint, within the waypoint merging distance. "
-      "Waypoint is part of both a unidirectional and a bidirectional lane.")
+    "Waypoint is part of both a unidirectional and a bidirectional lane.")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {0.1, 0.1}); // 1
@@ -78,11 +79,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1 + 1e-8, 0.1, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].location());
@@ -92,11 +94,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1 - 1e-8, 0.1, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].location());
@@ -106,11 +109,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1, 0.1 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].location());
@@ -120,11 +124,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1, 0.1 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].location());
@@ -134,7 +139,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is right on the border of merging to a waypoint, that is "
-      "connected to both a unidirectional and bidirectional lane.")
+    "connected to both a unidirectional and bidirectional lane.")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {0.1, 0.1}); // 1
@@ -149,11 +154,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1 + 0.1 - 1e-8, 0.1, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].location());
@@ -163,11 +169,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1 - 0.1 + 1e-8, 0.1, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].location());
@@ -177,11 +184,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1, 0.1 + 0.1 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].location());
@@ -191,11 +199,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1, 0.1 - 0.1 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].location());
@@ -205,8 +214,8 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is near multiple waypoints, could be merged to either one. "
-      "Waypoints are either connected to both unidirectional and bidirectional "
-      "lanes.")
+    "Waypoints are either connected to both unidirectional and bidirectional "
+    "lanes.")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {0.01, 0.01}); // 1
@@ -228,25 +237,26 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {0.05, 0.05, 0};
 
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
 
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 1);
     CHECK_FALSE(start_set[0].location());
     CHECK_FALSE(start_set[0].lane());
     CHECK((start_set[0].waypoint() == 0 || start_set[0].waypoint() == 1
-        || start_set[0].waypoint() == 2 || start_set[0].waypoint() == 3
-        || start_set[0].waypoint() == 4));
+      || start_set[0].waypoint() == 2 || start_set[0].waypoint() == 3
+      || start_set[0].waypoint() == 4));
   }
 
   WHEN("Location is not within merging with waypoints, within lane merging, "
-      "not between lane entry and lane exit, right outside of waypoint "
-      "merging distance. Waypoints are connected to both unidirectional or "
-      "bidirectional lanes.")
+    "not between lane entry and lane exit, right outside of waypoint "
+    "merging distance. Waypoints are connected to both unidirectional or "
+    "bidirectional lanes.")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {1, 0}); // 1
@@ -259,14 +269,15 @@ SCENARIO("Test computing Starts from coordinates")
     REQUIRE(graph.num_lanes() == 3);
 
     {
-      Eigen::Vector3d robot_loc =
-          {0 - max_waypoint_merging_distance - 1e-8, 0, 0};
+      Eigen::Vector3d robot_loc = {
+        0 - max_waypoint_merging_distance - 1e-8, 0, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -275,16 +286,16 @@ SCENARIO("Test computing Starts from coordinates")
     }
 
     const double slightly_larger_radius_x_y =
-        sqrt(pow(max_waypoint_merging_distance + 1e-8, 2.0) / 2.0);
+      sqrt(pow(max_waypoint_merging_distance + 1e-8, 2.0) / 2.0);
     {
-      Eigen::Vector3d robot_loc =
-          {0 - slightly_larger_radius_x_y, 0 + slightly_larger_radius_x_y, 0};
+      Eigen::Vector3d robot_loc = {
+        0 - slightly_larger_radius_x_y, 0 + slightly_larger_radius_x_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(
+        graph, robot_loc, initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -292,14 +303,15 @@ SCENARIO("Test computing Starts from coordinates")
       CHECK(start_set[0].waypoint() == 0);
     }
     {
-      Eigen::Vector3d robot_loc =
-          {0 - slightly_larger_radius_x_y, 0 - slightly_larger_radius_x_y, 0};
+      Eigen::Vector3d robot_loc = {
+        0 - slightly_larger_radius_x_y, 0 - slightly_larger_radius_x_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -308,15 +320,16 @@ SCENARIO("Test computing Starts from coordinates")
     }
 
     const double very_near_to_border_y =
-        sqrt(pow(max_waypoint_merging_distance + 1e-8, 2.0) - pow(1e-8, 2.0));
+      sqrt(pow(max_waypoint_merging_distance + 1e-8, 2.0) - pow(1e-8, 2.0));
     {
       Eigen::Vector3d robot_loc = {0 - 1e-8, 0 + very_near_to_border_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -326,11 +339,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0 - 1e-8, 0 - very_near_to_border_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -340,9 +354,9 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is not within merging with waypoints, within lane merging, "
-      "not between lane entry and lane exit, right within lane merging "
-      "distance. Waypoint is connected to both unidirectional and bidirectional"
-      " lanes.")
+    "not between lane entry and lane exit, right within lane merging "
+    "distance. Waypoint is connected to both unidirectional and bidirectional"
+    " lanes.")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {1, 0}); // 1
@@ -357,11 +371,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0 - max_lane_merging_distance + 1e-8, 0, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -370,18 +385,19 @@ SCENARIO("Test computing Starts from coordinates")
     }
 
     const double slightly_smaller_than_border_x_y =
-        sqrt(pow(max_lane_merging_distance - 1e-8, 2.0) / 2.0);
+      sqrt(pow(max_lane_merging_distance - 1e-8, 2.0) / 2.0);
     {
-      Eigen::Vector3d robot_loc =
-          {0 - slightly_smaller_than_border_x_y,
-          0 + slightly_smaller_than_border_x_y,
-          0};
+      Eigen::Vector3d robot_loc = {
+        0 - slightly_smaller_than_border_x_y,
+        0 + slightly_smaller_than_border_x_y,
+        0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -389,16 +405,16 @@ SCENARIO("Test computing Starts from coordinates")
       CHECK(start_set[0].waypoint() == 0);
     }
     {
-      Eigen::Vector3d robot_loc =
-          {0 - slightly_smaller_than_border_x_y,
-          0 - slightly_smaller_than_border_x_y,
-          0};
+      Eigen::Vector3d robot_loc = {
+        0 - slightly_smaller_than_border_x_y,
+        0 - slightly_smaller_than_border_x_y,
+        0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(
+        graph, robot_loc, initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -407,15 +423,16 @@ SCENARIO("Test computing Starts from coordinates")
     }
 
     const double very_near_to_border_y =
-        sqrt(pow(max_lane_merging_distance - 1e-8, 2.0) - pow(1e-8, 2.0));
+      sqrt(pow(max_lane_merging_distance - 1e-8, 2.0) - pow(1e-8, 2.0));
     {
       Eigen::Vector3d robot_loc = {0 - 1e-8, 0 + very_near_to_border_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -425,11 +442,11 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0 - 1e-8, 0 - very_near_to_border_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(
+        graph, robot_loc, initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK_FALSE(start_set[0].lane());
@@ -452,11 +469,12 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {5.5, 5.5, 0};
 
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 1);
     CHECK(start_set[0].waypoint() == 2);
@@ -480,11 +498,12 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {5.5, 5.5, 0};
 
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 2);
 
@@ -509,7 +528,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is not within merging with waypoints, within lane merging, "
-      "between unidirectional lane entry and exit.")
+    "between unidirectional lane entry and exit.")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {1, 0}); // 1
@@ -523,11 +542,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK(start_set[0].waypoint() == 2);
@@ -539,11 +559,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK(start_set[0].location());
@@ -554,11 +575,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 + max_lane_merging_distance - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK(start_set[0].location());
@@ -569,11 +591,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 - max_lane_merging_distance + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 1);
       CHECK(start_set[0].location());
@@ -584,7 +607,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is not within merging with waypoints, within lane merging, "
-      "between bidirectional lane entry and exit.")
+    "between bidirectional lane entry and exit.")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {1, 0}); // 1
@@ -599,11 +622,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 2);
 
@@ -629,11 +653,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 2);
 
@@ -659,11 +684,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 + 1.0 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 2);
 
@@ -689,11 +715,12 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 - 1.0 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-          rmf_traffic::agv::compute_plan_starts(
-              graph, robot_loc, initial_time,
-              max_waypoint_merging_distance,
-              max_lane_merging_distance,
-              min_lane_length);
+        rmf_traffic::agv::compute_plan_starts(graph,
+          robot_loc,
+          initial_time,
+          max_waypoint_merging_distance,
+          max_lane_merging_distance,
+          min_lane_length);
       CHECK(!start_set.empty());
       CHECK(start_set.size() == 2);
 
@@ -719,7 +746,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is on the cross section of 2 unidirectional lanes, within "
-      "lane merging for both lanes")
+    "lane merging for both lanes")
   {
     graph.add_waypoint(test_map_name, {-10, 0}); // 0
     graph.add_waypoint(test_map_name, {10, 0}); // 1
@@ -731,16 +758,17 @@ SCENARIO("Test computing Starts from coordinates")
     graph.add_lane(2, 3); // 1
     REQUIRE(graph.num_lanes() == 2);
 
-    Eigen::Vector3d robot_loc =
-        {0 + max_lane_merging_distance - 1e-8,
-        0 + max_lane_merging_distance - 1e-8,
-        0};
+    Eigen::Vector3d robot_loc = {
+      0 + max_lane_merging_distance - 1e-8,
+      0 + max_lane_merging_distance - 1e-8,
+      0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 2);
 
@@ -765,7 +793,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is on the cross section of a unidirectional lane, and a "
-      "bidirectional lane, within lane merging for both lanes")
+    "bidirectional lane, within lane merging for both lanes")
   {
     graph.add_waypoint(test_map_name, {-10, 0}); // 0
     graph.add_waypoint(test_map_name, {10, 0}); // 1
@@ -778,16 +806,17 @@ SCENARIO("Test computing Starts from coordinates")
     graph.add_lane(3, 2); // 2
     REQUIRE(graph.num_lanes() == 3);
 
-    Eigen::Vector3d robot_loc =
-        {0 + max_lane_merging_distance - 1e-8,
-        0 + max_lane_merging_distance - 1e-8,
-        0};
+    Eigen::Vector3d robot_loc = {
+      0 + max_lane_merging_distance - 1e-8,
+      0 + max_lane_merging_distance - 1e-8,
+      0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 3);
 
@@ -814,7 +843,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is on the cross section of 2 bidirectional lanes, within lane "
-      "merging for both lanes")
+    "merging for both lanes")
   {
     graph.add_waypoint(test_map_name, {-10, 0}); // 0
     graph.add_waypoint(test_map_name, {10, 0}); // 1
@@ -829,15 +858,16 @@ SCENARIO("Test computing Starts from coordinates")
     REQUIRE(graph.num_lanes() == 4);
 
     Eigen::Vector3d robot_loc =
-        {0 + max_lane_merging_distance - 1e-8,
-        0 + max_lane_merging_distance - 1e-8,
-        0};
+    {0 + max_lane_merging_distance - 1e-8,
+      0 + max_lane_merging_distance - 1e-8,
+      0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 4);
 
@@ -866,7 +896,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is near an elbow cross section of 2 unidirectional lanes, "
-      "within lane merging for both lanes, lanes moving away from elbow")
+    "within lane merging for both lanes, lanes moving away from elbow")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {5, 0}); // 1
@@ -878,13 +908,14 @@ SCENARIO("Test computing Starts from coordinates")
     REQUIRE(graph.num_lanes() == 2);
 
     Eigen::Vector3d robot_loc =
-        {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
+    {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 2);
 
@@ -909,7 +940,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is near an elbow cross section of 2 unidirectional lanes, "
-      "within lane merging for both lanes, lanes moving towards the elbow")
+    "within lane merging for both lanes, lanes moving towards the elbow")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {5, 0}); // 1
@@ -921,13 +952,14 @@ SCENARIO("Test computing Starts from coordinates")
     REQUIRE(graph.num_lanes() == 2);
 
     Eigen::Vector3d robot_loc =
-        {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
+    {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 2);
 
@@ -945,8 +977,8 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is near an elbow cross section of 2 unidirectional lanes, "
-      "within lane merging for both lanes, one lane moving away from the elbow "
-      "the other towards the elbow")
+    "within lane merging for both lanes, one lane moving away from the elbow "
+    "the other towards the elbow")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {5, 0}); // 1
@@ -957,14 +989,15 @@ SCENARIO("Test computing Starts from coordinates")
     graph.add_lane(0, 2); // 1
     REQUIRE(graph.num_lanes() == 2);
 
-    Eigen::Vector3d robot_loc =
-        {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
+    Eigen::Vector3d robot_loc = {
+      0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 2);
 
@@ -989,8 +1022,8 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is near an elbow cross section of one unidirectional lane "
-      "towards the elbow, and one bidirectional lane, within lane merging for "
-      "both lanes")
+    "towards the elbow, and one bidirectional lane, within lane merging for "
+    "both lanes")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {5, 0}); // 1
@@ -1002,14 +1035,14 @@ SCENARIO("Test computing Starts from coordinates")
     graph.add_lane(2, 0); // 2
     REQUIRE(graph.num_lanes() == 3);
 
-    Eigen::Vector3d robot_loc =
-        {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
+    Eigen::Vector3d robot_loc = {
+      0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc, initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 3);
 
@@ -1032,7 +1065,7 @@ SCENARIO("Test computing Starts from coordinates")
   }
 
   WHEN("Location is near an elbow cross section of two bidirectional lanes, "
-      "within lane merging for both lanes")
+    "within lane merging for both lanes")
   {
     graph.add_waypoint(test_map_name, {0, 0}); // 0
     graph.add_waypoint(test_map_name, {5, 0}); // 1
@@ -1045,14 +1078,15 @@ SCENARIO("Test computing Starts from coordinates")
     graph.add_lane(0, 2); // 3
     REQUIRE(graph.num_lanes() == 4);
 
-    Eigen::Vector3d robot_loc =
-        {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
+    Eigen::Vector3d robot_loc = {
+      0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(!start_set.empty());
     CHECK(start_set.size() == 4);
 
@@ -1090,11 +1124,12 @@ SCENARIO("Test computing Starts from coordinates")
 
     Eigen::Vector3d robot_loc = {1 + 1e-8, 1 + 1e-8, 0.0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(
-            graph, robot_loc, initial_time,
-            max_waypoint_merging_distance,
-            max_lane_merging_distance,
-            min_lane_length);
+      rmf_traffic::agv::compute_plan_starts(graph,
+        robot_loc,
+        initial_time,
+        max_waypoint_merging_distance,
+        max_lane_merging_distance,
+        min_lane_length);
     CHECK(start_set.empty());
   }
 }

--- a/rmf_traffic/test/unit/fcl_test.cpp
+++ b/rmf_traffic/test/unit/fcl_test.cpp
@@ -25,10 +25,10 @@ TEST_CASE("Verify that FCL can handle continuous collisions")
 {
   // Make sphere
   std::shared_ptr<fcl::CollisionGeometry> sphere_geom =
-      std::make_shared<fcl::Sphere>(0.5);
+    std::make_shared<fcl::Sphere>(0.5);
 
   std::shared_ptr<fcl::CollisionObject> object_1 =
-      std::make_shared<fcl::CollisionObject>(sphere_geom);
+    std::make_shared<fcl::CollisionObject>(sphere_geom);
 
   fcl::Transform3f tf_sphere_start;
   tf_sphere_start.setTranslation(fcl::Vec3f(1.0, 0.0, 0.0));
@@ -38,10 +38,10 @@ TEST_CASE("Verify that FCL can handle continuous collisions")
 
   // Make box
   std::shared_ptr<fcl::CollisionGeometry> box_geom =
-      std::make_shared<fcl::Box>(1.0, 1.0, 1.0);
+    std::make_shared<fcl::Box>(1.0, 1.0, 1.0);
 
   std::shared_ptr<fcl::CollisionObject> object_2 =
-      std::make_shared<fcl::CollisionObject>(box_geom);
+    std::make_shared<fcl::CollisionObject>(box_geom);
 
   fcl::Transform3f tf_box_start;
   tf_box_start.setTranslation(fcl::Vec3f(0.0, 5.0, 0.0));
@@ -60,9 +60,9 @@ TEST_CASE("Verify that FCL can handle continuous collisions")
   fcl::ContinuousCollisionResult result;
 
   fcl::continuousCollide(
-        object_1.get(), tf_sphere_final,
-        object_2.get(), tf_box_final,
-        request, result);
+    object_1.get(), tf_sphere_final,
+    object_2.get(), tf_box_final,
+    request, result);
 
   CHECK(result.is_collide);
 }

--- a/rmf_traffic/test/unit/make_shapes.cpp
+++ b/rmf_traffic/test/unit/make_shapes.cpp
@@ -26,47 +26,47 @@ SCENARIO("Verify that these shape types can be upcast")
 {
   // Make sure all the shape types can be constructed and cast to shapes
   std::shared_ptr<rmf_traffic::geometry::Shape> box =
-      std::make_shared<rmf_traffic::geometry::Box>(1.0, 1.0);
+    std::make_shared<rmf_traffic::geometry::Box>(1.0, 1.0);
 
   std::shared_ptr<rmf_traffic::geometry::Shape> circle =
-      std::make_shared<rmf_traffic::geometry::Circle>(1.0);
+    std::make_shared<rmf_traffic::geometry::Circle>(1.0);
 
   std::shared_ptr<rmf_traffic::geometry::Shape> polygon =
-      std::make_shared<rmf_traffic::geometry::SimplePolygon>(
-        std::vector<Eigen::Vector2d>());
+    std::make_shared<rmf_traffic::geometry::SimplePolygon>(
+    std::vector<Eigen::Vector2d>());
 
   // Make sure the two convex shape type can be constructed and cast to Convex
   std::shared_ptr<rmf_traffic::geometry::ConvexShape> convex_box =
-      std::make_shared<rmf_traffic::geometry::Box>(1.0, 1.0);
+    std::make_shared<rmf_traffic::geometry::Box>(1.0, 1.0);
 
   std::shared_ptr<rmf_traffic::geometry::ConvexShape> convex_circle =
-      std::make_shared<rmf_traffic::geometry::Circle>(1.0);
+    std::make_shared<rmf_traffic::geometry::Circle>(1.0);
 }
 
 SCENARIO("Verify characteristic lengths are accurately computed")
 {
-  // Box 
+  // Box
   const auto box_final_shape = rmf_traffic::geometry::make_final_convex<
-          rmf_traffic::geometry::Box>(4.0, 3.0);
+    rmf_traffic::geometry::Box>(4.0, 3.0);
   CHECK(box_final_shape->get_characteristic_length() - 2.5
-      == Approx(0.0).margin(1e-12));
+    == Approx(0.0).margin(1e-12));
 
-  // Circle 
+  // Circle
   const auto circle_final_shape = rmf_traffic::geometry::make_final_convex<
-          rmf_traffic::geometry::Circle>(6.0);
+    rmf_traffic::geometry::Circle>(6.0);
 
   CHECK(circle_final_shape->get_characteristic_length() - 6.0
-      == Approx(0.0).margin(1e-12));
-  
+    == Approx(0.0).margin(1e-12));
+
   // Simple Polygon
   std::vector<Eigen::Vector2d> vertices = {
-      {1.0, 1.0},
-      {0.0, 2.0},
-      {-1.0, 1.0},
-      {-1.0, -1.0},
-      {1.0, -1.0}};
+    {1.0, 1.0},
+    {0.0, 2.0},
+    {-1.0, 1.0},
+    {-1.0, -1.0},
+    {1.0, -1.0}};
   const auto polygon_final_shape = rmf_traffic::geometry::make_final<
-          rmf_traffic::geometry::SimplePolygon>(vertices);
+    rmf_traffic::geometry::SimplePolygon>(vertices);
   CHECK(polygon_final_shape->get_characteristic_length() -2.0
-      == Approx(0.0).margin(1e-12));
+    == Approx(0.0).margin(1e-12));
 }

--- a/rmf_traffic/test/unit/schedule/test_Database.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Database.cpp
@@ -36,36 +36,36 @@ SCENARIO("Test Database Conflicts")
 
     //check for empty instantiation
     const rmf_traffic::schedule::Query query_all =
-        rmf_traffic::schedule::query_all();
+      rmf_traffic::schedule::query_all();
 
-    rmf_traffic::schedule::Patch changes=
-        db.changes(query_all, rmf_utils::nullopt);
+    rmf_traffic::schedule::Patch changes =
+      db.changes(query_all, rmf_utils::nullopt);
 
-    REQUIRE(changes.size()==0);
+    REQUIRE(changes.size() == 0);
     CHECK(changes.latest_version() == 0);
 
     //adding simple two-point trajecotry
     const double profile_scale = 1.0;
     const rmf_traffic::Time time = std::chrono::steady_clock::now();
-    rmf_traffic::geometry::Box shape(profile_scale,profile_scale);
+    rmf_traffic::geometry::Box shape(profile_scale, profile_scale);
     rmf_traffic::geometry::FinalConvexShapePtr final_shape =
-        rmf_traffic::geometry::make_final_convex(shape);
+      rmf_traffic::geometry::make_final_convex(shape);
 
     const rmf_traffic::Profile profile{final_shape};
 
     const auto p1 = db.register_participant(
-          rmf_traffic::schedule::ParticipantDescription{
-            "test_participant",
-            "test_Database",
-            rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-            profile
-          });
+      rmf_traffic::schedule::ParticipantDescription{
+        "test_participant",
+        "test_Database",
+        rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+        profile
+      });
     CHECK(db.latest_version() == ++dbv);
 
     rmf_traffic::Trajectory t1;
-    t1.insert(time, Eigen::Vector3d{-5,0,0}, Eigen::Vector3d{0,0,0});
-    t1.insert(time + 10s, Eigen::Vector3d{5,0,0}, Eigen::Vector3d{0,0,0});
-    REQUIRE(t1.size()==2);
+    t1.insert(time, Eigen::Vector3d{-5, 0, 0}, Eigen::Vector3d{0, 0, 0});
+    t1.insert(time + 10s, Eigen::Vector3d{5, 0, 0}, Eigen::Vector3d{0, 0, 0});
+    REQUIRE(t1.size() == 2);
 
     rmf_traffic::schedule::ItineraryVersion iv1 = 0;
     rmf_traffic::RouteId rv1 = 0;
@@ -88,8 +88,8 @@ SCENARIO("Test Database Conflicts")
     // WHEN("Another Trajectory is inserted")
     {
       rmf_traffic::Trajectory t2;
-      t2.insert(time, Eigen::Vector3d{0,-5,0}, Eigen::Vector3d{0,0,0});
-      t2.insert(time+10min, Eigen::Vector3d{0,5,0}, Eigen::Vector3d{0,0,0});
+      t2.insert(time, Eigen::Vector3d{0, -5, 0}, Eigen::Vector3d{0, 0, 0});
+      t2.insert(time+10min, Eigen::Vector3d{0, 5, 0}, Eigen::Vector3d{0, 0, 0});
       REQUIRE(t2.size() == 2);
 
       db.extend(p1, create_test_input(rv1++, t2), iv1++);
@@ -109,7 +109,7 @@ SCENARIO("Test Database Conflicts")
       CHECK(changes.latest_version() == db.latest_version());
 
       // query the diff
-      changes=db.changes(query_all, db.latest_version()-1);
+      changes = db.changes(query_all, db.latest_version()-1);
       CHECK(changes.registered().size() == 0);
       CHECK(changes.unregistered().size() == 0);
       REQUIRE(changes.size() == 1);
@@ -143,7 +143,7 @@ SCENARIO("Test Database Conflicts")
       CHECK(changes.latest_version() == db.latest_version());
 
       // query the diff
-      changes=db.changes(query_all, db.latest_version()-1);
+      changes = db.changes(query_all, db.latest_version()-1);
       CHECK(changes.registered().size() == 0);
       CHECK(changes.unregistered().size() == 0);
       REQUIRE(changes.size() == 1);
@@ -221,15 +221,17 @@ SCENARIO("Test Database Conflicts")
     // WHEN("Schedule is culled")
     {
       const auto cull_time = time + 5min;
-      CHECK(rmf_traffic::schedule::Database::Debug::current_entry_history_count(db) == 2);
+      CHECK(rmf_traffic::schedule::Database::Debug::current_entry_history_count(
+          db) == 2);
       const auto v = db.cull(cull_time);
-      CHECK(rmf_traffic::schedule::Database::Debug::current_entry_history_count(db) == 1);
+      CHECK(rmf_traffic::schedule::Database::Debug::current_entry_history_count(
+          db) == 1);
       CHECK(db.latest_version() == ++dbv);
       CHECK(v == db.latest_version());
       CHECK_TRAJECTORY_COUNT(db, 1, 0);
 
       // query from the start
-      changes=db.changes(query_all, rmf_utils::nullopt);
+      changes = db.changes(query_all, rmf_utils::nullopt);
       CHECK(changes.registered().size() == 1);
       CHECK(changes.unregistered().size() == 0);
       CHECK(changes.size() == 0);
@@ -252,7 +254,8 @@ SCENARIO("Test Database Conflicts")
       db.set_current_time(current_time);
       db.unregister_participant(p1);
       CHECK(db.latest_version() == ++dbv);
-      CHECK(rmf_traffic::schedule::Database::Debug::current_removed_participant_count(db) == 1);
+      CHECK(rmf_traffic::schedule::Database::Debug::current_removed_participant_count(
+          db) == 1);
 
       // query from the start
       changes = db.changes(query_all, rmf_utils::nullopt);
@@ -274,7 +277,8 @@ SCENARIO("Test Database Conflicts")
       const auto cull_time = current_time + 10min;
       db.cull(cull_time);
       CHECK(db.latest_version() == ++dbv);
-      CHECK(rmf_traffic::schedule::Database::Debug::current_removed_participant_count(db) == 0);
+      CHECK(rmf_traffic::schedule::Database::Debug::current_removed_participant_count(
+          db) == 0);
 
       // query the diff
       changes = db.changes(query_all, db.latest_version()-1);
@@ -296,4 +300,3 @@ SCENARIO("Test Database Conflicts")
     }
   }
 }
-

--- a/rmf_traffic/test/unit/schedule/test_Mirror.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Mirror.cpp
@@ -30,8 +30,8 @@
 using namespace std::chrono_literals;
 
 using IdMap = std::unordered_map<
-    rmf_traffic::schedule::ParticipantId,
-    std::unordered_set<rmf_traffic::RouteId>>;
+  rmf_traffic::schedule::ParticipantId,
+  std::unordered_set<rmf_traffic::RouteId>>;
 
 SCENARIO("Test Mirror of a Database with two trajectories")
 {
@@ -40,35 +40,35 @@ SCENARIO("Test Mirror of a Database with two trajectories")
   rmf_traffic::schedule::Database db;
   const auto query_all = rmf_traffic::schedule::query_all();
   rmf_traffic::schedule::Patch changes =
-      db.changes(query_all, rmf_utils::nullopt);
+    db.changes(query_all, rmf_utils::nullopt);
   CHECK(changes.size() == 0);
   rmf_traffic::schedule::Version dbv = 0;
   CHECK(changes.latest_version() == dbv);
 
   // Add two participants
-  double profile_scale=1;
+  double profile_scale = 1;
   const auto shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(profile_scale, profile_scale);
+    rmf_traffic::geometry::Box>(profile_scale, profile_scale);
   const rmf_traffic::Profile profile{shape};
 
   const rmf_traffic::schedule::ParticipantId p1 = db.register_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "test_participant_1",
-          "test_Mirror",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
-          profile
-        });
+    rmf_traffic::schedule::ParticipantDescription{
+      "test_participant_1",
+      "test_Mirror",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
+      profile
+    });
   CHECK(db.latest_version() == ++dbv);
   rmf_traffic::schedule::ItineraryVersion iv1 = 0;
   rmf_traffic::RouteId rv1 = 0;
 
   const rmf_traffic::schedule::ParticipantId p2 = db.register_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "test_participant_2",
-          "test_Mirror",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-          profile
-        });
+    rmf_traffic::schedule::ParticipantDescription{
+      "test_participant_2",
+      "test_Mirror",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    });
   CHECK(db.latest_version() == ++dbv);
   rmf_traffic::schedule::ItineraryVersion iv2 = 0;
   rmf_traffic::RouteId rv2 = 0;
@@ -77,13 +77,13 @@ SCENARIO("Test Mirror of a Database with two trajectories")
   const rmf_traffic::Time time = std::chrono::steady_clock::now();
 
   rmf_traffic::Trajectory t1;
-  t1.insert(time, Eigen::Vector3d{-5,0,0}, Eigen::Vector3d{0,0,0});
-  t1.insert(time + 10s, Eigen::Vector3d{5,0,0}, Eigen::Vector3d{0,0,0});
+  t1.insert(time, Eigen::Vector3d{-5, 0, 0}, Eigen::Vector3d{0, 0, 0});
+  t1.insert(time + 10s, Eigen::Vector3d{5, 0, 0}, Eigen::Vector3d{0, 0, 0});
   REQUIRE(t1.size() == 2);
 
   rmf_traffic::Trajectory t2;
-  t2.insert(time, Eigen::Vector3d{-5,10,0}, Eigen::Vector3d{0,0,0});
-  t2.insert(time+10s, Eigen::Vector3d{5,10,0},Eigen::Vector3d{0,0,0});
+  t2.insert(time, Eigen::Vector3d{-5, 10, 0}, Eigen::Vector3d{0, 0, 0});
+  t2.insert(time+10s, Eigen::Vector3d{5, 10, 0}, Eigen::Vector3d{0, 0, 0});
   REQUIRE(t2.size() == 2);
 
   db.set(p1, create_test_input(rv1++, t1), iv1++);
@@ -103,7 +103,7 @@ SCENARIO("Test Mirror of a Database with two trajectories")
   {
     rmf_traffic::Trajectory t3;
     t3.insert(time, Eigen::Vector3d{-5, -10, 0}, Eigen::Vector3d{0, 0, 0});
-    t3.insert(time+10s, Eigen::Vector3d{5, 10, 0},Eigen::Vector3d{0, 0, 0});
+    t3.insert(time+10s, Eigen::Vector3d{5, 10, 0}, Eigen::Vector3d{0, 0, 0});
 
     db.extend(p1, create_test_input(rv1++, t3), iv1++);
     CHECK(db.latest_version() == ++dbv);
@@ -127,10 +127,11 @@ SCENARIO("Test Mirror of a Database with two trajectories")
 
     auto view = mirror.query(query_all);
     auto conflicting_trajectories =
-        get_conflicting_trajectories(view, profile, t3);
-    CHECK(conflicting_trajectories.size()==1);
+      get_conflicting_trajectories(view, profile, t3);
+    CHECK(conflicting_trajectories.size() == 1);
 
-    WHEN("Replacing conflicting trajectory in db and updating mirror should eliminate conflict")
+    WHEN(
+      "Replacing conflicting trajectory in db and updating mirror should eliminate conflict")
     {
       rmf_traffic::Trajectory t4;
       t4.insert(time, Eigen::Vector3d{-5, 0, 0}, Eigen::Vector3d{0, 0, 0});
@@ -141,7 +142,7 @@ SCENARIO("Test Mirror of a Database with two trajectories")
 
       view = db.query(query_all);
       conflicting_trajectories =
-          get_conflicting_trajectories(view, profile, t3);
+        get_conflicting_trajectories(view, profile, t3);
       CHECK(conflicting_trajectories.size() == 0);
 
       changes = db.changes(query_all, mirror.latest_version());
@@ -150,25 +151,27 @@ SCENARIO("Test Mirror of a Database with two trajectories")
 
       view = mirror.query(query_all);
       conflicting_trajectories =
-          get_conflicting_trajectories(view, profile, t3);
-      CHECK(conflicting_trajectories.size()==0);
+        get_conflicting_trajectories(view, profile, t3);
+      CHECK(conflicting_trajectories.size() == 0);
     }
 
-    WHEN("Erasing conflicting trajectory in db and updating mirror should eliminate conflict")
+    WHEN(
+      "Erasing conflicting trajectory in db and updating mirror should eliminate conflict")
     {
       db.erase(p1, {0}, iv1++);
       CHECK(db.latest_version() == ++dbv);
-      changes= db.changes(query_all, mirror.latest_version());
+      changes = db.changes(query_all, mirror.latest_version());
       mirror.update(changes);
       CHECK(mirror.latest_version() == db.latest_version());
 
       view = mirror.query(query_all);
       conflicting_trajectories =
-          get_conflicting_trajectories(view, profile, t3);
-      CHECK(conflicting_trajectories.size()==0);
+        get_conflicting_trajectories(view, profile, t3);
+      CHECK(conflicting_trajectories.size() == 0);
     }
 
-    WHEN("Delaying conflicting trajectory in db and updating mirror should eliminate conflict")
+    WHEN(
+      "Delaying conflicting trajectory in db and updating mirror should eliminate conflict")
     {
       db.delay(p1, time, 20s, iv1++);
       CHECK(db.latest_version() == ++dbv);
@@ -178,11 +181,12 @@ SCENARIO("Test Mirror of a Database with two trajectories")
 
       view = mirror.query(query_all);
       conflicting_trajectories =
-          get_conflicting_trajectories(view, profile, t3);
-      CHECK(conflicting_trajectories.size()==0);
+        get_conflicting_trajectories(view, profile, t3);
+      CHECK(conflicting_trajectories.size() == 0);
     }
 
-    WHEN("Culling conflicting trajectory in db and updating mirror should eliminate conflict")
+    WHEN(
+      "Culling conflicting trajectory in db and updating mirror should eliminate conflict")
     {
       db.cull(time + 11s);
       changes = db.changes(query_all, mirror.latest_version());
@@ -191,9 +195,9 @@ SCENARIO("Test Mirror of a Database with two trajectories")
 
       view = mirror.query(query_all);
       conflicting_trajectories =
-          get_conflicting_trajectories(view, profile, t3);
-      CHECK(conflicting_trajectories.size()==0);
-     }
+        get_conflicting_trajectories(view, profile, t3);
+      CHECK(conflicting_trajectories.size() == 0);
+    }
   }
 }
 
@@ -204,33 +208,33 @@ SCENARIO("Testing specialized mirrors")
 
   const auto query_all = rmf_traffic::schedule::query_all();
   rmf_traffic::schedule::Patch changes =
-      db.changes(query_all, rmf_utils::nullopt);
+    db.changes(query_all, rmf_utils::nullopt);
   REQUIRE(changes.size() == 0);
 
   // Creating participants
   const double profile_scale = 1.0;
   const auto shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(profile_scale, profile_scale);
+    rmf_traffic::geometry::Box>(profile_scale, profile_scale);
   const rmf_traffic::Profile profile{shape};
 
   const auto p1 = db.register_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "participant_1",
-          "test_Mirror",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-          profile
-        });
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant_1",
+      "test_Mirror",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    });
   CHECK(db.latest_version() == ++dbv);
   rmf_traffic::schedule::ItineraryVersion iv1 = 0;
   rmf_traffic::RouteId rv1 = 0;
 
   const auto p2 = db.register_participant(
-        rmf_traffic::schedule::ParticipantDescription{
-          "participant_2",
-          "test_Mirror",
-          rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
-          profile
-        });
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant_2",
+      "test_Mirror",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Unresponsive,
+      profile
+    });
   CHECK(db.latest_version() == ++dbv);
   rmf_traffic::schedule::ItineraryVersion iv2 = 0;
   rmf_traffic::RouteId rv2 = 0;
@@ -241,26 +245,26 @@ SCENARIO("Testing specialized mirrors")
   rmf_traffic::Trajectory t1;
   t1.insert(time, {-5, 0, 0}, {0, 0, 0});
   t1.insert(time + 10s, {5, 0, 0}, {0, 0, 0});
-  REQUIRE(t1.size()==2);
+  REQUIRE(t1.size() == 2);
   const auto r1 = std::make_shared<rmf_traffic::Route>("test_map", t1);
 
   rmf_traffic::Trajectory t2;
-  t2.insert(time, {-5,10,0}, {0, 0, 0});
+  t2.insert(time, {-5, 10, 0}, {0, 0, 0});
   t2.insert(time+11s, {5, 10, 0}, {0, 0, 0});
-  REQUIRE(t2.size()==2);
+  REQUIRE(t2.size() == 2);
   const auto r2 = std::make_shared<rmf_traffic::Route>("test_map", t2);
 
   rmf_traffic::Trajectory t3;
   t3.insert(time+11s, {0, -5, 0}, {0, 0, 0});
-  t3.insert(time+20s, {0,5,0}, {0, 0, 0});
-  REQUIRE(t3.size()==2);
+  t3.insert(time+20s, {0, 5, 0}, {0, 0, 0});
+  REQUIRE(t3.size() == 2);
   const auto r3 = std::make_shared<rmf_traffic::Route>("test_map", t3);
 
   // creating routes r4 and r5 in "test_map_2"
   rmf_traffic::Trajectory t4;
   t4.insert(time, {-5, 0, 0}, {0, 0, 0});
   t4.insert(time + 10s, {5, 0, 0}, {0, 0, 0});
-  REQUIRE(t4.size()==2);
+  REQUIRE(t4.size() == 2);
   const auto r4 = std::make_shared<rmf_traffic::Route>("test_map_2", t4);
 
   rmf_traffic::Trajectory t5;
@@ -291,7 +295,7 @@ SCENARIO("Testing specialized mirrors")
 
     //creating space to add to region
     const auto box = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(10.0, 1.0);
+      rmf_traffic::geometry::Box>(10.0, 1.0);
     rmf_traffic::geometry::Space space(box, tf);
     std::vector<rmf_traffic::geometry::Space> spaces;
     spaces.push_back(space);
@@ -300,7 +304,7 @@ SCENARIO("Testing specialized mirrors")
     query.spacetime().regions()->push_back(region);
 
     rmf_traffic::schedule::Patch changes =
-        db.changes(query, rmf_utils::nullopt);
+      db.changes(query, rmf_utils::nullopt);
 
     REQUIRE(changes.size() > 0);
     CHECK(changes.size() == 1);
@@ -313,7 +317,7 @@ SCENARIO("Testing specialized mirrors")
   {
     auto time = std::chrono::steady_clock::now();
     Eigen::Isometry2d tf = Eigen::Isometry2d::Identity();
-    auto query= rmf_traffic::schedule::make_query({});
+    auto query = rmf_traffic::schedule::make_query({});
     REQUIRE(query.spacetime().regions() != nullptr);
 
     //creating space to add to region
@@ -329,7 +333,7 @@ SCENARIO("Testing specialized mirrors")
 
     //querying for Patch using defined spacetime query
     rmf_traffic::schedule::Patch changes =
-        db.changes(query, rmf_utils::nullopt);
+      db.changes(query, rmf_utils::nullopt);
 
     REQUIRE(changes.size() > 0);
     CHECK(changes.size() == 1);
@@ -376,7 +380,7 @@ SCENARIO("Testing specialized mirrors")
 
     //creating space to add to region
     const auto box = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(1.0, 1.0);
+      rmf_traffic::geometry::Box>(1.0, 1.0);
     rmf_traffic::geometry::Space space(box, tf);
     std::vector<rmf_traffic::geometry::Space> spaces;
     spaces.push_back(space);
@@ -387,7 +391,7 @@ SCENARIO("Testing specialized mirrors")
 
     // querying for Patch using defined spacetime query
     rmf_traffic::schedule::Patch changes =
-        db.changes(query, rmf_utils::nullopt);
+      db.changes(query, rmf_utils::nullopt);
     REQUIRE(changes.size() > 0);
     CHECK(changes.size() == 1);
     CHECK(changes.begin()->participant_id() == p2);
@@ -405,18 +409,18 @@ SCENARIO("Testing specialized mirrors")
 
     // creating space to add to region
     const auto box = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(10, 10);
-    rmf_traffic::geometry::Space space(box,tf);
+      rmf_traffic::geometry::Box>(10, 10);
+    rmf_traffic::geometry::Space space(box, tf);
     std::vector<rmf_traffic::geometry::Space> spaces;
     spaces.push_back(space);
 
     //creating a region with time bounds and spaces that overlap with trajectory
-    rmf_traffic::Region region("test_map", time, time+20s,spaces);
+    rmf_traffic::Region region("test_map", time, time+20s, spaces);
     query.spacetime().regions()->push_back(region);
 
     //querying for Patch using defined spacetime query
     rmf_traffic::schedule::Patch changes =
-        db.changes(query, rmf_utils::nullopt);
+      db.changes(query, rmf_utils::nullopt);
 
     // Only t1 and t3 are within range of the region. t2 runs along the line y=10,
     // which is outside the range of a 10x10 box that is centered at the origin,
@@ -448,18 +452,18 @@ SCENARIO("Testing specialized mirrors")
 
     // creating space to add to region
     const auto box = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(10, 20);
+      rmf_traffic::geometry::Box>(10, 20);
     rmf_traffic::geometry::Space space(box, tf);
     std::vector<rmf_traffic::geometry::Space> spaces;
     spaces.push_back(space);
 
     //creating a region with time bounds and spaces that overlap with trajectory
-    rmf_traffic::Region region("test_map", time, time+20s,spaces);
+    rmf_traffic::Region region("test_map", time, time+20s, spaces);
     query.spacetime().regions()->push_back(region);
 
     // querying for Patch using defined spacetime query
     rmf_traffic::schedule::Patch changes =
-        db.changes(query, rmf_utils::nullopt);
+      db.changes(query, rmf_utils::nullopt);
 
     REQUIRE(changes.size() > 0);
     CHECK(changes.size() == 2);

--- a/rmf_traffic/test/unit/schedule/test_Modular.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Modular.cpp
@@ -49,10 +49,12 @@ TEMPLATE_TEST_CASE("Test Modular", "[modular]", uint8_t, uint16_t, uint64_t)
   CHECK(rmf_utils::modular(max_value).less_than(min_value, min_value+1));
 
   // Check the noncommutativity
-  CHECK_FALSE(rmf_utils::modular(max_value-2).less_than(max_value, max_value-1));
+  CHECK_FALSE(rmf_utils::modular(max_value-2).less_than(max_value,
+    max_value-1));
   CHECK_FALSE(rmf_utils::modular(max_value).less_than(min_value+1, min_value));
 
   // Here we check lhs = rhs when basis < lhs
-  CHECK(rmf_utils::modular(max_value-1).less_than_or_equal(max_value, max_value));
+  CHECK(rmf_utils::modular(max_value-1).less_than_or_equal(max_value,
+    max_value));
   CHECK(rmf_utils::modular(max_value).less_than_or_equal(min_value, min_value));
 }

--- a/rmf_traffic/test/unit/schedule/test_Participant.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Participant.cpp
@@ -30,12 +30,11 @@
 #include <unordered_map>
 
 class FaultyWriter : public rmf_traffic::schedule::Writer
-
 {
 public:
 
   FaultyWriter(rmf_traffic::schedule::Database& database)
-    : _database(database)
+  : _database(database)
   {
     // Do nothing
   }
@@ -43,9 +42,9 @@ public:
   bool drop_packets = false;
 
   void set(
-      rmf_traffic::schedule::ParticipantId participant,
-      const Input& itinerary,
-      rmf_traffic::schedule::ItineraryVersion version) final
+    rmf_traffic::schedule::ParticipantId participant,
+    const Input& itinerary,
+    rmf_traffic::schedule::ItineraryVersion version) final
   {
     if (drop_packets)
       return;
@@ -54,9 +53,9 @@ public:
   }
 
   void extend(
-      rmf_traffic::schedule::ParticipantId participant,
-      const Input& routes,
-      rmf_traffic::schedule::ItineraryVersion version) final
+    rmf_traffic::schedule::ParticipantId participant,
+    const Input& routes,
+    rmf_traffic::schedule::ItineraryVersion version) final
   {
     if (drop_packets)
       return;
@@ -65,10 +64,10 @@ public:
   }
 
   void delay(
-      rmf_traffic::schedule::ParticipantId participant,
-      rmf_traffic::Time from,
-      rmf_traffic::Duration delay,
-      rmf_traffic::schedule::ItineraryVersion version) final
+    rmf_traffic::schedule::ParticipantId participant,
+    rmf_traffic::Time from,
+    rmf_traffic::Duration delay,
+    rmf_traffic::schedule::ItineraryVersion version) final
   {
     if (drop_packets)
       return;
@@ -77,8 +76,8 @@ public:
   }
 
   void erase(
-      rmf_traffic::schedule::ParticipantId participant,
-      rmf_traffic::schedule::ItineraryVersion version) final
+    rmf_traffic::schedule::ParticipantId participant,
+    rmf_traffic::schedule::ItineraryVersion version) final
   {
     if (drop_packets)
       return;
@@ -87,9 +86,9 @@ public:
   }
 
   void erase(
-      rmf_traffic::schedule::ParticipantId participant,
-      const std::vector<rmf_traffic::RouteId>& routes,
-      rmf_traffic::schedule::ItineraryVersion version) final
+    rmf_traffic::schedule::ParticipantId participant,
+    const std::vector<rmf_traffic::RouteId>& routes,
+    rmf_traffic::schedule::ItineraryVersion version) final
   {
     if (drop_packets)
       return;
@@ -98,14 +97,14 @@ public:
   }
 
   rmf_traffic::schedule::ParticipantId register_participant(
-      rmf_traffic::schedule::ParticipantDescription participant_info) final
+    rmf_traffic::schedule::ParticipantDescription participant_info) final
   {
     // We assume participant registration is done over a reliable connection
     return _database.register_participant(participant_info);
   }
 
   void unregister_participant(
-      rmf_traffic::schedule::ParticipantId participant) final
+    rmf_traffic::schedule::ParticipantId participant) final
   {
     _database.set_current_time(std::chrono::steady_clock::now());
     _database.unregister_participant(participant);
@@ -122,8 +121,8 @@ using RouteId = rmf_traffic::RouteId;
 using ConstRoutePtr = rmf_traffic::ConstRoutePtr;
 
 inline void CHECK_EQUAL_TRAJECOTRY(
-    const rmf_traffic::Trajectory& t1,
-    const rmf_traffic::Trajectory& t2)
+  const rmf_traffic::Trajectory& t1,
+  const rmf_traffic::Trajectory& t2)
 {
   REQUIRE(t1.size() == t2.size());
   REQUIRE(t1.start_time());
@@ -134,16 +133,18 @@ inline void CHECK_EQUAL_TRAJECOTRY(
   auto t1_it = t1.begin();
   auto t2_it = t2.begin();
 
-  for(; t1_it != t1.end(); ++t1_it, ++t2_it)
+  for (; t1_it != t1.end(); ++t1_it, ++t2_it)
   {
-    REQUIRE((t1_it->position() - t2_it->position()).norm() == Approx(0.0).margin(1e-6));
-    REQUIRE((t1_it->velocity() - t2_it->velocity()).norm() == Approx(0.0).margin(1e-6));
+    REQUIRE((t1_it->position() - t2_it->position()).norm() == Approx(0.0).margin(
+        1e-6));
+    REQUIRE((t1_it->velocity() - t2_it->velocity()).norm() == Approx(0.0).margin(
+        1e-6));
     REQUIRE((t1_it->time() - t2_it->time()).count() == Approx(0.0));
   }
 }
 
 std::unordered_map<RouteId, ConstRoutePtr> convert_itinerary(
-    rmf_traffic::schedule::Writer::Input input)
+  rmf_traffic::schedule::Writer::Input input)
 {
   std::unordered_map<RouteId, ConstRoutePtr> itinerary;
   itinerary.reserve(input.size());
@@ -157,15 +158,15 @@ std::unordered_map<RouteId, ConstRoutePtr> convert_itinerary(
 }
 
 inline void CHECK_ITINERARY(
-    const rmf_traffic::schedule::Participant& p,
-    const rmf_traffic::schedule::Database& db)
+  const rmf_traffic::schedule::Participant& p,
+  const rmf_traffic::schedule::Database& db)
 {
   using Debug = rmf_traffic::schedule::Database::Debug;
 
   REQUIRE(db.get_itinerary(p.id()));
 
   auto db_iti = convert_itinerary(
-      Debug::get_itinerary(db, p.id()).value());
+    Debug::get_itinerary(db, p.id()).value());
   auto p_iti = convert_itinerary(p.itinerary());
   REQUIRE(db_iti.size() == p_iti.size());
 
@@ -174,7 +175,8 @@ inline void CHECK_ITINERARY(
     const auto db_it = db_iti.find(item.first);
     REQUIRE(db_it != db_iti.end());
     CHECK(item.second->map() == db_it->second->map());
-    CHECK_EQUAL_TRAJECOTRY(item.second->trajectory(), db_it->second->trajectory());
+    CHECK_EQUAL_TRAJECOTRY(item.second->trajectory(),
+      db_it->second->trajectory());
   }
 }
 
@@ -220,7 +222,7 @@ SCENARIO("Test Participant")
 
   // Create a shape
   const auto shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Circle>(1.0);
+    rmf_traffic::geometry::Circle>(1.0);
 
   // Create a participant
   auto p1 = rmf_traffic::schedule::make_participant(
@@ -238,7 +240,7 @@ SCENARIO("Test Participant")
   CHECK(description.name() == "participant 1");
   CHECK(description.owner() == "test_Participant");
   CHECK(description.responsiveness() == rmf_traffic::schedule
-      ::ParticipantDescription::Rx::Responsive);
+    ::ParticipantDescription::Rx::Responsive);
   REQUIRE(p1.itinerary().size() == 0);
 
   CHECK(db.participant_ids().size() == 1);
@@ -260,11 +262,11 @@ SCENARIO("Test Participant")
   REQUIRE(t2.size() == 2);
 
   rmf_traffic::Trajectory t3;
-  t3.insert(time + 22s, {10, 10 ,0}, {0, 0, 0});
-  t3.insert(time + 32s, {10, 0 , 0}, {0, 0, 0});
+  t3.insert(time + 22s, {10, 10, 0}, {0, 0, 0});
+  t3.insert(time + 32s, {10, 0, 0}, {0, 0, 0});
   REQUIRE(t3.size() == 2);
 
-  GIVEN ("Changes: S")
+  GIVEN("Changes: S")
   {
     auto route_id = p1.set({Route{"test_map", t1}});
     CHECK(route_id == std::numeric_limits<rmf_traffic::RouteId>::max());
@@ -295,9 +297,9 @@ SCENARIO("Test Participant")
     CHECK_ITINERARY(p1, db);
 
     route_id = p1.set({
-        Route{"test_map_2", t1},
-        Route{"test_map_3", t2}
-    });
+          Route{"test_map_2", t1},
+          Route{"test_map_3", t2}
+        });
 
     CHECK(route_id == 0);
     // The RouteIds continue from previous set()
@@ -341,14 +343,14 @@ SCENARIO("Test Participant")
   {
     p1.delay(time, 5s);
     CHECK(p1.last_route_id() ==
-        std::numeric_limits<rmf_traffic::RouteId>::max());
+      std::numeric_limits<rmf_traffic::RouteId>::max());
     CHECK(p1.itinerary().size() == 0);
 
     // We do not need to transmit a delay when the itinerary is empty
     CHECK(db.latest_version() == dbv);
 
     CHECK(p1.last_route_id() ==
-        std::numeric_limits<rmf_traffic::RouteId>::max());
+      std::numeric_limits<rmf_traffic::RouteId>::max());
   }
 
   GIVEN("Changes: SD")
@@ -366,16 +368,16 @@ SCENARIO("Test Participant")
     REQUIRE(p1.itinerary().size() == 1);
     CHECK(old_itinerary.front().id == p1.itinerary().front().id);
     CHECK(old_itinerary.front().route->map() ==
-        p1.itinerary().front().route->map());
+      p1.itinerary().front().route->map());
 
     auto old_it = old_itinerary.front().route->trajectory().begin();
     auto new_it = p1.itinerary().front().route->trajectory().begin();
 
     for (; new_it != p1.itinerary().front().route->trajectory().end();
-        new_it++, old_it++)
+      new_it++, old_it++)
     {
       CHECK((new_it->time() - (old_it->time() + delay_duration)).count()
-          == Approx(0.0));
+        == Approx(0.0));
     }
 
     CHECK(db.latest_version() == ++dbv);
@@ -387,7 +389,7 @@ SCENARIO("Test Participant")
     // Erasing RouteId not in the itinerary
     p1.erase({0});
     CHECK(p1.last_route_id() ==
-        std::numeric_limits<rmf_traffic::RouteId>::max());
+      std::numeric_limits<rmf_traffic::RouteId>::max());
     CHECK(p1.itinerary().size() == 0);
     // No change in database version
     CHECK(db.latest_version() == dbv);
@@ -412,7 +414,7 @@ SCENARIO("Test Participant")
     // Clearing an empty itinerary
     p1.clear();
     CHECK(p1.last_route_id() ==
-        std::numeric_limits<rmf_traffic::RouteId>::max());
+      std::numeric_limits<rmf_traffic::RouteId>::max());
     CHECK(p1.itinerary().size() == 0);
     // No change in database version
     CHECK(db.latest_version() == dbv);
@@ -487,14 +489,14 @@ SCENARIO("Test Participant")
     REQUIRE(db.inconsistencies().size() == 1);
     CHECK(db.inconsistencies().begin()->ranges.size() == 1);
     CHECK(db.inconsistencies().begin()->ranges.last_known_version() ==
-          rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
+      rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
 
     writer.drop_packets = true;
 
     p1.delay(time, 10s);
     CHECK(db.latest_version() == dbv);
     CHECK(db.inconsistencies().begin()->ranges.last_known_version() + 1 ==
-          rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
+      rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
 
     writer.drop_packets = false;
 
@@ -505,7 +507,7 @@ SCENARIO("Test Participant")
     CHECK(db.get_itinerary(p1.id())->size() == 1);
     CHECK(db.inconsistencies().begin()->ranges.size() == 0);
     CHECK(db.inconsistencies().begin()->ranges.last_known_version() ==
-          rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
+      rmf_traffic::schedule::Participant::Debug::get_itinerary_version(p1));
 
     rectifier.rectify();
     // There is no need to fix anything, because the last change was a
@@ -751,14 +753,14 @@ SCENARIO("Test Participant")
 
     {
       auto p2 = rmf_traffic::schedule::make_participant(
-      rmf_traffic::schedule::ParticipantDescription{
-        "participant 2",
-        "test_Participant",
-        rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
-        rmf_traffic::Profile{shape}
-      },
-      writer,
-      &rectifier);
+        rmf_traffic::schedule::ParticipantDescription{
+          "participant 2",
+          "test_Participant",
+          rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+          rmf_traffic::Profile{shape}
+        },
+        writer,
+        &rectifier);
 
       p2_id = p2.id();
       CHECK(db.latest_version() == ++dbv);

--- a/rmf_traffic/test/unit/schedule/test_Query.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Query.cpp
@@ -27,51 +27,51 @@ SCENARIO("Test Query API")
 
   rmf_traffic::schedule::Query query = rmf_traffic::schedule::make_query({});
 
-    auto now = std::chrono::steady_clock::now();
+  auto now = std::chrono::steady_clock::now();
 
-    const auto box = rmf_traffic::geometry::Box(10.0, 1.0);
-    const auto final_box = rmf_traffic::geometry::make_final_convex(box);
-    Eigen::Isometry2d tf = Eigen::Isometry2d::Identity();
+  const auto box = rmf_traffic::geometry::Box(10.0, 1.0);
+  const auto final_box = rmf_traffic::geometry::make_final_convex(box);
+  Eigen::Isometry2d tf = Eigen::Isometry2d::Identity();
 
-    REQUIRE(query.spacetime().regions() != nullptr);
+  REQUIRE(query.spacetime().regions() != nullptr);
 
-    query.spacetime().regions()->push_back(
-        rmf_traffic::Region{"test_map", now, now+10s, {}});
+  query.spacetime().regions()->push_back(
+    rmf_traffic::Region{"test_map", now, now+10s, {}});
 
-    REQUIRE(query.spacetime().regions()->begin()
-            != query.spacetime().regions()->end());
+  REQUIRE(query.spacetime().regions()->begin()
+    != query.spacetime().regions()->end());
 
-    auto& region = *query.spacetime().regions()->begin();
+  auto& region = *query.spacetime().regions()->begin();
 
-    REQUIRE(region.get_lower_time_bound() != nullptr);
-    CHECK(*region.get_lower_time_bound() == now);
-    REQUIRE(region.get_upper_time_bound() != nullptr);
-    CHECK(*region.get_upper_time_bound() == now+10s);
+  REQUIRE(region.get_lower_time_bound() != nullptr);
+  CHECK(*region.get_lower_time_bound() == now);
+  REQUIRE(region.get_upper_time_bound() != nullptr);
+  CHECK(*region.get_upper_time_bound() == now+10s);
 
-    region.push_back(rmf_traffic::geometry::Space{final_box, tf});
+  region.push_back(rmf_traffic::geometry::Space{final_box, tf});
 
-    tf.rotate(Eigen::Rotation2Dd(90.0*M_PI/180.0));
-    region.push_back(rmf_traffic::geometry::Space{final_box, tf});
-    tf.rotate(Eigen::Rotation2Dd(180.0*M_PI/180.0));
-    region.push_back(rmf_traffic::geometry::Space{final_box, tf});
+  tf.rotate(Eigen::Rotation2Dd(90.0*M_PI/180.0));
+  region.push_back(rmf_traffic::geometry::Space{final_box, tf});
+  tf.rotate(Eigen::Rotation2Dd(180.0*M_PI/180.0));
+  region.push_back(rmf_traffic::geometry::Space{final_box, tf});
 
-    std::size_t regions = 0;
-    std::size_t spaces = 0;
-    for(const auto& region : *query.spacetime().regions())
+  std::size_t regions = 0;
+  std::size_t spaces = 0;
+  for (const auto& region : *query.spacetime().regions())
+  {
+    ++regions;
+    for (const auto& space : region)
     {
-      ++regions;
-      for(const auto& space : region)
-      {
-        ++spaces;
+      ++spaces;
 
-        // TODO(MXG): replace this with [[maybe_unused]] when we can use C++17
-        (void)space;
-      }
+      // TODO(MXG): replace this with [[maybe_unused]] when we can use C++17
+      (void)space;
     }
+  }
 
-    CHECK(regions == 1);
-    CHECK(spaces == 3);
+  CHECK(regions == 1);
+  CHECK(spaces == 3);
 
-    // TODO(MXG): Write tests for every function to confirm that the
-    // Query API works as intended
+  // TODO(MXG): Write tests for every function to confirm that the
+  // Query API works as intended
 }

--- a/rmf_traffic/test/unit/schedule/test_Spacetime.cpp
+++ b/rmf_traffic/test/unit/schedule/test_Spacetime.cpp
@@ -28,7 +28,6 @@
 #include <rmf_traffic/Trajectory.hpp>
 
 
-
 SCENARIO("Testing intersection of spacetime with trajectories")
 {
   using namespace std::chrono_literals;
@@ -37,12 +36,12 @@ SCENARIO("Testing intersection of spacetime with trajectories")
 
   // creating space to create spacetime
   const auto region_box_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(10.0, 1.0);
+    rmf_traffic::geometry::Box>(10.0, 1.0);
 
-  std::chrono::_V2::steady_clock::time_point lower_time_bound=time;
-  std::chrono::_V2::steady_clock::time_point upper_time_bound=time+10s;
+  std::chrono::_V2::steady_clock::time_point lower_time_bound = time;
+  std::chrono::_V2::steady_clock::time_point upper_time_bound = time+10s;
 
-  rmf_traffic::internal::Spacetime region={
+  rmf_traffic::internal::Spacetime region = {
     &lower_time_bound,
     &upper_time_bound,
     tf,
@@ -50,19 +49,19 @@ SCENARIO("Testing intersection of spacetime with trajectories")
   };
 
   const auto box_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(1, 1);
+    rmf_traffic::geometry::Box>(1, 1);
   rmf_traffic::Profile box{box_shape};
 
   const auto circle_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Circle>(1.0);
+    rmf_traffic::geometry::Circle>(1.0);
   rmf_traffic::Profile circle{circle_shape};
 
   GIVEN("A box trajectory that does not intersect with the spacetime region")
   {
     rmf_traffic::Trajectory t1;
-    t1.insert(time, {-5,10,0}, {5,0,0});
-    t1.insert(time+10s, {5,10,0}, {5,0,0});
-    REQUIRE(t1.size()==2);
+    t1.insert(time, {-5, 10, 0}, {5, 0, 0});
+    t1.insert(time+10s, {5, 10, 0}, {5, 0, 0});
+    REQUIRE(t1.size() == 2);
 
     CHECK_FALSE(rmf_traffic::internal::detect_conflicts(box, t1, region));
   }
@@ -70,29 +69,30 @@ SCENARIO("Testing intersection of spacetime with trajectories")
   GIVEN("A box trajectory that completely intersects with the spacetime region")
   {
     rmf_traffic::Trajectory t1;
-    t1.insert(time, {-5,0,0}, {5,0,0});
-    t1.insert(time+10s, {5,0,0}, {5,0,0});
-    REQUIRE(t1.size()==2);
+    t1.insert(time, {-5, 0, 0}, {5, 0, 0});
+    t1.insert(time+10s, {5, 0, 0}, {5, 0, 0});
+    REQUIRE(t1.size() == 2);
 
-    CHECK(rmf_traffic::internal::detect_conflicts(box, t1,region));
+    CHECK(rmf_traffic::internal::detect_conflicts(box, t1, region));
   }
 
   GIVEN("A box trajectory that partially intersects with the spacetime region")
   {
     rmf_traffic::Trajectory t1;
-    t1.insert(time, {-1,0,0}, {5,0,0});
-    t1.insert(time+10s, {1,0,0}, {5,0,0});
-    REQUIRE(t1.size()==2);
+    t1.insert(time, {-1, 0, 0}, {5, 0, 0});
+    t1.insert(time+10s, {1, 0, 0}, {5, 0, 0});
+    REQUIRE(t1.size() == 2);
 
     CHECK(rmf_traffic::internal::detect_conflicts(box, t1, region));
   }
 
-  GIVEN("A circular trajectory that partially intersects with the spacetime region")
+  GIVEN(
+    "A circular trajectory that partially intersects with the spacetime region")
   {
     rmf_traffic::Trajectory t1;
-    t1.insert(time, {-1,-1.5,0}, {5,0,0});
-    t1.insert(time+10s, {1,-1.5,0}, {5,0,0});
-    REQUIRE(t1.size()==2);
+    t1.insert(time, {-1, -1.5, 0}, {5, 0, 0});
+    t1.insert(time+10s, {1, -1.5, 0}, {5, 0, 0});
+    REQUIRE(t1.size() == 2);
 
     CHECK(rmf_traffic::internal::detect_conflicts(circle, t1, region));
   }
@@ -100,14 +100,13 @@ SCENARIO("Testing intersection of spacetime with trajectories")
   GIVEN("A circular trajectory that touches the spacetime region")
   {
     rmf_traffic::Trajectory t1;
-    t1.insert(time, {-1,-2,0}, {5,0,0});
-    t1.insert(time+10s, {1,-2,0}, {5,0,0});
-    REQUIRE(t1.size()==2);
+    t1.insert(time, {-1, -2, 0}, {5, 0, 0});
+    t1.insert(time+10s, {1, -2, 0}, {5, 0, 0});
+    REQUIRE(t1.size() == 2);
 
     CHECK_FALSE(rmf_traffic::internal::detect_conflicts(circle, t1, region));
   }
 }
-
 
 
 SCENARIO("Testing intersction of various spacetimes and trajectories")
@@ -119,46 +118,47 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
   std::chrono::_V2::steady_clock::time_point upper_time_bound;
 
   const auto region_box_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(10.0, 1.0);
+    rmf_traffic::geometry::Box>(10.0, 1.0);
 
   const auto double_region_box_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(10.0, 2.0);
+    rmf_traffic::geometry::Box>(10.0, 2.0);
 
   const auto vertical_region_box_shape =
-      rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(1.0, 10.0);
+    rmf_traffic::geometry::make_final_convex<
+    rmf_traffic::geometry::Box>(1.0, 10.0);
 
   const auto double_vertical_region_box_shape =
-      rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(2.0, 10.0);
+    rmf_traffic::geometry::make_final_convex<
+    rmf_traffic::geometry::Box>(2.0, 10.0);
 
   const auto unit_box_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(1, 1);
+    rmf_traffic::geometry::Box>(1, 1);
   rmf_traffic::Profile unit_box{unit_box_shape};
 
   const auto double_box_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(2.0, 2.0);
+    rmf_traffic::geometry::Box>(2.0, 2.0);
   rmf_traffic::Profile double_box{double_box_shape};
 
   const auto unit_circle_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Circle>(1.0);
+    rmf_traffic::geometry::Circle>(1.0);
   rmf_traffic::Profile unit_circle{unit_circle_shape};
 
   const auto small_circle_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Circle>(0.5);
+    rmf_traffic::geometry::Circle>(0.5);
   rmf_traffic::Profile small_circle{small_circle_shape};
 
-  GIVEN("A trajectory along X-Axis and spacetime region that completely overlaps")
+  GIVEN(
+    "A trajectory along X-Axis and spacetime region that completely overlaps")
   {
     // Creating trajectory
     rmf_traffic::Trajectory t1;
-    t1.insert(time, {-5,0,0}, {0,0,0});
-    t1.insert(time + 10s, {5,0,0}, {0,0,0});
-    REQUIRE(t1.size()==2);
+    t1.insert(time, {-5, 0, 0}, {0, 0, 0});
+    t1.insert(time + 10s, {5, 0, 0}, {0, 0, 0});
+    REQUIRE(t1.size() == 2);
 
     // Creating Spacetime
-    lower_time_bound=time;
-    upper_time_bound=time+10s;
+    lower_time_bound = time;
+    upper_time_bound = time+10s;
 
     rmf_traffic::internal::Spacetime region{
       &lower_time_bound,
@@ -169,8 +169,8 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
     rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
     CHECK(rmf_traffic::internal::detect_conflicts(
-            unit_box, t1, region, &conflicts));
-    CHECK(conflicts.size()==1);
+        unit_box, t1, region, &conflicts));
+    CHECK(conflicts.size() == 1);
   }
 
   GIVEN("A trajectory along y=10 and spacetime region that completely overlaps")
@@ -180,14 +180,14 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
     // Creating trajectory
     rmf_traffic::Trajectory t1;
     t1.insert(time, {-5, 10, 0}, {0, 0, 0});
-    t1.insert(time + 10s, {5,10,0}, {0,0,0});
+    t1.insert(time + 10s, {5, 10, 0}, {0, 0, 0});
     REQUIRE(t1.size() == 2);
 
     // Creating Spacetime
-    lower_time_bound=time;
-    upper_time_bound=time+10s;
+    lower_time_bound = time;
+    upper_time_bound = time+10s;
 
-    tf.translate(Eigen::Vector2d{0.0,10.0});
+    tf.translate(Eigen::Vector2d{0.0, 10.0});
 
     rmf_traffic::internal::Spacetime region{
       &lower_time_bound,
@@ -198,11 +198,12 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
     rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
     CHECK(rmf_traffic::internal::detect_conflicts(
-            unit_box, t1, region, &conflicts));
-    CHECK(conflicts.size()==1);
+        unit_box, t1, region, &conflicts));
+    CHECK(conflicts.size() == 1);
   }
 
-  GIVEN("A trajectory along Y-Axis and spacetime region that completely overlaps")
+  GIVEN(
+    "A trajectory along Y-Axis and spacetime region that completely overlaps")
   {
     // trajectory timing is varied
 
@@ -210,15 +211,15 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
     rmf_traffic::Trajectory t1;
     t1.insert(time+11s, {0, -5, 0}, {0, 0, 0});
     t1.insert(time+20s, {0, 5, 0}, {0, 0, 0});
-    REQUIRE(t1.size()==2);
+    REQUIRE(t1.size() == 2);
 
     // Creating Spacetime
-    lower_time_bound=time+10s;
-    upper_time_bound=time+20s;
+    lower_time_bound = time+10s;
+    upper_time_bound = time+20s;
 
     tf.rotate(Eigen::Rotation2Dd(M_PI_2));
 
-    rmf_traffic::internal::Spacetime region={
+    rmf_traffic::internal::Spacetime region = {
       &lower_time_bound,
       &upper_time_bound,
       tf,
@@ -227,115 +228,115 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
     rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
     CHECK(rmf_traffic::internal::detect_conflicts(
-            unit_box, t1, region, &conflicts));
-    CHECK(conflicts.size()==1);
+        unit_box, t1, region, &conflicts));
+    CHECK(conflicts.size() == 1);
   }
   //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
   GIVEN("A trajectory along X-Axis and spacetime region roated at the origin")
   {
-    bool rotate=false;
-    double rot_ang=0;
+    bool rotate = false;
+    double rot_ang = 0;
 
-   /* WHEN("Trajectory profile is 1x1, space is 10x1, space box rotated by 90deg ") //this fails
-    {
+    /* WHEN("Trajectory profile is 1x1, space is 10x1, space box rotated by 90deg ") //this fails
+     {
 
-    //Creating trajectory
-    rmf_traffic::Trajectory t1("test_map");
-    rmf_traffic::geometry::Box shape(1.0,1.0);
-    rmf_traffic::geometry::ConstFinalConvexShapePtr final_shape =rmf_traffic::geometry::make_final_convex(shape);
-    auto profile = rmf_traffic::Trajectory::Profile::make_guided(final_shape);
-    t1.insert(time, profile, Eigen::Vector3d{-5.0,0,0}, Eigen::Vector3d{0,0,0});
-    t1.insert(time+10s, profile, Eigen::Vector3d{5.0,0,0}, Eigen::Vector3d{0,0,0});
-    REQUIRE(t1.size()==2);
+     //Creating trajectory
+     rmf_traffic::Trajectory t1("test_map");
+     rmf_traffic::geometry::Box shape(1.0,1.0);
+     rmf_traffic::geometry::ConstFinalConvexShapePtr final_shape =rmf_traffic::geometry::make_final_convex(shape);
+     auto profile = rmf_traffic::Trajectory::Profile::make_guided(final_shape);
+     t1.insert(time, profile, Eigen::Vector3d{-5.0,0,0}, Eigen::Vector3d{0,0,0});
+     t1.insert(time+10s, profile, Eigen::Vector3d{5.0,0,0}, Eigen::Vector3d{0,0,0});
+     REQUIRE(t1.size()==2);
 
-    //Creating Spacetime
+     //Creating Spacetime
 
-    const auto box = rmf_traffic::geometry::Box(10.0, 1.0); //Centered at (0,0) with width 10m and height 1m
-    const auto final_box = rmf_traffic::geometry::make_final_convex(box);
-    lower_time_bound=time;
-    upper_time_bound=time+10s;
+     const auto box = rmf_traffic::geometry::Box(10.0, 1.0); //Centered at (0,0) with width 10m and height 1m
+     const auto final_box = rmf_traffic::geometry::make_final_convex(box);
+     lower_time_bound=time;
+     upper_time_bound=time+10s;
 
-    rotate=true;
-    rot_ang=90;
-    if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+     rotate=true;
+     rot_ang=90;
+     if(rotate)
+         tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
 
-    rmf_traffic::internal::Spacetime region={
-      &lower_time_bound,
-      &upper_time_bound,
-      tf,
-      final_box
-    };
-    // std::cout<<"\nT_box("<<shape.get_x_length()<<","<<shape.get_y_length()<<") Shape_box:("<<box.get_x_length()<<","<<box.get_y_length()<<")";
-    // std::cout<<" Rot:"<<rotate<<" ";
-    // if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
+     rmf_traffic::internal::Spacetime region={
+       &lower_time_bound,
+       &upper_time_bound,
+       tf,
+       final_box
+     };
+     // std::cout<<"\nT_box("<<shape.get_x_length()<<","<<shape.get_y_length()<<") Shape_box:("<<box.get_x_length()<<","<<box.get_y_length()<<")";
+     // std::cout<<" Rot:"<<rotate<<" ";
+     // if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
 
-    bool conflict= rmf_traffic::internal::detect_conflicts(t1,region,&output_iterators);
-    // CHECK(conflict);
-    // CHECK(output_iterators.size()==1);
-    } 
+     bool conflict= rmf_traffic::internal::detect_conflicts(t1,region,&output_iterators);
+     // CHECK(conflict);
+     // CHECK(output_iterators.size()==1);
+     }
 
-    WHEN("Trajectory profile is 1x1, space is 10x1, space box rotated by 69deg ") //this fails
-    {
+     WHEN("Trajectory profile is 1x1, space is 10x1, space box rotated by 69deg ") //this fails
+     {
 
-    //Creating trajectory
-    rmf_traffic::Trajectory t1("test_map");
-    rmf_traffic::geometry::Box shape(1.0,1.0);
-    rmf_traffic::geometry::ConstFinalConvexShapePtr final_shape =rmf_traffic::geometry::make_final_convex(shape);
-    auto profile = rmf_traffic::Trajectory::Profile::make_guided(final_shape);
-    t1.insert(time, profile, Eigen::Vector3d{-5.0,0,0}, Eigen::Vector3d{0,0,0});
-    t1.insert(time+10s, profile, Eigen::Vector3d{5.0,0,0}, Eigen::Vector3d{0,0,0});
-    REQUIRE(t1.size()==2);
+     //Creating trajectory
+     rmf_traffic::Trajectory t1("test_map");
+     rmf_traffic::geometry::Box shape(1.0,1.0);
+     rmf_traffic::geometry::ConstFinalConvexShapePtr final_shape =rmf_traffic::geometry::make_final_convex(shape);
+     auto profile = rmf_traffic::Trajectory::Profile::make_guided(final_shape);
+     t1.insert(time, profile, Eigen::Vector3d{-5.0,0,0}, Eigen::Vector3d{0,0,0});
+     t1.insert(time+10s, profile, Eigen::Vector3d{5.0,0,0}, Eigen::Vector3d{0,0,0});
+     REQUIRE(t1.size()==2);
 
-    //Creating Spacetime
+     //Creating Spacetime
 
-    const auto box = rmf_traffic::geometry::Box(10.0, 1.0); //Centered at (0,0) with width 10m and height 1m
-    const auto final_box = rmf_traffic::geometry::make_final_convex(box);
-    lower_time_bound=time;
-    upper_time_bound=time+10s;
+     const auto box = rmf_traffic::geometry::Box(10.0, 1.0); //Centered at (0,0) with width 10m and height 1m
+     const auto final_box = rmf_traffic::geometry::make_final_convex(box);
+     lower_time_bound=time;
+     upper_time_bound=time+10s;
 
-    rotate=true;
-    rot_ang=69;
-    if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+     rotate=true;
+     rot_ang=69;
+     if(rotate)
+         tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
 
-    //print out the translation compotent of tf
-    // for(int i=0;i<2;i++)
-    //   std::cout<<"Translation "<<i<<":"<<tf.translation()[i]<<std::endl;
-    
+     //print out the translation compotent of tf
+     // for(int i=0;i<2;i++)
+     //   std::cout<<"Translation "<<i<<":"<<tf.translation()[i]<<std::endl;
 
-    rmf_traffic::internal::Spacetime region={
-      &lower_time_bound,
-      &upper_time_bound,
-      tf,
-      final_box
-    };
-    std::cout<<"\nT_box("<<shape.get_x_length()<<","<<shape.get_y_length()<<") Shape_box:("<<box.get_x_length()<<","<<box.get_y_length()<<")";
-    std::cout<<" Rot:"<<rotate<<" ";
-    if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
 
-    bool conflict= rmf_traffic::internal::detect_conflicts(t1,region,&output_iterators);
-    CHECK(conflict);
-    CHECK(output_iterators.size()==1);
-    }*/
+     rmf_traffic::internal::Spacetime region={
+       &lower_time_bound,
+       &upper_time_bound,
+       tf,
+       final_box
+     };
+     std::cout<<"\nT_box("<<shape.get_x_length()<<","<<shape.get_y_length()<<") Shape_box:("<<box.get_x_length()<<","<<box.get_y_length()<<")";
+     std::cout<<" Rot:"<<rotate<<" ";
+     if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
+
+     bool conflict= rmf_traffic::internal::detect_conflicts(t1,region,&output_iterators);
+     CHECK(conflict);
+     CHECK(output_iterators.size()==1);
+     }*/
 
     WHEN("Trajectory profile is 1x1, space is 10x1, space box rotated by 68deg ") //this passes
     {
       //Creating trajectory
       rmf_traffic::Trajectory t1;
       t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
-      t1.insert(time+10s, {5.0,0,0}, {0,0,0});
-      REQUIRE(t1.size()==2);
+      t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
+      REQUIRE(t1.size() == 2);
 
       //Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      rotate=true;
-      rot_ang=68;
-      if(rotate)
-          tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      rotate = true;
+      rot_ang = 68;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
       //print out the translation compotent of tf
       // for(int i=0;i<2;i++)
@@ -354,8 +355,8 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              unit_box, t1, region, &conflicts));
-      CHECK(conflicts.size()==1);
+          unit_box, t1, region, &conflicts));
+      CHECK(conflicts.size() == 1);
     }
 
     /*WHEN("Trajectory profile is 1x1, space is 10x2, space box rotated by 90deg ") //this fails
@@ -397,7 +398,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
     bool conflict= rmf_traffic::internal::detect_conflicts(t1,region,&output_iterators);
     CHECK(conflict);
     CHECK(output_iterators.size()==1);
-    } 
+    }
 
     WHEN("Trajectory profile is 1x1, space is 10x2, space box rotated by 75deg")
     {
@@ -423,7 +424,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
     if(rotate)
         tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
 
-    
+
 
     rmf_traffic::internal::Spacetime region={
       &lower_time_bound,
@@ -446,19 +447,19 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       // Creating trajectory
       rmf_traffic::Trajectory t1;
       t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
-      t1.insert(time+10s, {5.0,0,0}, {0,0,0});
+      t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
       REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      rotate=true;
-      rot_ang=74;
-      if(rotate)
-          tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      rotate = true;
+      rot_ang = 74;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -471,28 +472,28 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              unit_box, t1, region, &conflicts));
-      CHECK(conflicts.size()==1);
+          unit_box, t1, region, &conflicts));
+      CHECK(conflicts.size() == 1);
     }
 
     WHEN("Trajectory profile is 2x2, space is 10x1, space box rotated by 90deg ") //this passes
     {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
-      t1.insert(time, {-5.0,0,0}, {0,0,0});
-      t1.insert(time+10s, {5.0,0,0}, {0,0,0});
-      REQUIRE(t1.size()==2);
+      t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
+      t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
+      REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      rotate=true;
-      rot_ang=90;
-        if(rotate)
-          tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      rotate = true;
+      rot_ang = 90;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -503,8 +504,8 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       // if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              double_box, t1, region, &conflicts));
-      CHECK(conflicts.size()==1);
+          double_box, t1, region, &conflicts));
+      CHECK(conflicts.size() == 1);
     }
 
 //    WHEN("Trajectory profile is 2x2, space is 10x2, space box rotated by 90deg ") //this fails
@@ -529,7 +530,6 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 //      rot_ang=90;
 //      if(rotate)
 //          tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
-
 
 
 //      rmf_traffic::internal::Spacetime region={
@@ -571,7 +571,6 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 //          tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
 
 
-
 //      rmf_traffic::internal::Spacetime region={
 //        &lower_time_bound,
 //        &upper_time_bound,
@@ -588,27 +587,25 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 //    }
 
 
-
     WHEN("Trajectory profile is 2x2, space is 10x2, space box rotated by 87deg ") //this passes
     {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
-      t1.insert(time, {-5.0, 0, 0}, {0,0,0});
+      t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
       t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
-      REQUIRE(t1.size()==2);
+      REQUIRE(t1.size() == 2);
 
       //Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      rotate=true;
-      rot_ang=87;
-      if(rotate)
-          tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      rotate = true;
+      rot_ang = 87;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
 
-
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -620,7 +617,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            double_box, t1, region, &conflicts));
+          double_box, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
@@ -629,20 +626,20 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
     {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
-      t1.insert(time, {-5.0,0,0}, {0,0,0});
-      t1.insert(time+10s, {5.0,0,0}, {0,0,0});
-      REQUIRE(t1.size()==2);
+      t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
+      t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
+      REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      rotate=false;
-      rot_ang=0;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      rotate = false;
+      rot_ang = 0;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -654,7 +651,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            unit_box, t1, region, &conflicts));
+          unit_box, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
@@ -663,19 +660,19 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       // Creating trajectory
       rmf_traffic::Trajectory t1;
       t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
-      t1.insert(time+10s, {5.0,0,0}, {0,0,0});
-      REQUIRE(t1.size()==2);
+      t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
+      REQUIRE(t1.size() == 2);
 
       // Creating spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      bool rotate=false;
-      double rot_ang=0;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      bool rotate = false;
+      double rot_ang = 0;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -686,14 +683,13 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       // if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            unit_box, t1, region, &conflicts));
+          unit_box, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
-    } 
-
+    }
 
 
     WHEN("Trajectory profile is 2x2, space is 2x10, space box not rotated")
-    {  
+    {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
       t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
@@ -701,15 +697,15 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      bool rotate=false;
-      double rot_ang=0;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      bool rotate = false;
+      double rot_ang = 0;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -721,7 +717,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       // if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            double_box, t1, region, &conflicts));
+          double_box, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
@@ -731,18 +727,18 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       rmf_traffic::Trajectory t1;
       t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
       t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
-      REQUIRE(t1.size()==2);
+      REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      bool rotate=false;
-      double rot_ang=0;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      bool rotate = false;
+      double rot_ang = 0;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -764,20 +760,20 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       // Creating trajectory
       rmf_traffic::Trajectory t1;
-      t1.insert(time, {-5.0,0,0}, {0,0,0});
-      t1.insert(time+10s, {5.0,0,0}, {0,0,0});
+      t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
+      t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
       REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      bool rotate=true;
-      double rot_ang=0;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      bool rotate = true;
+      double rot_ang = 0;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -790,7 +786,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            unit_box, t1, region, &conflicts));
+          unit_box, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
@@ -798,20 +794,20 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
     {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
-      t1.insert(time, {-5.0,0,0}, {0,0,0});
-      t1.insert(time+10s, {5.0,0,0}, {0,0,0});
-      REQUIRE(t1.size()==2);
+      t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
+      t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
+      REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      bool rotate=true;
-      double rot_ang=90;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      bool rotate = true;
+      double rot_ang = 90;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -824,7 +820,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              unit_box, t1, region, &conflicts));
+          unit_box, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
@@ -837,20 +833,20 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      bool rotate=false;
-      double rot_ang=0;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      bool rotate = false;
+      double rot_ang = 0;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
         rmf_traffic::geometry::make_final_convex<
-            rmf_traffic::geometry::Box>(2.0, 1.0)
+          rmf_traffic::geometry::Box>(2.0, 1.0)
       };
 
       // std::cout<<"\nT_box("<<shape.get_x_length()<<","<<shape.get_y_length()<<") Shape_box:("<<box.get_x_length()<<","<<box.get_y_length()<<")";
@@ -858,11 +854,12 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       // if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              unit_box, t1,region, &conflicts));
+          unit_box, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
-    WHEN("Trajectory profile is 0.5x1 and dim is 1x1, space is 10x1, space box rotated by 90")
+    WHEN(
+      "Trajectory profile is 0.5x1 and dim is 1x1, space is 10x1, space box rotated by 90")
     {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
@@ -871,15 +868,15 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      bool rotate=true;
-      double rot_ang=90;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      bool rotate = true;
+      double rot_ang = 90;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -891,32 +888,33 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       // if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              rmf_traffic::Profile{
-                rmf_traffic::geometry::make_final_convex<
-                    rmf_traffic::geometry::Box>(0.5, 1.0)},
-              t1, region, &conflicts));
+          rmf_traffic::Profile{
+            rmf_traffic::geometry::make_final_convex<
+              rmf_traffic::geometry::Box>(0.5, 1.0)},
+          t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
 
-    WHEN("Trajectory profile is 1x1 and dim is 1x1, space is 10x1, space box rotated by 90")
+    WHEN(
+      "Trajectory profile is 1x1 and dim is 1x1, space is 10x1, space box rotated by 90")
     {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
       t1.insert(time, {0, 0, 0}, {0, 0, 0});
       t1.insert(time+10s, {0, 0, 0}, {0, 0, 0});
-      REQUIRE(t1.size()==2);
+      REQUIRE(t1.size() == 2);
 
       //Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      bool rotate=true;
-      double rot_ang=90;
-      if(rotate)
-        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      bool rotate = true;
+      double rot_ang = 90;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -928,7 +926,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
       // if(rotate) std::cout<<" Ang:"<<rot_ang<<"\n";
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              unit_box, t1, region, &conflicts));
+          unit_box, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
@@ -1023,24 +1021,25 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 //      CHECK(output_iterators.size()==1);
 //    }
 
-    WHEN("Trajectory profile is circle(0.5), space is 1x10, space box not rotated ") //this fails
+    WHEN(
+      "Trajectory profile is circle(0.5), space is 1x10, space box not rotated ") //this fails
     {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
       t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
       t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
-      REQUIRE(t1.size()==2);
+      REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      rotate=false;
-      rot_ang=90;
-      if(rotate)
-          tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      rotate = false;
+      rot_ang = 90;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -1049,29 +1048,30 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              small_circle, t1, region, &conflicts));
+          small_circle, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
 
-    WHEN("Trajectory profile is circle(0.5), space is circle (1), space not rotated ") //this fails
+    WHEN(
+      "Trajectory profile is circle(0.5), space is circle (1), space not rotated ") //this fails
     {
       // Creating trajectory
       rmf_traffic::Trajectory t1;
       t1.insert(time, {-5.0, 0, 0}, {0, 0, 0});
       t1.insert(time+10s, {5.0, 0, 0}, {0, 0, 0});
-      REQUIRE(t1.size()==2);
+      REQUIRE(t1.size() == 2);
 
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+10s;
+      lower_time_bound = time;
+      upper_time_bound = time+10s;
 
-      rotate=false;
-      rot_ang=0;
-      if(rotate)
-          tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180)); //conflict is only detected when angle is 69deg
+      rotate = false;
+      rot_ang = 0;
+      if (rotate)
+        tf.rotate(Eigen::Rotation2Dd(rot_ang*M_PI/180));//conflict is only detected when angle is 69deg
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -1080,7 +1080,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              small_circle, t1, region, &conflicts));
+          small_circle, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
@@ -1115,7 +1115,7 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
 //              unit_box, t1, region, &conflicts));
 //      CHECK(conflicts.size() == 1);
 //    }
- 
+
 //    WHEN("Trajectory profile is 1x1 and length is 1x1, space is 10x2, space box rotated by 90")
 //    {
 //      // Creating trajectory
@@ -1178,38 +1178,36 @@ SCENARIO("Testing intersction of various spacetimes and trajectories")
   }
 }
 //=====================================================================================================================
-  //test trajectorties with 3 or more segments
-
-
+//test trajectorties with 3 or more segments
 
 
 SCENARIO("Testing intersection of curved trajectory with various spacetimes")
 {
   using namespace std::chrono_literals;
-  auto time= std::chrono::steady_clock::now();
+  auto time = std::chrono::steady_clock::now();
 
   const auto unit_circle_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Circle>(1.0);
+    rmf_traffic::geometry::Circle>(1.0);
   rmf_traffic::Profile unit_circle{unit_circle_shape};
 
   const auto region_box_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(10.0, 10.0);
+    rmf_traffic::geometry::Box>(10.0, 10.0);
 
   const auto small_region_box_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(2.0, 2.0);
+    rmf_traffic::geometry::Box>(2.0, 2.0);
 
   rmf_traffic::Trajectory t1;
-  t1.insert(time, {-5,0,0}, {1,0,0});
+  t1.insert(time, {-5, 0, 0}, {1, 0, 0});
   t1.insert(time+10s, {0, -5, 0}, {0, -1, 0});
 
   GIVEN("spacetime that encompasses the trajectory in space and time")
   {
     //creating space to create spacetime
-    std::chrono::_V2::steady_clock::time_point lower_time_bound=time;
-    std::chrono::_V2::steady_clock::time_point upper_time_bound=time+10s;
+    std::chrono::_V2::steady_clock::time_point lower_time_bound = time;
+    std::chrono::_V2::steady_clock::time_point upper_time_bound = time+10s;
     Eigen::Isometry2d tf = Eigen::Isometry2d::Identity();
 
-    rmf_traffic::internal::Spacetime region={
+    rmf_traffic::internal::Spacetime region = {
       &lower_time_bound,
       &upper_time_bound,
       tf,
@@ -1222,11 +1220,11 @@ SCENARIO("Testing intersection of curved trajectory with various spacetimes")
   GIVEN("spacetime that encompasses the trajectory in space but not time")
   {
     //creating space to create spacetime
-    std::chrono::_V2::steady_clock::time_point lower_time_bound=time+20s;
-    std::chrono::_V2::steady_clock::time_point upper_time_bound=time+30s;
+    std::chrono::_V2::steady_clock::time_point lower_time_bound = time+20s;
+    std::chrono::_V2::steady_clock::time_point upper_time_bound = time+30s;
     Eigen::Isometry2d tf = Eigen::Isometry2d::Identity();
 
-    rmf_traffic::internal::Spacetime region={
+    rmf_traffic::internal::Spacetime region = {
       &lower_time_bound,
       &upper_time_bound,
       tf,
@@ -1239,11 +1237,11 @@ SCENARIO("Testing intersection of curved trajectory with various spacetimes")
   GIVEN("spacetime that partially intersects the trajectory in space and time")
   {
     //creating space to create spacetime
-    std::chrono::_V2::steady_clock::time_point lower_time_bound=time;
-    std::chrono::_V2::steady_clock::time_point upper_time_bound=time+10s;
+    std::chrono::_V2::steady_clock::time_point lower_time_bound = time;
+    std::chrono::_V2::steady_clock::time_point upper_time_bound = time+10s;
     Eigen::Isometry2d tf = Eigen::Isometry2d::Identity();
 
-    rmf_traffic::internal::Spacetime region={
+    rmf_traffic::internal::Spacetime region = {
       &lower_time_bound,
       &upper_time_bound,
       tf,
@@ -1262,12 +1260,13 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
   std::chrono::_V2::steady_clock::time_point upper_time_bound;
 
   const auto small_circle_shape = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Circle>(0.5);
+    rmf_traffic::geometry::Circle>(0.5);
   rmf_traffic::Profile small_circle{small_circle_shape};
 
-  GIVEN("A Trajectory t1 with circular profile which traces the outline of a box")
+  GIVEN(
+    "A Trajectory t1 with circular profile which traces the outline of a box")
   {
-    auto time =std::chrono::steady_clock::now();
+    auto time = std::chrono::steady_clock::now();
 
     rmf_traffic::Trajectory t1;
     //defining t1 as box with corners (-10,10), (-10,-10), (10,-10) and (10,10)
@@ -1277,61 +1276,61 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
     t1.insert(time+60s, {10.0, 10.0, 0}, {0, 0, 0});
     t1.insert(time+80s, {-10.0, 10.0, 0}, {0, 0, 0});
 
-    REQUIRE(t1.size()==5);
+    REQUIRE(t1.size() == 5);
 
-    Eigen::Isometry2d tf= Eigen::Isometry2d::Identity();
+    Eigen::Isometry2d tf = Eigen::Isometry2d::Identity();
 
     WHEN("Checked with circular spacetime circumscribing t1")
     {
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+81s;
+      lower_time_bound = time;
+      upper_time_bound = time+81s;
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
         rmf_traffic::geometry::make_final_convex<
-            rmf_traffic::geometry::Circle>(15.0)
+          rmf_traffic::geometry::Circle>(15.0)
       };
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-              small_circle, t1, region, &conflicts));
+          small_circle, t1, region, &conflicts));
       CHECK(conflicts.size() == 4);
     }
 
     WHEN("Checked with circular spacetime intersecting 3 segments of t1")
     {
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+81s;
+      lower_time_bound = time;
+      upper_time_bound = time+81s;
 
       tf.translate(Eigen::Vector2d{10, 0});
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
         rmf_traffic::geometry::make_final_convex<
-            rmf_traffic::geometry::Circle>(15.0)
+          rmf_traffic::geometry::Circle>(15.0)
       };
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            small_circle, t1, region, &conflicts));
+          small_circle, t1, region, &conflicts));
       CHECK(conflicts.size() == 3);
     }
 
     WHEN("Checked with circular spacetime intersecting 1 waypoint of t1")
     {
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+81s;
+      lower_time_bound = time;
+      upper_time_bound = time+81s;
 
       tf.translate(Eigen::Vector2d{5, 10});
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
@@ -1340,71 +1339,71 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            small_circle, t1, region, &conflicts));
+          small_circle, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
     WHEN("Checked with box spacetime encompassing t1")
     {
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+81s;
+      lower_time_bound = time;
+      upper_time_bound = time+81s;
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
         rmf_traffic::geometry::make_final_convex<
-            rmf_traffic::geometry::Box>(30.0, 30.0)
+          rmf_traffic::geometry::Box>(30.0, 30.0)
       };
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            small_circle, t1, region, &conflicts));
+          small_circle, t1, region, &conflicts));
       CHECK(conflicts.size() == 4);
     }
 
     WHEN("Checked with box spacetime intersecting 3 segments of t1")
     {
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+81s;
+      lower_time_bound = time;
+      upper_time_bound = time+81s;
 
-      tf.translate(Eigen::Vector2d{-10,0});
+      tf.translate(Eigen::Vector2d{-10, 0});
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
         rmf_traffic::geometry::make_final_convex<
-            rmf_traffic::geometry::Box>(30.0, 30.0)
+          rmf_traffic::geometry::Box>(30.0, 30.0)
       };
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            small_circle, t1, region, &conflicts));
+          small_circle, t1, region, &conflicts));
       CHECK(conflicts.size() == 3);
     }
 
     WHEN("Checked with box spacetime intersecting 1 waypoint of t1")
     {
       // Creating Spacetime
-      lower_time_bound=time;
-      upper_time_bound=time+81s;
+      lower_time_bound = time;
+      upper_time_bound = time+81s;
 
       tf.translate(Eigen::Vector2d{-10, 0});
 
-      rmf_traffic::internal::Spacetime region={
+      rmf_traffic::internal::Spacetime region = {
         &lower_time_bound,
         &upper_time_bound,
         tf,
         rmf_traffic::geometry::make_final_convex<
-            rmf_traffic::geometry::Box>(1.0, 1.0)
+          rmf_traffic::geometry::Box>(1.0, 1.0)
       };
 
       rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
       CHECK(rmf_traffic::internal::detect_conflicts(
-            small_circle, t1, region, &conflicts));
+          small_circle, t1, region, &conflicts));
       CHECK(conflicts.size() == 1);
     }
 
@@ -1413,14 +1412,14 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
       //Creating Spacetime
 
       const auto big_region_shape = rmf_traffic::geometry::make_final_convex<
-          rmf_traffic::geometry::Box>(30.0, 30.0);
+        rmf_traffic::geometry::Box>(30.0, 30.0);
 
       THEN("Single conflict when time bounds overlap with first waypoint only")
       {
-        lower_time_bound=time;
-        upper_time_bound=time+19s;
+        lower_time_bound = time;
+        upper_time_bound = time+19s;
 
-        rmf_traffic::internal::Spacetime region={
+        rmf_traffic::internal::Spacetime region = {
           &lower_time_bound,
           &upper_time_bound,
           tf,
@@ -1429,16 +1428,16 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
 
         rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
         CHECK(rmf_traffic::internal::detect_conflicts(
-              small_circle, t1, region, &conflicts));
+            small_circle, t1, region, &conflicts));
         CHECK(conflicts.size() == 1);
       }
 
       THEN("Single conflict when time bounds overlap with second waypoint only")
       {
-        lower_time_bound=time+21s;
-        upper_time_bound=time+39s;
+        lower_time_bound = time+21s;
+        upper_time_bound = time+39s;
 
-        rmf_traffic::internal::Spacetime region={
+        rmf_traffic::internal::Spacetime region = {
           &lower_time_bound,
           &upper_time_bound,
           tf,
@@ -1447,16 +1446,16 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
 
         rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
         CHECK(rmf_traffic::internal::detect_conflicts(
-              small_circle, t1, region, &conflicts));
+            small_circle, t1, region, &conflicts));
         CHECK(conflicts.size() == 1);
       }
 
       THEN("Single conflict when time bounds overlap with third waypoint only")
       {
-        lower_time_bound=time+41s;
-        upper_time_bound=time+59s;
+        lower_time_bound = time+41s;
+        upper_time_bound = time+59s;
 
-        rmf_traffic::internal::Spacetime region={
+        rmf_traffic::internal::Spacetime region = {
           &lower_time_bound,
           &upper_time_bound,
           tf,
@@ -1465,16 +1464,16 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
 
         rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
         CHECK(rmf_traffic::internal::detect_conflicts(
-              small_circle, t1, region, &conflicts));
+            small_circle, t1, region, &conflicts));
         CHECK(conflicts.size() == 1);
       }
 
       THEN("Single conflict when time bounds overlap with fourth waypoint only")
       {
-        lower_time_bound=time+61s;
-        upper_time_bound=time+79s;
+        lower_time_bound = time+61s;
+        upper_time_bound = time+79s;
 
-        rmf_traffic::internal::Spacetime region={
+        rmf_traffic::internal::Spacetime region = {
           &lower_time_bound,
           &upper_time_bound,
           tf,
@@ -1483,18 +1482,19 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
 
         rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
         CHECK(rmf_traffic::internal::detect_conflicts(
-              small_circle, t1, region, &conflicts));
+            small_circle, t1, region, &conflicts));
         CHECK(conflicts.size() == 1);
       }
     }
   } //end of given
 
 
-  GIVEN("A Trajectory t1 with circular profile which traces the outline of a circle")
+  GIVEN(
+    "A Trajectory t1 with circular profile which traces the outline of a circle")
   {
     // TODO(MXG): It looks like this test was never finished.
 
-    auto time =std::chrono::steady_clock::now();
+    auto time = std::chrono::steady_clock::now();
 
     // defining t1 as circle with corners of radius 10m
     rmf_traffic::Trajectory t1;
@@ -1504,17 +1504,9 @@ SCENARIO("Testing multi-waypoint trajectories with various spacetimes")
     t1.insert(time+60s, {10.0, 10.0, 0}, {0, 0, 0});
     t1.insert(time+80s, {-10.0, 10.0, 0}, {0, 0, 0});
 
-    REQUIRE(t1.size()==5);
+    REQUIRE(t1.size() == 5);
 
     rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
-   // Eigen::Isometry2d tf= Eigen::Isometry2d::Identity();
+    // Eigen::Isometry2d tf= Eigen::Isometry2d::Identity();
   }
 }
-
-
-
-
-
-
-
-

--- a/rmf_traffic/test/unit/schedule/utils_Database.hpp
+++ b/rmf_traffic/test/unit/schedule/utils_Database.hpp
@@ -28,12 +28,13 @@
 
 #include <rmf_utils/catch.hpp>
 
-inline void CHECK_EQUAL_TRAJECTORY(const rmf_traffic::Trajectory *t, rmf_traffic::Trajectory t2)
+inline void CHECK_EQUAL_TRAJECTORY(const rmf_traffic::Trajectory* t,
+  rmf_traffic::Trajectory t2)
 {
-  rmf_traffic::Trajectory t1= *t;
-  REQUIRE(t1.size()==t2.size());
+  rmf_traffic::Trajectory t1 = *t;
+  REQUIRE(t1.size() == t2.size());
 
-  for(auto it1=t1.begin(),it2=t2.begin();it1!=t1.end();it1++,it2++)
+  for (auto it1 = t1.begin(), it2 = t2.begin(); it1 != t1.end(); it1++, it2++)
   {
     CHECK(it1->position() == it2->position());
     CHECK(it1->velocity() == it2->velocity());
@@ -42,9 +43,9 @@ inline void CHECK_EQUAL_TRAJECTORY(const rmf_traffic::Trajectory *t, rmf_traffic
 }
 
 inline void CHECK_TRAJECTORY_COUNT(
-    const rmf_traffic::schedule::Viewer& d,
-    const std::size_t expected_participant_num,
-    const std::size_t expected_trajectory_num)
+  const rmf_traffic::schedule::Viewer& d,
+  const std::size_t expected_participant_num,
+  const std::size_t expected_trajectory_num)
 {
   const auto view = d.query(rmf_traffic::schedule::query_all());
   CHECK(view.size() == expected_trajectory_num);
@@ -52,16 +53,16 @@ inline void CHECK_TRAJECTORY_COUNT(
 }
 
 inline std::vector<rmf_traffic::Trajectory> get_conflicting_trajectories(
-    const rmf_traffic::schedule::Viewer::View& view,
-    const rmf_traffic::Profile& p,
-    const rmf_traffic::Trajectory& t)
+  const rmf_traffic::schedule::Viewer::View& view,
+  const rmf_traffic::Profile& p,
+  const rmf_traffic::Trajectory& t)
 {
   std::vector<rmf_traffic::Trajectory> collision_trajectories;
-  for(const auto& v : view)
+  for (const auto& v : view)
   {
     const auto& v_p = v.description.profile();
     const auto& v_t = v.route.trajectory();
-    if(rmf_traffic::DetectConflict::between(v_p, v_t, p, t))
+    if (rmf_traffic::DetectConflict::between(v_p, v_t, p, t))
       collision_trajectories.push_back(v_t);
   }
 
@@ -69,7 +70,7 @@ inline std::vector<rmf_traffic::Trajectory> get_conflicting_trajectories(
 }
 
 inline rmf_traffic::schedule::Writer::Input create_test_input(
-    rmf_traffic::RouteId id, const rmf_traffic::Trajectory& t)
+  rmf_traffic::RouteId id, const rmf_traffic::Trajectory& t)
 {
   return rmf_traffic::schedule::Writer::Input{
     {
@@ -77,7 +78,6 @@ inline rmf_traffic::schedule::Writer::Input create_test_input(
     }
   };
 }
-
 
 
 #endif //RMF_TRAFFIC__TEST__UNIT__SCHEDULE__UTILS_TRAJECTORY_HPP

--- a/rmf_traffic/test/unit/test_Conflict.cpp
+++ b/rmf_traffic/test/unit/test_Conflict.cpp
@@ -35,12 +35,13 @@ SCENARIO("DetectConflict unit tests")
   // We will call the reference trajectory t1, and comparison trajectory t2
   const double fcl_error_margin = 0.5;
 
-  GIVEN("A 2-point trajectory t1 with unit square box profile (stationary robot)")
+  GIVEN(
+    "A 2-point trajectory t1 with unit square box profile (stationary robot)")
   {
     const double profile_scale = 1.0;
     const rmf_traffic::Time time = std::chrono::steady_clock::now();
     const auto shape = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(profile_scale, profile_scale);
+      rmf_traffic::geometry::Box>(profile_scale, profile_scale);
     rmf_traffic::Profile profile{shape};
     Eigen::Vector3d pos = Eigen::Vector3d(0, 0, 0);
     Eigen::Vector3d vel = Eigen::Vector3d(0, 0, 0);
@@ -67,7 +68,7 @@ SCENARIO("DetectConflict unit tests")
             ++t1.begin(),    // Waypoint from Trajectory 1 that will conflict
             ++t2.begin(),    // Waypoint from Trajectory 2 that will conflict
             fcl_error_margin // Error Margin for computing collision time
-        });
+          });
 
         CHECK_ConflictList(conflicts, expected_conflicts);
         CHECK_between_is_commutative(profile, t1, profile, t2);
@@ -75,7 +76,8 @@ SCENARIO("DetectConflict unit tests")
       }
     }
 
-    WHEN("t2 is t1 but displaced positionally, with bare overlap at the profile within error margin")
+    WHEN(
+      "t2 is t1 but displaced positionally, with bare overlap at the profile within error margin")
     {
       rmf_traffic::Trajectory t2;
       const double dx = 0.8;
@@ -94,7 +96,7 @@ SCENARIO("DetectConflict unit tests")
             ++t1.begin(),    // Waypoint from Trajectory 1 that will conflict
             ++t2.begin(),    // Waypoint from Trajectory 2 that will conflict
             fcl_error_margin // Error Margin for computing collision time
-        });
+          });
 
         CHECK_ConflictList(conflicts, expected_conflicts);
         CHECK_between_is_commutative(profile, t1, profile, t2);
@@ -108,7 +110,7 @@ SCENARIO("DetectConflict unit tests")
       const Eigen::Vector3d new_pos = Eigen::Vector3d(dx, dx, dx);
       t2.insert(time, new_pos, vel);
       t2.insert(time + 10s, new_pos, vel);
-      REQUIRE(t2.size()==2);
+      REQUIRE(t2.size() == 2);
     }
 
     WHEN("t1 and t2 overlap positionally but not in timing")
@@ -134,7 +136,7 @@ SCENARIO("DetectConflict unit tests")
     const double box_x_length = 2;
     const double box_y_length = 1;
     const auto shape = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(box_x_length, box_y_length);
+      rmf_traffic::geometry::Box>(box_x_length, box_y_length);
     const rmf_traffic::Profile profile{shape};
 
     Eigen::Vector3d pos = Eigen::Vector3d{0, 0, 0};
@@ -207,28 +209,28 @@ SCENARIO("DetectConflict unit tests")
 
     rmf_traffic::Trajectory trajectory_a;
     trajectory_a.insert(
-        begin_time,
-        Eigen::Vector3d{-5.0, 0.0, 0.0},
-        Eigen::Vector3d{0.0, 0.0, 0.0});
+      begin_time,
+      Eigen::Vector3d{-5.0, 0.0, 0.0},
+      Eigen::Vector3d{0.0, 0.0, 0.0});
 
     trajectory_a.insert(
-        begin_time + 10s,
-        Eigen::Vector3d{5.0, 0.0, 0.0},
-        Eigen::Vector3d{0.0, 0.0, 0.0});
+      begin_time + 10s,
+      Eigen::Vector3d{5.0, 0.0, 0.0},
+      Eigen::Vector3d{0.0, 0.0, 0.0});
     REQUIRE(trajectory_a.size() == 2);
 
     WHEN("Checked against a conflicting Trajectory")
     {
       rmf_traffic::Trajectory trajectory_b;
       trajectory_b.insert(
-          begin_time,
-          Eigen::Vector3d{0.0, -5.0, 0.0},
-          Eigen::Vector3d{0.0, 0.0, 0.0});
+        begin_time,
+        Eigen::Vector3d{0.0, -5.0, 0.0},
+        Eigen::Vector3d{0.0, 0.0, 0.0});
 
       trajectory_b.insert(
-          begin_time + 10s,
-          Eigen::Vector3d{0.0, 5.0, 0.0},
-          Eigen::Vector3d{0.0, 0.0, 0.0});
+        begin_time + 10s,
+        Eigen::Vector3d{0.0, 5.0, 0.0},
+        Eigen::Vector3d{0.0, 0.0, 0.0});
 
       REQUIRE(trajectory_b.size() == 2);
 
@@ -236,7 +238,7 @@ SCENARIO("DetectConflict unit tests")
           profile, trajectory_a, profile, trajectory_b));
 
       const auto conflicts = get_conflicts(
-          profile, trajectory_a, profile, trajectory_b);
+        profile, trajectory_a, profile, trajectory_b);
       REQUIRE(conflicts.size() == 1);
 
       // Note: The expected time in this case is the root of the polynomial
@@ -244,7 +246,7 @@ SCENARIO("DetectConflict unit tests")
       // -0.02 t^3 + 0.3 t^2 - 4 t = 0
       const double expected_time = 4.32931077;
       const double computed_time = rmf_traffic::time::to_seconds(
-          conflicts.front().time - begin_time);
+        conflicts.front().time - begin_time);
 
       // Note: FCL is able to calculate the collision time to very high
       // precision, but it requires many iterations (~1000000 for a precision of
@@ -263,19 +265,19 @@ SCENARIO("DetectConflict unit tests")
 
       // This trajectory is parallel to trajectory_a
       trajectory_c.insert(
-          begin_time,
-          Eigen::Vector3d{-5.0, 5.0, 0.0},
-          Eigen::Vector3d{0.0, 0.0, 0.0});
+        begin_time,
+        Eigen::Vector3d{-5.0, 5.0, 0.0},
+        Eigen::Vector3d{0.0, 0.0, 0.0});
 
       trajectory_c.insert(
-          begin_time + 10s,
-          Eigen::Vector3d{5.0, 5.0, 0.0},
-          Eigen::Vector3d{0.0, 0.0, 0.0});
+        begin_time + 10s,
+        Eigen::Vector3d{5.0, 5.0, 0.0},
+        Eigen::Vector3d{0.0, 0.0, 0.0});
 
       REQUIRE(trajectory_c.size() == 2);
 
       const auto conflicts = get_conflicts(
-            profile, trajectory_a, profile, trajectory_c);
+        profile, trajectory_a, profile, trajectory_c);
       CHECK(conflicts.empty());
     }
   }
@@ -287,38 +289,38 @@ SCENARIO("DetectConflict unit tests")
 
     rmf_traffic::Trajectory trajectory_a;
     trajectory_a.insert(
-        begin_time,
-        Eigen::Vector3d{-5.0, 0.0, 0.0},
-        Eigen::Vector3d{1.0, 0.0, 0.0});
+      begin_time,
+      Eigen::Vector3d{-5.0, 0.0, 0.0},
+      Eigen::Vector3d{1.0, 0.0, 0.0});
 
     trajectory_a.insert(
-        begin_time + 10s,
-        Eigen::Vector3d{0.0, -5.0, 0.0},
-        Eigen::Vector3d{0.0, -1.0, 0.0});
+      begin_time + 10s,
+      Eigen::Vector3d{0.0, -5.0, 0.0},
+      Eigen::Vector3d{0.0, -1.0, 0.0});
     REQUIRE(trajectory_a.size() == 2);
 
     WHEN("Checked against a conflicting Trajectory")
     {
       rmf_traffic::Trajectory trajectory_b;
       trajectory_b.insert(
-          begin_time,
-          Eigen::Vector3d{-5.0, -5.0, 0.0},
-          Eigen::Vector3d{1.0, 0.0, 0.0});
+        begin_time,
+        Eigen::Vector3d{-5.0, -5.0, 0.0},
+        Eigen::Vector3d{1.0, 0.0, 0.0});
 
       trajectory_b.insert(
-          begin_time + 10s,
-          Eigen::Vector3d{0.0, 0.0, 0.0},
-          Eigen::Vector3d{0.0, 1.0, 0.0});
+        begin_time + 10s,
+        Eigen::Vector3d{0.0, 0.0, 0.0},
+        Eigen::Vector3d{0.0, 1.0, 0.0});
       REQUIRE(trajectory_b.size() == 2);
 
       const auto conflicts = get_conflicts(
-            profile, trajectory_a, profile, trajectory_b);
+        profile, trajectory_a, profile, trajectory_b);
       REQUIRE(conflicts.size() == 1);
 
       // Note: The expected collision time, calculated by hand, is sqrt(30)
       const double expected_time = std::sqrt(30.0);
       const double computed_time = rmf_traffic::time::to_seconds(
-          conflicts.front().time - begin_time);
+        conflicts.front().time - begin_time);
 
       CHECK(computed_time == Approx(expected_time).margin(0.2));
     }
@@ -329,18 +331,18 @@ SCENARIO("DetectConflict unit tests")
 
       rmf_traffic::Trajectory trajectory_c;
       trajectory_c.insert(
-          begin_time,
-          Eigen::Vector3d{5.0, 0.0, 0.0},
-          Eigen::Vector3d{-1.0, 0.0, 0.0});
+        begin_time,
+        Eigen::Vector3d{5.0, 0.0, 0.0},
+        Eigen::Vector3d{-1.0, 0.0, 0.0});
 
       trajectory_c.insert(
-          begin_time + 10s,
-          Eigen::Vector3d{0.0, 5.0, 0.0},
-          Eigen::Vector3d{0.0, 1.0, 0.0});
+        begin_time + 10s,
+        Eigen::Vector3d{0.0, 5.0, 0.0},
+        Eigen::Vector3d{0.0, 1.0, 0.0});
       REQUIRE(trajectory_c.size() == 2);
 
       const auto conflicts = get_conflicts(
-          profile, trajectory_a, profile, trajectory_c);
+        profile, trajectory_a, profile, trajectory_c);
 
       CHECK(conflicts.empty());
     }
@@ -353,15 +355,17 @@ SCENARIO("DetectConflict unit tests")
     double box_x_length = 1;
     double box_y_length = 1;
     const auto shape = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(box_x_length, box_y_length);
+      rmf_traffic::geometry::Box>(box_x_length, box_y_length);
     const rmf_traffic::Profile profile{shape};
 
     //L shaped trajectory
     t1.insert(time, Eigen::Vector3d{0, 5, 0}, Eigen::Vector3d::Zero());
     t1.insert(time + 10s, Eigen::Vector3d{0, -5, 0}, Eigen::Vector3d::Zero());
-    t1.insert(time + 20s, Eigen::Vector3d{0,-5,M_PI_2}, Eigen::Vector3d::Zero());
-    t1.insert(time + 30s, Eigen::Vector3d{10, -5, M_PI_2}, Eigen::Vector3d::Zero());
-    REQUIRE(t1.size() == 4);  
+    t1.insert(time + 20s, Eigen::Vector3d{0, -5, M_PI_2},
+      Eigen::Vector3d::Zero());
+    t1.insert(time + 30s, Eigen::Vector3d{10, -5, M_PI_2},
+      Eigen::Vector3d::Zero());
+    REQUIRE(t1.size() == 4);
 
     WHEN("Checked with a trajectory that intersects first segment of t1")
     {
@@ -376,15 +380,16 @@ SCENARIO("DetectConflict unit tests")
 
       const double expected_time = 4.32931077;
       const double computed_time =
-          rmf_traffic::time::to_seconds(conflicts.front().time - time);
-      CHECK(computed_time==Approx(expected_time).margin(fcl_error_margin));
+        rmf_traffic::time::to_seconds(conflicts.front().time - time);
+      CHECK(computed_time == Approx(expected_time).margin(fcl_error_margin));
     }
 
     WHEN("Checked with a trajectory that intersects last segment of t1")
     {
       rmf_traffic::Trajectory t2;
       t2.insert(time + 20s, Eigen::Vector3d{5, 0, 0}, Eigen::Vector3d{0, 0, 0});
-      t2.insert(time + 30s, Eigen::Vector3d{5, -10, 0},Eigen::Vector3d{0, 0, 0});
+      t2.insert(time + 30s, Eigen::Vector3d{5, -10, 0},
+        Eigen::Vector3d{0, 0, 0});
       REQUIRE(t2.size() == 2);
 
       const auto conflicts = get_conflicts(profile, t1, profile, t2);
@@ -393,21 +398,27 @@ SCENARIO("DetectConflict unit tests")
 
       const double expected_time = 24.32931077;
       const double computed_time =
-          rmf_traffic::time::to_seconds(conflicts.front().time - time);
+        rmf_traffic::time::to_seconds(conflicts.front().time - time);
 
-      CHECK(computed_time==Approx(expected_time).margin(fcl_error_margin));     
+      CHECK(computed_time == Approx(expected_time).margin(fcl_error_margin));
     }
 
-    WHEN("Checked with a multi-segment trajectory that intersects t1 at two-points")
+    WHEN(
+      "Checked with a multi-segment trajectory that intersects t1 at two-points")
     {
       rmf_traffic::Trajectory t2;
-      t2.insert(time, Eigen::Vector3d{-5, -0, -M_PI_4}, Eigen::Vector3d{0, 0, 0});
-      t2.insert(time + 2s, Eigen::Vector3d{0, 0, -M_PI_4},Eigen::Vector3d{0, 0, 0});
-      t2.insert(time + 10s, Eigen::Vector3d{0, 0, -M_PI_4},Eigen::Vector3d{0, 0, 0});
-      t2.insert(time + 20s, Eigen::Vector3d{5, -5, M_PI_4},Eigen::Vector3d{0, 0, 0});
-      t2.insert(time + 30s, Eigen::Vector3d{5, -5, M_PI_4},Eigen::Vector3d{0, 0, 0});
+      t2.insert(time, Eigen::Vector3d{-5, -0, -M_PI_4},
+        Eigen::Vector3d{0, 0, 0});
+      t2.insert(time + 2s, Eigen::Vector3d{0, 0, -M_PI_4}, Eigen::Vector3d{0, 0,
+          0});
+      t2.insert(time + 10s, Eigen::Vector3d{0, 0, -M_PI_4}, Eigen::Vector3d{0,
+          0, 0});
+      t2.insert(time + 20s, Eigen::Vector3d{5, -5, M_PI_4}, Eigen::Vector3d{0,
+          0, 0});
+      t2.insert(time + 30s, Eigen::Vector3d{5, -5, M_PI_4}, Eigen::Vector3d{0,
+          0, 0});
 
-      REQUIRE(t2.size()==5);
+      REQUIRE(t2.size() == 5);
 
       auto conflicts = get_conflicts(profile, t1, profile, t2);
       CHECK(conflicts.size() == 2);
@@ -418,11 +429,13 @@ SCENARIO("DetectConflict unit tests")
     WHEN("Checked with a trajectory that overlaps partially in time")
     {
       rmf_traffic::Trajectory t2;
-      t2.insert(time + 25s, Eigen::Vector3d{-5, 5, 0}, Eigen::Vector3d{0, 0, 0});
+      t2.insert(time + 25s, Eigen::Vector3d{-5, 5, 0},
+        Eigen::Vector3d{0, 0, 0});
       t2.insert(time + 35s, Eigen::Vector3d{5, 5, 0}, Eigen::Vector3d{0, 0, 0});
       REQUIRE(t2.size() == 2);
 
-      CHECK_FALSE(rmf_traffic::DetectConflict::between(profile, t1, profile, t2));
+      CHECK_FALSE(rmf_traffic::DetectConflict::between(profile, t1, profile,
+        t2));
     }
   }
 
@@ -431,30 +444,30 @@ SCENARIO("DetectConflict unit tests")
     const double r = 1.0;
     const rmf_traffic::Time begin_time = std::chrono::steady_clock::now();
     const auto circle = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Circle>(r);
+      rmf_traffic::geometry::Circle>(r);
 
     const rmf_traffic::Profile profile{circle};
 
     rmf_traffic::Trajectory trajectory;
     trajectory.insert(
-          begin_time,
-          Eigen::Vector3d(-10.0, -5.0, 0.0),
-          Eigen::Vector3d(0.5, 0.0, 0.0));
+      begin_time,
+      Eigen::Vector3d(-10.0, -5.0, 0.0),
+      Eigen::Vector3d(0.5, 0.0, 0.0));
 
     trajectory.insert(
-          begin_time + 10s,
-          Eigen::Vector3d(-5.0, -5.0, 0.0),
-          Eigen::Vector3d(0.5, 0.0, 0.0));
+      begin_time + 10s,
+      Eigen::Vector3d(-5.0, -5.0, 0.0),
+      Eigen::Vector3d(0.5, 0.0, 0.0));
 
     trajectory.insert(
-          begin_time + 30s,
-          Eigen::Vector3d(0.0, 0.0, 0.0),
-          Eigen::Vector3d(0.0, 0.5, 0.0));
+      begin_time + 30s,
+      Eigen::Vector3d(0.0, 0.0, 0.0),
+      Eigen::Vector3d(0.0, 0.5, 0.0));
 
     trajectory.insert(
-          begin_time + 40s,
-          Eigen::Vector3d(0.0, 5.0, 0.0),
-          Eigen::Vector3d(0.0, 0.5, 0.0));
+      begin_time + 40s,
+      Eigen::Vector3d(0.0, 5.0, 0.0),
+      Eigen::Vector3d(0.0, 0.5, 0.0));
 
     rmf_traffic::internal::Spacetime region{
       nullptr, nullptr,
@@ -466,7 +479,7 @@ SCENARIO("DetectConflict unit tests")
     {
       std::vector<ConflictData> conflicts;
       const bool has_conflicts = rmf_traffic::internal::detect_conflicts(
-            profile, trajectory, region, &conflicts);
+        profile, trajectory, region, &conflicts);
       CHECK(has_conflicts);
 
       REQUIRE(conflicts.size() == 1);
@@ -483,7 +496,7 @@ SCENARIO("DetectConflict unit tests")
       region.upper_time_bound = &region_finish_time;
 
       const bool has_conflicts = rmf_traffic::internal::detect_conflicts(
-            profile, trajectory, region, nullptr);
+        profile, trajectory, region, nullptr);
       CHECK_FALSE(has_conflicts);
     }
 
@@ -496,7 +509,7 @@ SCENARIO("DetectConflict unit tests")
       region.upper_time_bound = &region_finish_time;
 
       const bool has_conflicts = rmf_traffic::internal::detect_conflicts(
-            profile, trajectory, region, nullptr);
+        profile, trajectory, region, nullptr);
       CHECK_FALSE(has_conflicts);
     }
 
@@ -510,7 +523,7 @@ SCENARIO("DetectConflict unit tests")
 
       std::vector<ConflictData> conflicts;
       const bool has_conflicts = rmf_traffic::internal::detect_conflicts(
-            profile, trajectory, region, &conflicts);
+        profile, trajectory, region, &conflicts);
       CHECK(has_conflicts);
 
       REQUIRE(conflicts.size() == 1);

--- a/rmf_traffic/test/unit/test_Profile.cpp
+++ b/rmf_traffic/test/unit/test_Profile.cpp
@@ -31,9 +31,9 @@ SCENARIO("Testing Construction")
   WHEN("Vicinity is not passed into the constructor")
   {
     const auto circle_1 = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Circle>(1.0);
+      rmf_traffic::geometry::Circle>(1.0);
     const auto circle_2 = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Circle>(2.0);
+      rmf_traffic::geometry::Circle>(2.0);
 
     auto profile = Profile{circle_1};
 
@@ -76,12 +76,12 @@ SCENARIO("Testing Construction")
     }
   }
 
-  WHEN ("Vicinity is passed into the constructor")
+  WHEN("Vicinity is passed into the constructor")
   {
     const auto circle_1 = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Circle>(1.0);
+      rmf_traffic::geometry::Circle>(1.0);
     const auto circle_2 = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Circle>(2.0);
+      rmf_traffic::geometry::Circle>(2.0);
 
     auto profile = Profile{circle_1, circle_2};
 
@@ -123,22 +123,22 @@ SCENARIO("Testing Construction")
   }
 }
 
-SCENARIO ("Testing conflicts")
+SCENARIO("Testing conflicts")
 {
   using Trajecotry = rmf_traffic::Trajectory;
 
   const auto start_time = std::chrono::steady_clock::now();
 
   const auto circle_1 = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Circle>(1.0);
+    rmf_traffic::geometry::Circle>(1.0);
   const auto circle_2 = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Circle>(2.0);
+    rmf_traffic::geometry::Circle>(2.0);
   const auto box_1 = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(1.0, 1.0);
+    rmf_traffic::geometry::Box>(1.0, 1.0);
   const auto box_2 = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(2.0, 2.0);
+    rmf_traffic::geometry::Box>(2.0, 2.0);
   const auto box_3 = rmf_traffic::geometry::make_final_convex<
-      rmf_traffic::geometry::Box>(3.0, 3.0);
+    rmf_traffic::geometry::Box>(3.0, 3.0);
 
   GIVEN("Two stationary trajectories with non-overlapping vicinities")
   {

--- a/rmf_traffic/test/unit/test_Spline.cpp
+++ b/rmf_traffic/test/unit/test_Spline.cpp
@@ -30,18 +30,18 @@ SCENARIO("Test spline")
 
   rmf_traffic::Trajectory trajectory_a;
   trajectory_a.insert(
-        begin_time,
-        Eigen::Vector3d{-5.0,  0.0,  0.0},
-        Eigen::Vector3d{ 1.0,  0.0,  0.0});
+    begin_time,
+    Eigen::Vector3d{-5.0, 0.0, 0.0},
+    Eigen::Vector3d{ 1.0, 0.0, 0.0});
 
   trajectory_a.insert(
-        begin_time + 10s,
-        Eigen::Vector3d{ 5.0,  0.0,  0.0},
-        Eigen::Vector3d{ 1.0,  0.0,  0.0});
+    begin_time + 10s,
+    Eigen::Vector3d{ 5.0, 0.0, 0.0},
+    Eigen::Vector3d{ 1.0, 0.0, 0.0});
   REQUIRE(trajectory_a.size() == 2);
 
   rmf_traffic::Spline spline_a(++trajectory_a.begin());
-  for(const auto delta_t : {0s, 1s, 2s, 3s, 4s, 5s, 6s, 7s, 8s, 9s, 10s})
+  for (const auto delta_t : {0s, 1s, 2s, 3s, 4s, 5s, 6s, 7s, 8s, 9s, 10s})
   {
     const Eigen::Vector3d p = spline_a.compute_position(begin_time + delta_t);
     CHECK(p[0] == Approx(delta_t.count() - 5.0));
@@ -49,18 +49,18 @@ SCENARIO("Test spline")
 
   rmf_traffic::Trajectory trajectory_b;
   trajectory_b.insert(
-        begin_time,
-        Eigen::Vector3d{ 0.0, -5.0,  0.0},
-        Eigen::Vector3d{ 0.0,  1.0,  0.0});
+    begin_time,
+    Eigen::Vector3d{ 0.0, -5.0, 0.0},
+    Eigen::Vector3d{ 0.0, 1.0, 0.0});
 
   trajectory_b.insert(
-        begin_time + 10s,
-        Eigen::Vector3d{ 0.0,  5.0,  0.0},
-        Eigen::Vector3d{ 0.0,  1.0,  0.0});
+    begin_time + 10s,
+    Eigen::Vector3d{ 0.0, 5.0, 0.0},
+    Eigen::Vector3d{ 0.0, 1.0, 0.0});
   REQUIRE(trajectory_b.size() == 2);
 
   rmf_traffic::Spline spline_b(++trajectory_b.begin());
-  for(const auto delta_t : {0s, 1s, 2s, 3s, 4s, 5s, 6s, 7s, 8s, 9s, 10s})
+  for (const auto delta_t : {0s, 1s, 2s, 3s, 4s, 5s, 6s, 7s, 8s, 9s, 10s})
   {
     const Eigen::Vector3d p = spline_b.compute_position(begin_time + delta_t);
     CHECK(p[1] == Approx(delta_t.count() - 5.0));

--- a/rmf_traffic/test/unit/test_Trajectory.cpp
+++ b/rmf_traffic/test/unit/test_Trajectory.cpp
@@ -36,12 +36,13 @@ SCENARIO("Waypoint Unit Tests")
     const Eigen::Vector3d pos = Eigen::Vector3d(0, 0, 0);
     const Eigen::Vector3d vel = Eigen::Vector3d(0, 0, 0);
 
-    WHEN("Attemping to construct Waypoint using rmf_traffic::Trajectory::insert()")
+    WHEN(
+      "Attemping to construct Waypoint using rmf_traffic::Trajectory::insert()")
     {
       rmf_traffic::Trajectory trajectory;
       auto result = trajectory.insert(time, pos, vel);
 
-      const rmf_traffic::Trajectory::Waypoint &waypoint = *(result.it);
+      const rmf_traffic::Trajectory::Waypoint& waypoint = *(result.it);
 
       THEN("Waypoint is constructed according to specifications.")
       {
@@ -59,9 +60,14 @@ SCENARIO("Waypoint Unit Tests")
   {
     std::vector<TrajectoryInsertInput> inputs;
     rmf_traffic::Time time = std::chrono::steady_clock::now();
-    inputs.push_back({time, UnitBox, Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(0, 0, 0)});
-    inputs.push_back({time + 10s, UnitBox, Eigen::Vector3d(1, 1, 1), Eigen::Vector3d(1, 1, 1)});
-    inputs.push_back({time + 20s, UnitBox, Eigen::Vector3d(2, 2, 2), Eigen::Vector3d(0, 0, 0)});
+    inputs.push_back({time, UnitBox, Eigen::Vector3d(0, 0, 0),
+        Eigen::Vector3d(0, 0, 0)});
+    inputs.push_back({time + 10s, UnitBox, Eigen::Vector3d(1, 1,
+        1),
+        Eigen::Vector3d(1, 1, 1)});
+    inputs.push_back({time + 20s, UnitBox, Eigen::Vector3d(2, 2,
+        2),
+        Eigen::Vector3d(0, 0, 0)});
     rmf_traffic::Trajectory trajectory = create_test_trajectory(inputs);
     rmf_traffic::Trajectory::iterator trajectory_it = trajectory.begin();
     rmf_traffic::Trajectory::Waypoint& waypoint = *trajectory_it;
@@ -110,7 +116,8 @@ SCENARIO("Waypoint Unit Tests")
       }
     }
 
-    WHEN("Setting a new finish time that causes a rearrangement of adjacent waypoints")
+    WHEN(
+      "Setting a new finish time that causes a rearrangement of adjacent waypoints")
     {
       const rmf_traffic::Time new_time = time + 12s;
       waypoint.change_time(new_time);
@@ -119,12 +126,14 @@ SCENARIO("Waypoint Unit Tests")
       {
         int new_order[3] = {1, 0, 2};
         int i = 0;
-        for (rmf_traffic::Trajectory::iterator it = trajectory.begin(); it != trajectory.end(); it++, i++)
+        for (rmf_traffic::Trajectory::iterator it = trajectory.begin();
+          it != trajectory.end(); it++, i++)
           CHECK(it->position() == Eigen::Vector3d::Constant(new_order[i]));
       }
     }
 
-    WHEN("Setting a new finish time that causes a rearrangement of non-adjacent waypoints")
+    WHEN(
+      "Setting a new finish time that causes a rearrangement of non-adjacent waypoints")
     {
       const rmf_traffic::Time new_time = time + 22s;
       waypoint.change_time(new_time);
@@ -133,30 +142,35 @@ SCENARIO("Waypoint Unit Tests")
       {
         int new_order[3] = {1, 2, 0};
         int i = 0;
-        for (rmf_traffic::Trajectory::iterator it = trajectory.begin(); it != trajectory.end(); it++, i++)
+        for (rmf_traffic::Trajectory::iterator it = trajectory.begin();
+          it != trajectory.end(); it++, i++)
         {
           CHECK(it->position() == Eigen::Vector3d::Constant(new_order[i]));
         }
       }
     }
 
-    WHEN("Positively adjusting all finish times using adjust_finish_times function, using first waypoint")
+    WHEN(
+      "Positively adjusting all finish times using adjust_finish_times function, using first waypoint")
     {
       const std::chrono::seconds delta_t = std::chrono::seconds(5);
       waypoint.adjust_times(delta_t);
       int i = 0;
-      const rmf_traffic::Time new_order[3] = {time + 5s, time + 15s, time + 25s};
+      const rmf_traffic::Time new_order[3] =
+      {time + 5s, time + 15s, time + 25s};
 
       THEN("All finish times are adjusted correctly.")
       {
-        for (rmf_traffic::Trajectory::iterator it = trajectory.begin(); it != trajectory.end(); it++, i++)
+        for (rmf_traffic::Trajectory::iterator it = trajectory.begin();
+          it != trajectory.end(); it++, i++)
         {
           CHECK(it->time() == new_order[i]);
         }
       }
     }
 
-    WHEN("Negatively adjusting all finish times using adjust_finish_times function, using first waypoint")
+    WHEN(
+      "Negatively adjusting all finish times using adjust_finish_times function, using first waypoint")
     {
       const std::chrono::seconds delta_t = std::chrono::seconds(-5);
       waypoint.adjust_times(delta_t);
@@ -165,30 +179,36 @@ SCENARIO("Waypoint Unit Tests")
 
       THEN("All finish times are adjusted correctly.")
       {
-        for (rmf_traffic::Trajectory::iterator it = trajectory.begin(); it != trajectory.end(); it++, i++)
+        for (rmf_traffic::Trajectory::iterator it = trajectory.begin();
+          it != trajectory.end(); it++, i++)
         {
           CHECK(it->time() == new_order[i]);
         }
       }
     }
 
-    WHEN("Large negative adjustment all finish times using adjust_finish_times function, using first waypoint")
+    WHEN(
+      "Large negative adjustment all finish times using adjust_finish_times function, using first waypoint")
     {
       const std::chrono::seconds delta_t = std::chrono::seconds(-50);
       waypoint.adjust_times(delta_t);
       int i = 0;
-      const rmf_traffic::Time new_order[3] = {time - 50s, time - 40s, time - 30s};
+      const rmf_traffic::Time new_order[3] =
+      {time - 50s, time - 40s, time - 30s};
 
-      THEN("All finish times are adjusted correctly, as there is no waypoint preceding first waypoint")
+      THEN(
+        "All finish times are adjusted correctly, as there is no waypoint preceding first waypoint")
       {
-        for (rmf_traffic::Trajectory::iterator it = trajectory.begin(); it != trajectory.end(); it++, i++)
+        for (rmf_traffic::Trajectory::iterator it = trajectory.begin();
+          it != trajectory.end(); it++, i++)
         {
           CHECK(it->time() == new_order[i]);
         }
       }
     }
 
-    WHEN("Positively adjusting all finish times using adjust_finish_times function, using second waypoint")
+    WHEN(
+      "Positively adjusting all finish times using adjust_finish_times function, using second waypoint")
     {
       const std::chrono::seconds delta_t = std::chrono::seconds(5);
       waypoint_10s.adjust_times(delta_t);
@@ -197,14 +217,16 @@ SCENARIO("Waypoint Unit Tests")
       THEN("Finish times from the second waypoint on are adjusted correctly.")
       {
         const rmf_traffic::Time new_order[3] = {time, time + 15s, time + 25s};
-        for (rmf_traffic::Trajectory::iterator it = trajectory.begin(); it != trajectory.end(); it++, i++)
+        for (rmf_traffic::Trajectory::iterator it = trajectory.begin();
+          it != trajectory.end(); it++, i++)
         {
           CHECK(it->time() == new_order[i]);
         }
       }
     }
 
-    WHEN("Negatively adjusting all finish times using adjust_finish_times function, using second waypoint")
+    WHEN(
+      "Negatively adjusting all finish times using adjust_finish_times function, using second waypoint")
     {
       const std::chrono::seconds delta_t = std::chrono::seconds(-5);
       waypoint_10s.adjust_times(delta_t);
@@ -213,18 +235,21 @@ SCENARIO("Waypoint Unit Tests")
       THEN("All finish times are adjusted correctly.")
       {
         const rmf_traffic::Time new_order[3] = {time, time + 5s, time + 15s};
-        for (rmf_traffic::Trajectory::iterator it = trajectory.begin(); it != trajectory.end(); it++, i++)
+        for (rmf_traffic::Trajectory::iterator it = trajectory.begin();
+          it != trajectory.end(); it++, i++)
         {
           CHECK(it->time() == new_order[i]);
         }
       }
     }
 
-    WHEN("Large negative adjustment all finish times using adjust_finish_times function, using second waypoint")
+    WHEN(
+      "Large negative adjustment all finish times using adjust_finish_times function, using second waypoint")
     {
       const std::chrono::seconds delta_t = std::chrono::seconds(-50);
 
-      THEN("std::invalid_argument exception thrown due to violation of previous waypoint time boundary")
+      THEN(
+        "std::invalid_argument exception thrown due to violation of previous waypoint time boundary")
       {
         CHECK_THROWS(waypoint_10s.adjust_times(delta_t));
       }
@@ -360,7 +385,8 @@ SCENARIO("Trajectory and base_iterator unit tests")
 
       THEN("New iterator is created")
       {
-        const rmf_traffic::Trajectory::iterator &&rvalue_it = std::move(zeroth_it);
+        const rmf_traffic::Trajectory::iterator&& rvalue_it = std::move(
+          zeroth_it);
         const rmf_traffic::Trajectory::iterator copied_zeroth_it(rvalue_it);
         CHECK(&zeroth_it != &copied_zeroth_it);
       }
@@ -377,7 +403,8 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("New iterator is created")
       {
         const rmf_traffic::Trajectory::iterator copied_zeroth_it(zeroth_it);
-        const rmf_traffic::Trajectory::iterator moved_zeroth_it(std::move(copied_zeroth_it));
+        const rmf_traffic::Trajectory::iterator moved_zeroth_it(std::move(
+            copied_zeroth_it));
         CHECK(&zeroth_it != &moved_zeroth_it);
         CHECK(zeroth_it == moved_zeroth_it);
       }
@@ -385,7 +412,8 @@ SCENARIO("Trajectory and base_iterator unit tests")
 
     WHEN("Copy Construction of Trajectory from another trajectory")
     {
-      const rmf_traffic::Trajectory trajectory = create_test_trajectory(param_inputs);
+      const rmf_traffic::Trajectory trajectory = create_test_trajectory(
+        param_inputs);
       const rmf_traffic::Trajectory trajectory_copy = trajectory;
 
       THEN("Elements of trajectories are consistent")
@@ -405,7 +433,8 @@ SCENARIO("Trajectory and base_iterator unit tests")
 
     WHEN("Copy Construction of Trajectory followed by move of source trajectory")
     {
-      const rmf_traffic::Trajectory trajectory = create_test_trajectory(param_inputs);
+      const rmf_traffic::Trajectory trajectory = create_test_trajectory(
+        param_inputs);
       rmf_traffic::Trajectory trajectory_copy = trajectory;
       const rmf_traffic::Trajectory trajectory_moved = std::move(trajectory);
 
@@ -413,7 +442,8 @@ SCENARIO("Trajectory and base_iterator unit tests")
       {
         rmf_traffic::Trajectory::const_iterator ct = trajectory_copy.begin();
         rmf_traffic::Trajectory::const_iterator mt = trajectory_moved.begin();
-        for (; ct != trajectory_copy.end() && mt != trajectory_moved.end(); ++ct, ++mt)
+        for (; ct != trajectory_copy.end() && mt != trajectory_moved.end();
+          ++ct, ++mt)
         {
           CHECK(ct->position() == mt->position());
           CHECK(ct->velocity() == mt->velocity());
@@ -507,9 +537,15 @@ SCENARIO("Trajectory and base_iterator unit tests")
   {
     std::vector<TrajectoryInsertInput> param_inputs;
     const rmf_traffic::Time time = std::chrono::steady_clock::now();
-    param_inputs.push_back({time, UnitBox, Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 1, 1)});
-    param_inputs.push_back({time + 10s, UnitBox, Eigen::Vector3d(2, 2, 2), Eigen::Vector3d(3, 3, 3)});
-    param_inputs.push_back({time + 20s, UnitBox, Eigen::Vector3d(4, 4, 4), Eigen::Vector3d(5, 5, 5)});
+    param_inputs.push_back({time, UnitBox, Eigen::Vector3d(0, 0,
+        0),
+        Eigen::Vector3d(1, 1, 1)});
+    param_inputs.push_back({time + 10s, UnitBox, Eigen::Vector3d(2, 2,
+        2), Eigen::Vector3d(
+          3, 3, 3)});
+    param_inputs.push_back({time + 20s, UnitBox, Eigen::Vector3d(4, 4,
+        4), Eigen::Vector3d(
+          5, 5, 5)});
     rmf_traffic::Trajectory trajectory = create_test_trajectory(param_inputs);
     const rmf_traffic::Trajectory empty_trajectory = create_test_trajectory();
 
@@ -518,8 +554,10 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("Waypoint is retreieved successfully")
       {
         CHECK(trajectory.find(time)->position() == Eigen::Vector3d(0, 0, 0));
-        CHECK(trajectory.find(time + 10s)->position() == Eigen::Vector3d(2, 2, 2));
-        CHECK(trajectory.find(time + 20s)->position() == Eigen::Vector3d(4, 4, 4));
+        CHECK(trajectory.find(time + 10s)->position() == Eigen::Vector3d(2, 2,
+          2));
+        CHECK(trajectory.find(time + 20s)->position() == Eigen::Vector3d(4, 4,
+          4));
       }
     }
 
@@ -528,10 +566,14 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("Waypoints currently active are retrieved successfully")
       {
         CHECK(trajectory.find(time)->position() == Eigen::Vector3d(0, 0, 0));
-        CHECK(trajectory.find(time + 2s)->position() == Eigen::Vector3d(2, 2, 2));
-        CHECK(trajectory.find(time + 8s)->position() == Eigen::Vector3d(2, 2, 2));
-        CHECK(trajectory.find(time + 12s)->position() == Eigen::Vector3d(4, 4, 4));
-        CHECK(trajectory.find(time + 20s)->position() == Eigen::Vector3d(4, 4, 4));
+        CHECK(trajectory.find(time + 2s)->position() ==
+          Eigen::Vector3d(2, 2, 2));
+        CHECK(trajectory.find(time + 8s)->position() ==
+          Eigen::Vector3d(2, 2, 2));
+        CHECK(trajectory.find(time + 12s)->position() == Eigen::Vector3d(4, 4,
+          4));
+        CHECK(trajectory.find(time + 20s)->position() == Eigen::Vector3d(4, 4,
+          4));
       }
     }
 
@@ -549,8 +591,10 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("Waypoint is erased and trajectory is rearranged")
       {
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_target = trajectory.begin();
-        rmf_traffic::Trajectory::iterator next_it = trajectory.erase(erase_target);
+        const rmf_traffic::Trajectory::iterator erase_target =
+          trajectory.begin();
+        rmf_traffic::Trajectory::iterator next_it = trajectory.erase(
+          erase_target);
         CHECK(next_it->time() == time + 10s);
         CHECK(trajectory.size() == 2);
       }
@@ -563,8 +607,10 @@ SCENARIO("Trajectory and base_iterator unit tests")
         rmf_traffic::Trajectory trajectory_copy = trajectory;
         CHECK(trajectory_copy.size() == 3);
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_target = trajectory_copy.begin();
-        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(erase_target);
+        const rmf_traffic::Trajectory::iterator erase_target =
+          trajectory_copy.begin();
+        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(
+          erase_target);
         CHECK(next_it->time() == time + 10s);
         CHECK(trajectory_copy.size() == 2);
         CHECK(trajectory.size() == 3);
@@ -576,8 +622,10 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("Waypoint is erased and trajectory is rearranged")
       {
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_target = ++(trajectory.begin());
-        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(erase_target);
+        const rmf_traffic::Trajectory::iterator erase_target =
+          ++(trajectory.begin());
+        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(
+          erase_target);
         CHECK(next_it->time() == time + 20s);
         CHECK(trajectory.size() == 2);
       }
@@ -590,8 +638,10 @@ SCENARIO("Trajectory and base_iterator unit tests")
         rmf_traffic::Trajectory trajectory_copy = trajectory;
         CHECK(trajectory_copy.size() == 3);
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_target = ++(trajectory_copy.begin());
-        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(erase_target);
+        const rmf_traffic::Trajectory::iterator erase_target =
+          ++(trajectory_copy.begin());
+        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(
+          erase_target);
         CHECK(next_it->time() == time + 20s);
         CHECK(trajectory_copy.size() == 2);
         CHECK(trajectory.size() == 3);
@@ -603,9 +653,11 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("Nothing is erased and current iterator is returned")
       {
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory.begin();
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory.begin();
         const rmf_traffic::Trajectory::iterator erase_last = erase_first;
-        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(
+          erase_first, erase_last);
         CHECK(trajectory.size() == 3);
         CHECK(next_it->time() == time);
       }
@@ -618,9 +670,11 @@ SCENARIO("Trajectory and base_iterator unit tests")
         rmf_traffic::Trajectory trajectory_copy = trajectory;
         CHECK(trajectory_copy.size() == 3);
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory.begin();
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory.begin();
         const rmf_traffic::Trajectory::iterator erase_last = erase_first;
-        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(
+          erase_first, erase_last);
         CHECK(trajectory_copy.size() == 3);
         CHECK(trajectory.size() == 3);
         CHECK(next_it->time() == time);
@@ -632,9 +686,12 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("1 Waypoint is erased and trajectory is rearranged")
       {
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory.begin();
-        const rmf_traffic::Trajectory::iterator erase_last = trajectory.find(time + 10s);
-        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory.begin();
+        const rmf_traffic::Trajectory::iterator erase_last = trajectory.find(
+          time + 10s);
+        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(
+          erase_first, erase_last);
         CHECK(trajectory.size() == 2);
         CHECK(next_it->time() == time + 10s);
       }
@@ -647,9 +704,12 @@ SCENARIO("Trajectory and base_iterator unit tests")
         rmf_traffic::Trajectory trajectory_copy = trajectory;
         CHECK(trajectory_copy.size() == 3);
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory.begin();
-        const rmf_traffic::Trajectory::iterator erase_last = trajectory.find(time + 10s);
-        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory.begin();
+        const rmf_traffic::Trajectory::iterator erase_last = trajectory.find(
+          time + 10s);
+        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(
+          erase_first, erase_last);
         CHECK(trajectory_copy.size() == 2);
         CHECK(next_it->time() == time + 10s);
       }
@@ -660,9 +720,12 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("2 Waypoints are erased and trajectory is rearranged")
       {
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory.begin();
-        const rmf_traffic::Trajectory::iterator erase_last = trajectory.find(time + 20s);
-        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory.begin();
+        const rmf_traffic::Trajectory::iterator erase_last = trajectory.find(
+          time + 20s);
+        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(
+          erase_first, erase_last);
         CHECK(trajectory.size() == 1);
         CHECK(next_it->time() == time + 20s);
       }
@@ -675,9 +738,12 @@ SCENARIO("Trajectory and base_iterator unit tests")
         rmf_traffic::Trajectory trajectory_copy = trajectory;
         CHECK(trajectory_copy.size() == 3);
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory.begin();
-        const rmf_traffic::Trajectory::iterator erase_last = trajectory.find(time + 20s);
-        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory.begin();
+        const rmf_traffic::Trajectory::iterator erase_last = trajectory.find(
+          time + 20s);
+        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(
+          erase_first, erase_last);
         CHECK(trajectory_copy.size() == 1);
         CHECK(next_it->time() == time + 20s);
       }
@@ -688,9 +754,11 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("All Waypoints are erased and trajectory is empty")
       {
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory.begin();
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory.begin();
         const rmf_traffic::Trajectory::iterator erase_last = trajectory.end();
-        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(
+          erase_first, erase_last);
         CHECK(trajectory.size() == 0);
         CHECK(next_it == trajectory.end());
       }
@@ -701,9 +769,12 @@ SCENARIO("Trajectory and base_iterator unit tests")
       THEN("All but one Waypoint is erased")
       {
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory.begin();
-        const rmf_traffic::Trajectory::iterator erase_last = --(trajectory.end());
-        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory.begin();
+        const rmf_traffic::Trajectory::iterator erase_last =
+          --(trajectory.end());
+        const rmf_traffic::Trajectory::iterator next_it = trajectory.erase(
+          erase_first, erase_last);
         CHECK(trajectory.size() == 1);
         CHECK(next_it == trajectory.begin());
         CHECK(next_it == --trajectory.end());
@@ -717,9 +788,12 @@ SCENARIO("Trajectory and base_iterator unit tests")
         rmf_traffic::Trajectory trajectory_copy = trajectory;
         CHECK(trajectory_copy.size() == 3);
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory_copy.begin();
-        const rmf_traffic::Trajectory::iterator erase_last = trajectory_copy.end();
-        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory_copy.begin();
+        const rmf_traffic::Trajectory::iterator erase_last =
+          trajectory_copy.end();
+        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(
+          erase_first, erase_last);
         CHECK(trajectory_copy.size() == 0);
         CHECK(next_it == trajectory_copy.end());
       }
@@ -732,9 +806,12 @@ SCENARIO("Trajectory and base_iterator unit tests")
         rmf_traffic::Trajectory trajectory_copy = trajectory;
         CHECK(trajectory_copy.size() == 3);
         CHECK(trajectory.size() == 3);
-        const rmf_traffic::Trajectory::iterator erase_first = trajectory_copy.begin();
-        const rmf_traffic::Trajectory::iterator erase_last = --(trajectory_copy.end());
-        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(erase_first, erase_last);
+        const rmf_traffic::Trajectory::iterator erase_first =
+          trajectory_copy.begin();
+        const rmf_traffic::Trajectory::iterator erase_last =
+          --(trajectory_copy.end());
+        const rmf_traffic::Trajectory::iterator next_it = trajectory_copy.erase(
+          erase_first, erase_last);
         CHECK(trajectory_copy.size() == 1);
         CHECK(next_it == trajectory_copy.begin());
         CHECK(next_it == --trajectory_copy.end());

--- a/rmf_traffic/test/unit/utils_Conflict.hpp
+++ b/rmf_traffic/test/unit/utils_Conflict.hpp
@@ -28,32 +28,32 @@ using ConflictData = rmf_traffic::DetectConflict::Implementation::Conflict;
 
 //==============================================================================
 inline std::vector<ConflictData> get_conflicts(
-    const rmf_traffic::Profile& p1,
-    const rmf_traffic::Trajectory& t1,
-    const rmf_traffic::Profile& p2,
-    const rmf_traffic::Trajectory& t2)
+  const rmf_traffic::Profile& p1,
+  const rmf_traffic::Trajectory& t1,
+  const rmf_traffic::Profile& p2,
+  const rmf_traffic::Trajectory& t2)
 {
   rmf_traffic::DetectConflict::Implementation::Conflicts conflicts;
   rmf_traffic::DetectConflict::Implementation::between(
-        p1, t1, p2, t2, rmf_traffic::DetectConflict::Interpolate::CubicSpline,
-        &conflicts);
+    p1, t1, p2, t2, rmf_traffic::DetectConflict::Interpolate::CubicSpline,
+    &conflicts);
 
   return conflicts;
 }
 
 //==============================================================================
 inline void CHECK_between_is_commutative(
-    const rmf_traffic::Profile& p1,
-    const rmf_traffic::Trajectory& t1,
-    const rmf_traffic::Profile& p2,
-    const rmf_traffic::Trajectory& t2)
+  const rmf_traffic::Profile& p1,
+  const rmf_traffic::Trajectory& t1,
+  const rmf_traffic::Profile& p2,
+  const rmf_traffic::Trajectory& t2)
 {
   const auto conflicts_1 = get_conflicts(p1, t1, p2, t2);
   const auto conflicts_2 = get_conflicts(p2, t2, p1, t1);
 
   REQUIRE(conflicts_1.size() == conflicts_2.size());
   for (auto i_1 = conflicts_1.begin(), i_2 = conflicts_2.begin();
-       i_1 != conflicts_1.end(); i_1++, i_2++)
+    i_1 != conflicts_1.end(); i_1++, i_2++)
   {
     CHECK(i_1->time == i_2->time);
     rmf_traffic::Trajectory::const_iterator conflict_1_t1 = i_1->a_it;
@@ -68,43 +68,45 @@ inline void CHECK_between_is_commutative(
 
 //==============================================================================
 inline void CHECK_ConflictData(
-    const ConflictData& data,
-    const rmf_traffic::Time start_time,
-    const rmf_traffic::Time expected_conflict_time,
-    rmf_traffic::Trajectory::const_iterator t1_expected_conflict_segment,
-    rmf_traffic::Trajectory::const_iterator t2_expected_conflict_segment,
-    const double error_margin)
+  const ConflictData& data,
+  const rmf_traffic::Time start_time,
+  const rmf_traffic::Time expected_conflict_time,
+  rmf_traffic::Trajectory::const_iterator t1_expected_conflict_segment,
+  rmf_traffic::Trajectory::const_iterator t2_expected_conflict_segment,
+  const double error_margin)
 {
-    // t1 and t2 are precisely pointing to the Trajectory segments we are trying to verify,
-    // Not a "mock up" waypoint created separately
-    // Note that the const_iterators should not be the first in a trajectory: ie trajectory.begin()
-    // ConflictData will not return the first iterator as it only represents a point in time and cannot "conflict"
+  // t1 and t2 are precisely pointing to the Trajectory segments we are trying to verify,
+  // Not a "mock up" waypoint created separately
+  // Note that the const_iterators should not be the first in a trajectory: ie trajectory.begin()
+  // ConflictData will not return the first iterator as it only represents a point in time and cannot "conflict"
 
-    rmf_traffic::Trajectory::const_iterator t1_conflict_segment = data.a_it;
-    rmf_traffic::Trajectory::const_iterator t2_conflict_segment = data.b_it;
-    CHECK(t1_conflict_segment == t1_expected_conflict_segment);
-    CHECK(t2_conflict_segment == t2_expected_conflict_segment);
+  rmf_traffic::Trajectory::const_iterator t1_conflict_segment = data.a_it;
+  rmf_traffic::Trajectory::const_iterator t2_conflict_segment = data.b_it;
+  CHECK(t1_conflict_segment == t1_expected_conflict_segment);
+  CHECK(t2_conflict_segment == t2_expected_conflict_segment);
 
-    // We can only test for approximate accuracies due to the numerical nature of FCL
-    const double expected_duration = rmf_traffic::time::to_seconds(expected_conflict_time - start_time);
-    const double computed_duration = rmf_traffic::time::to_seconds(data.time - start_time);
-    CHECK(computed_duration == Approx(expected_duration).margin(error_margin));
+  // We can only test for approximate accuracies due to the numerical nature of FCL
+  const double expected_duration = rmf_traffic::time::to_seconds(
+    expected_conflict_time - start_time);
+  const double computed_duration = rmf_traffic::time::to_seconds(
+    data.time - start_time);
+  CHECK(computed_duration == Approx(expected_duration).margin(error_margin));
 }
 
 //==============================================================================
 struct ConflictDataParams
 {
-    const rmf_traffic::Time start_time;
-    const rmf_traffic::Time expected_conflict_time;
-    rmf_traffic::Trajectory::const_iterator t1_expected_conflict_segment;
-    rmf_traffic::Trajectory::const_iterator t2_expected_conflict_segment;
-    const double error_margin;
+  const rmf_traffic::Time start_time;
+  const rmf_traffic::Time expected_conflict_time;
+  rmf_traffic::Trajectory::const_iterator t1_expected_conflict_segment;
+  rmf_traffic::Trajectory::const_iterator t2_expected_conflict_segment;
+  const double error_margin;
 };
 
 //==============================================================================
 inline void CHECK_ConflictList(
-    const std::vector<ConflictData>& computed_conflicts,
-    const std::vector<ConflictDataParams>& expected_conflicts)
+  const std::vector<ConflictData>& computed_conflicts,
+  const std::vector<ConflictDataParams>& expected_conflicts)
 {
   REQUIRE(computed_conflicts.size() == computed_conflicts.size());
   auto c_it = computed_conflicts.begin();
@@ -115,24 +117,24 @@ inline void CHECK_ConflictList(
     // unpack
     const rmf_traffic::Time start_time = exp_it->start_time;
     const rmf_traffic::Time expected_conflict_time =
-        exp_it->expected_conflict_time;
+      exp_it->expected_conflict_time;
 
     const auto t1_expected_conflict_segment =
-        exp_it->t1_expected_conflict_segment;
+      exp_it->t1_expected_conflict_segment;
 
     const auto t2_expected_conflict_segment =
-        exp_it->t2_expected_conflict_segment;
+      exp_it->t2_expected_conflict_segment;
 
     ConflictData data = *c_it;
     const double error_margin = exp_it->error_margin;
 
     CHECK_ConflictData(
-          data,
-          start_time,
-          expected_conflict_time,
-          t1_expected_conflict_segment,
-          t2_expected_conflict_segment,
-          error_margin);
+      data,
+      start_time,
+      expected_conflict_time,
+      t1_expected_conflict_segment,
+      t2_expected_conflict_segment,
+      error_margin);
   }
 }
 

--- a/rmf_traffic/test/unit/utils_Trajectory.hpp
+++ b/rmf_traffic/test/unit/utils_Trajectory.hpp
@@ -38,10 +38,10 @@ inline rmf_traffic::Profile create_test_profile(TestProfileType shape_type)
 
   if (UnitBox == shape_type)
     shape = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Box>(1.0, 1.0);
+      rmf_traffic::geometry::Box>(1.0, 1.0);
   else if (UnitCircle == shape_type)
     shape = rmf_traffic::geometry::make_final_convex<
-        rmf_traffic::geometry::Circle>(1.0);
+      rmf_traffic::geometry::Circle>(1.0);
 
   return rmf_traffic::Profile(shape, shape);
 }
@@ -64,7 +64,7 @@ inline rmf_traffic::Trajectory create_test_trajectory()
 
 //==============================================================================
 inline rmf_traffic::Trajectory create_test_trajectory(
-    std::vector<TrajectoryInsertInput> param_list)
+  std::vector<TrajectoryInsertInput> param_list)
 {
   rmf_traffic::Trajectory trajectory;
   for (auto x : param_list)

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -21,6 +21,17 @@ find_package(rmf_fleet_msgs REQUIRED)
 # TODO(MXG): Consider splitting off the components that depend on yaml-cpp
 find_package(yaml-cpp REQUIRED)
 
+if(BUILD_TESTING)
+  find_package(rmf_cmake_uncrustify REQUIRED)
+  find_file(uncrustify_config_file NAMES "share/format/rmf_code_style.cfg")
+                
+  rmf_uncrustify(
+    ARGN include src examples
+    CONFIG_FILE ${uncrustify_config_file}
+    MAX_LINE_LENGTH 80
+  )
+endif()
+
 file(GLOB_RECURSE core_lib_srcs "src/rmf_traffic_ros2/*.cpp")
 add_library(rmf_traffic_ros2 SHARED ${core_lib_srcs})
 

--- a/rmf_traffic_ros2/examples/participant_node.cpp
+++ b/rmf_traffic_ros2/examples/participant_node.cpp
@@ -28,7 +28,7 @@ class ParticipantNode : public rclcpp::Node
 public:
 
   ParticipantNode()
-    : rclcpp::Node("schedule_participant_node")
+  : rclcpp::Node("schedule_participant_node")
   {
     writer = rmf_traffic_ros2::schedule::Writer::make(*this);
   }
@@ -44,7 +44,7 @@ std::shared_ptr<ParticipantNode> make_node()
 {
   auto node = std::make_shared<ParticipantNode>();
 
-  while(!node->writer->ready())
+  while (!node->writer->ready())
     rclcpp::spin_some(node);
 
   using namespace std::chrono_literals;
@@ -65,13 +65,13 @@ std::shared_ptr<ParticipantNode> make_node()
   t.insert(now + 10s, {0, 10, 0}, {0, 0, 0});
 
   node->writer->async_make_participant(
-        std::move(description),
-        [node, t = std::move(t)](rmf_traffic::schedule::Participant participant)
-  {
-    node->participant = std::move(participant);
-    std::cout << "Sending trajectory" << std::endl;
-    node->participant->set({{"test map", std::move(t)}});
-  });
+    std::move(description),
+    [node, t = std::move(t)](rmf_traffic::schedule::Participant participant)
+    {
+      node->participant = std::move(participant);
+      std::cout << "Sending trajectory" << std::endl;
+      node->participant->set({{"test map", std::move(t)}});
+    });
 
   return node;
 }

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/Route.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/Route.hpp
@@ -29,10 +29,10 @@ rmf_traffic_msgs::msg::Route convert(const rmf_traffic::Route& from);
 
 //==============================================================================
 std::vector<rmf_traffic::Route> convert(
-    const std::vector<rmf_traffic_msgs::msg::Route>& from);
+  const std::vector<rmf_traffic_msgs::msg::Route>& from);
 
 //==============================================================================
 std::vector<rmf_traffic_msgs::msg::Route> convert(
-    const std::vector<rmf_traffic::Route>& from);
+  const std::vector<rmf_traffic::Route>& from);
 
 } // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/StandardNames.hpp
@@ -29,18 +29,26 @@ const std::string ItineraryDelayTopicName = Prefix + "itinerary_delay";
 const std::string ItineraryEraseTopicName = Prefix + "itinerary_erase";
 const std::string ItineraryClearTopicName = Prefix + "itinerary_clear";
 const std::string RegisterParticipantSrvName = Prefix + "register_participant";
-const std::string UnregisterParticipantSrvName = Prefix + "unregister_participant";
+const std::string UnregisterParticipantSrvName = Prefix +
+  "unregister_participant";
 const std::string RegisterQueryServiceName = Prefix + "register_query";
 const std::string UnregisterQueryServiceName = Prefix + "unregister_query";
 const std::string MirrorUpdateServiceName = Prefix + "mirror_update";
 const std::string MirrorWakeupTopicName = Prefix + "mirror_wakeup";
-const std::string ScheduleInconsistencyTopicName = Prefix + "schedule_inconsistency";
-const std::string ScheduleConflictAckTopicName = Prefix + "schedule_conflict_ack";
-const std::string ScheduleConflictRepeatTopicName = Prefix + "schedule_conflict_repeat";
-const std::string ScheduleConflictNoticeTopicName = Prefix + "schedule_conflict_notice";
-const std::string ScheduleConflictProposalTopicName = Prefix + "schedule_conflict_proposal";
-const std::string ScheduleConflictRejectionTopicName = Prefix + "schedule_conflict_rejection";
-const std::string ScheduleConflictConclusionTopicName = Prefix + "schedule_conflict_conclusion";
+const std::string ScheduleInconsistencyTopicName = Prefix +
+  "schedule_inconsistency";
+const std::string ScheduleConflictAckTopicName = Prefix +
+  "schedule_conflict_ack";
+const std::string ScheduleConflictRepeatTopicName = Prefix +
+  "schedule_conflict_repeat";
+const std::string ScheduleConflictNoticeTopicName = Prefix +
+  "schedule_conflict_notice";
+const std::string ScheduleConflictProposalTopicName = Prefix +
+  "schedule_conflict_proposal";
+const std::string ScheduleConflictRejectionTopicName = Prefix +
+  "schedule_conflict_rejection";
+const std::string ScheduleConflictConclusionTopicName = Prefix +
+  "schedule_conflict_conclusion";
 
 const std::string EmergencyTopicName = "fire_alarm_trigger";
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/geometry/Circle.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/geometry/Circle.hpp
@@ -26,11 +26,11 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic_msgs::msg::Circle convert(
-    const rmf_traffic::geometry::Circle& circle);
+  const rmf_traffic::geometry::Circle& circle);
 
 //==============================================================================
 rmf_traffic::geometry::Circle convert(
-    const rmf_traffic_msgs::msg::Circle& circle);
+  const rmf_traffic_msgs::msg::Circle& circle);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/geometry/ConvexShape.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/geometry/ConvexShape.hpp
@@ -34,10 +34,10 @@ public:
   ConvexShapeContext();
 
   rmf_traffic_msgs::msg::ConvexShape insert(
-      rmf_traffic::geometry::ConstFinalConvexShapePtr shape);
+    rmf_traffic::geometry::ConstFinalConvexShapePtr shape);
 
   rmf_traffic::geometry::ConstFinalConvexShapePtr at(
-      const rmf_traffic_msgs::msg::ConvexShape& shape) const;
+    const rmf_traffic_msgs::msg::ConvexShape& shape) const;
 
   class Implementation;
 private:
@@ -48,11 +48,11 @@ private:
 
 //==============================================================================
 geometry::ConvexShapeContext convert(
-    const rmf_traffic_msgs::msg::ConvexShapeContext& from);
+  const rmf_traffic_msgs::msg::ConvexShapeContext& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ConvexShapeContext convert(
-    const geometry::ConvexShapeContext& from);
+  const geometry::ConvexShapeContext& from);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/geometry/Shape.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/geometry/Shape.hpp
@@ -34,10 +34,10 @@ public:
   ShapeContext();
 
   rmf_traffic_msgs::msg::Shape insert(
-      rmf_traffic::geometry::ConstFinalShapePtr shape);
+    rmf_traffic::geometry::ConstFinalShapePtr shape);
 
   rmf_traffic::geometry::ConstFinalShapePtr at(
-      const rmf_traffic_msgs::msg::Shape& shape) const;
+    const rmf_traffic_msgs::msg::Shape& shape) const;
 
   class Implementation;
 private:
@@ -48,11 +48,11 @@ private:
 
 //==============================================================================
 geometry::ShapeContext convert(
-    const rmf_traffic_msgs::msg::ShapeContext& from);
+  const rmf_traffic_msgs::msg::ShapeContext& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ShapeContext convert(
-    const geometry::ShapeContext& from);
+  const geometry::ShapeContext& from);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Change.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Change.hpp
@@ -29,19 +29,19 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::schedule::Change::Add::Item convert(
-    const rmf_traffic_msgs::msg::ScheduleChangeAdd& from);
+  const rmf_traffic_msgs::msg::ScheduleChangeAdd& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleChangeAdd convert(
-    const rmf_traffic::schedule::Change::Add::Item& from);
+  const rmf_traffic::schedule::Change::Add::Item& from);
 
 //==============================================================================
 rmf_traffic::schedule::Change::Delay convert(
-    const rmf_traffic_msgs::msg::ScheduleChangeDelay& from);
+  const rmf_traffic_msgs::msg::ScheduleChangeDelay& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleChangeDelay convert(
-    const rmf_traffic::schedule::Change::Delay& from);
+  const rmf_traffic::schedule::Change::Delay& from);
 
 //==============================================================================
 // TODO(MXG): Fix this. This function does not make much sense because of the
@@ -59,23 +59,23 @@ rmf_traffic_msgs::msg::ScheduleChangeDelay convert(
 
 //==============================================================================
 rmf_traffic::schedule::Change::RegisterParticipant convert(
-    const rmf_traffic_msgs::msg::ScheduleRegister& from);
+  const rmf_traffic_msgs::msg::ScheduleRegister& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleRegister convert(
-    const rmf_traffic::schedule::Change::RegisterParticipant& from);
+  const rmf_traffic::schedule::Change::RegisterParticipant& from);
 
 //==============================================================================
 rmf_traffic::schedule::ParticipantId convert(
-    const rmf_traffic::schedule::Change::UnregisterParticipant& from);
+  const rmf_traffic::schedule::Change::UnregisterParticipant& from);
 
 //==============================================================================
 rmf_traffic::schedule::Change::Cull convert(
-    const rmf_traffic_msgs::msg::ScheduleChangeCull& from);
+  const rmf_traffic_msgs::msg::ScheduleChangeCull& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleChangeCull convert(
-    const rmf_traffic::schedule::Change::Cull& from);
+  const rmf_traffic::schedule::Change::Cull& from);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Inconsistencies.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Inconsistencies.hpp
@@ -25,7 +25,7 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleInconsistency convert(
-    const rmf_traffic::schedule::Inconsistencies::Element& from);
+  const rmf_traffic::schedule::Inconsistencies::Element& from);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Itinerary.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Itinerary.hpp
@@ -25,7 +25,7 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 std::vector<rmf_traffic_msgs::msg::Route> convert(
-    const rmf_traffic::schedule::Itinerary& from);
+  const rmf_traffic::schedule::Itinerary& from);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/MirrorManager.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/MirrorManager.hpp
@@ -45,8 +45,8 @@ public:
     ///   Specify if the mirror should perform an update whenever it gets woken
     ///   up by the schedule.
     Options(
-        std::mutex* update_mutex = nullptr,
-        bool update_on_wakeup = true);
+      std::mutex* update_mutex = nullptr,
+      bool update_on_wakeup = true);
 
     /// Get a reference to the mutex that will be used when performing an
     /// update.
@@ -152,8 +152,8 @@ private:
 // TODO(MXG): Use std::optional here instead of std::unique_ptr when C++17 can
 // be supported.
 MirrorManagerFuture make_mirror(rclcpp::Node& node,
-    rmf_traffic::schedule::Query query,
-    MirrorManager::Options options = MirrorManager::Options());
+  rmf_traffic::schedule::Query query,
+  MirrorManager::Options options = MirrorManager::Options());
 
 } // namespace schedule
 } // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Negotiation.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Negotiation.hpp
@@ -37,8 +37,8 @@ public:
 
   /// Constructor
   Negotiation(
-      rclcpp::Node& node,
-      const rmf_traffic::schedule::Viewer& viewer);
+    rclcpp::Node& node,
+    const rmf_traffic::schedule::Viewer& viewer);
 
   /// Register a negotiator with this Negotiation manager.
   ///
@@ -51,8 +51,8 @@ public:
   /// \return a handle that should be kept by the caller. When this handle
   /// expires, this negotiator will be automatically unregistered.
   std::shared_ptr<void> register_negotiator(
-      rmf_traffic::schedule::ParticipantId for_participant,
-      std::unique_ptr<rmf_traffic::schedule::Negotiator> negotiator);
+    rmf_traffic::schedule::ParticipantId for_participant,
+    std::unique_ptr<rmf_traffic::schedule::Negotiator> negotiator);
 
   class Implementation;
 private:

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/ParticipantDescription.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/ParticipantDescription.hpp
@@ -26,11 +26,11 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::schedule::ParticipantDescription convert(
-    const rmf_traffic_msgs::msg::ParticipantDescription& from);
+  const rmf_traffic_msgs::msg::ParticipantDescription& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ParticipantDescription convert(
-    const rmf_traffic::schedule::ParticipantDescription& from);
+  const rmf_traffic::schedule::ParticipantDescription& from);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Patch.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Patch.hpp
@@ -26,11 +26,11 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic_msgs::msg::SchedulePatch convert(
-    const rmf_traffic::schedule::Patch& from);
+  const rmf_traffic::schedule::Patch& from);
 
 //==============================================================================
 rmf_traffic::schedule::Patch convert(
-    const rmf_traffic_msgs::msg::SchedulePatch& from);
+  const rmf_traffic_msgs::msg::SchedulePatch& from);
 
 } // nmaespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Query.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Query.hpp
@@ -26,27 +26,27 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::schedule::Query::Spacetime convert(
-    const rmf_traffic_msgs::msg::ScheduleQuerySpacetime& from);
+  const rmf_traffic_msgs::msg::ScheduleQuerySpacetime& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleQuerySpacetime convert(
-    const rmf_traffic::schedule::Query::Spacetime& from);
+  const rmf_traffic::schedule::Query::Spacetime& from);
 
 //==============================================================================
 rmf_traffic::schedule::Query::Participants convert(
-    const rmf_traffic_msgs::msg::ScheduleQueryParticipants& from);
+  const rmf_traffic_msgs::msg::ScheduleQueryParticipants& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleQueryParticipants convert(
-    const rmf_traffic::schedule::Query::Participants& from);
+  const rmf_traffic::schedule::Query::Participants& from);
 
 //==============================================================================
 rmf_traffic::schedule::Query convert(
-    const rmf_traffic_msgs::msg::ScheduleQuery& from);
+  const rmf_traffic_msgs::msg::ScheduleQuery& from);
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleQuery convert(
-    const rmf_traffic::schedule::Query& from);
+  const rmf_traffic::schedule::Query& from);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Writer.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Writer.hpp
@@ -65,7 +65,7 @@ public:
   /// \param[in] description.
   ///   The description of the participant.
   std::future<rmf_traffic::schedule::Participant> make_participant(
-      rmf_traffic::schedule::ParticipantDescription description);
+    rmf_traffic::schedule::ParticipantDescription description);
 
   /// Asynchronously create a schedule participant.
   ///
@@ -78,8 +78,8 @@ public:
   /// \param[in] ready_callback
   ///   The callback that will be triggered when the participant is ready.
   void async_make_participant(
-      rmf_traffic::schedule::ParticipantDescription description,
-      std::function<void(rmf_traffic::schedule::Participant)> ready_callback);
+    rmf_traffic::schedule::ParticipantDescription description,
+    std::function<void(rmf_traffic::schedule::Participant)> ready_callback);
 
   class Implementation;
 private:
@@ -93,11 +93,11 @@ using WriterPtr = std::shared_ptr<Writer>;
 
 //==============================================================================
 rmf_traffic::schedule::Writer::Input convert(
-    const std::vector<rmf_traffic_msgs::msg::ScheduleWriterItem>& from);
+  const std::vector<rmf_traffic_msgs::msg::ScheduleWriterItem>& from);
 
 //==============================================================================
 std::vector<rmf_traffic_msgs::msg::ScheduleWriterItem> convert(
-    const rmf_traffic::schedule::Writer::Input& from);
+  const rmf_traffic::schedule::Writer::Input& from);
 
 } // namespace rmf_traffic_ros2
 

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Profile.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Profile.cpp
@@ -26,9 +26,9 @@ rmf_traffic::Profile convert(const rmf_traffic_msgs::msg::Profile& from)
   const geometry::ConvexShapeContext context = convert(from.shape_context);
 
   return rmf_traffic::Profile{
-      context.at(from.footprint),
-      context.at(from.vicinity)
-    };
+    context.at(from.footprint),
+    context.at(from.vicinity)
+  };
 }
 
 //==============================================================================

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Route.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Route.cpp
@@ -37,7 +37,7 @@ rmf_traffic_msgs::msg::Route convert(const rmf_traffic::Route& from)
 
 //==============================================================================
 std::vector<rmf_traffic::Route> convert(
-    const std::vector<rmf_traffic_msgs::msg::Route>& from)
+  const std::vector<rmf_traffic_msgs::msg::Route>& from)
 {
   std::vector<rmf_traffic::Route> output;
   for (const auto& msg : from)
@@ -48,7 +48,7 @@ std::vector<rmf_traffic::Route> convert(
 
 //==============================================================================
 std::vector<rmf_traffic_msgs::msg::Route> convert(
-    const std::vector<rmf_traffic::Route>& from)
+  const std::vector<rmf_traffic::Route>& from)
 {
   std::vector<rmf_traffic_msgs::msg::Route> output;
   for (const auto& msg : from)

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Time.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Time.cpp
@@ -31,8 +31,8 @@ builtin_interfaces::msg::Time convert(rmf_traffic::Time time)
 rmf_traffic::Time convert(builtin_interfaces::msg::Time time)
 {
   return std::chrono::steady_clock::time_point(
-        std::chrono::seconds(time.sec)
-        + std::chrono::nanoseconds(time.nanosec));
+    std::chrono::seconds(time.sec)
+    + std::chrono::nanoseconds(time.nanosec));
 }
 
 //==============================================================================
@@ -45,7 +45,7 @@ rclcpp::Time to_ros2(rmf_traffic::Time from)
 rmf_traffic::Time convert(rclcpp::Time from)
 {
   return std::chrono::steady_clock::time_point(
-        std::chrono::nanoseconds(from.nanoseconds()));
+    std::chrono::nanoseconds(from.nanoseconds()));
 }
 
 //==============================================================================

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Trajectory.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/convert_Trajectory.cpp
@@ -46,9 +46,9 @@ rmf_traffic::Trajectory convert(const rmf_traffic_msgs::msg::Trajectory& from)
   for (const auto& waypoint : from.waypoints)
   {
     output.insert(
-          rmf_traffic::Time(rmf_traffic::Duration(waypoint.time)),
-          to_eigen(waypoint.position),
-          to_eigen(waypoint.velocity));
+      rmf_traffic::Time(rmf_traffic::Duration(waypoint.time)),
+      to_eigen(waypoint.position),
+      to_eigen(waypoint.velocity));
   }
 
   return output;
@@ -57,7 +57,7 @@ rmf_traffic::Trajectory convert(const rmf_traffic_msgs::msg::Trajectory& from)
 namespace {
 //==============================================================================
 rmf_traffic_msgs::msg::TrajectoryWaypoint convert_waypoint(
-    const rmf_traffic::Trajectory::Waypoint& from)
+  const rmf_traffic::Trajectory::Waypoint& from)
 {
   rmf_traffic_msgs::msg::TrajectoryWaypoint output;
   output.time = from.time().time_since_epoch().count();

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/Circle.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/Circle.cpp
@@ -21,7 +21,7 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic_msgs::msg::Circle convert(
-    const rmf_traffic::geometry::Circle& circle)
+  const rmf_traffic::geometry::Circle& circle)
 {
   rmf_traffic_msgs::msg::Circle output;
   output.radius = circle.get_radius();
@@ -30,7 +30,7 @@ rmf_traffic_msgs::msg::Circle convert(
 
 //==============================================================================
 rmf_traffic::geometry::Circle convert(
-    const rmf_traffic_msgs::msg::Circle& circle)
+  const rmf_traffic_msgs::msg::Circle& circle)
 {
   return rmf_traffic::geometry::Circle(circle.radius);
 }

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/ConvexShape.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/ConvexShape.cpp
@@ -26,25 +26,26 @@ namespace geometry {
 
 //==============================================================================
 class ConvexShapeContext::Implementation
-    : public internal::ShapeContextImpl<
-        rmf_traffic::geometry::FinalConvexShape,
-        rmf_traffic_msgs::msg::ConvexShape,
-        rmf_traffic_msgs::msg::ConvexShapeContext>
+  : public internal::ShapeContextImpl<
+    rmf_traffic::geometry::FinalConvexShape,
+    rmf_traffic_msgs::msg::ConvexShape,
+    rmf_traffic_msgs::msg::ConvexShapeContext>
 {
 public:
 
   Implementation()
   {
-    if(!initialized)
+    if (!initialized)
     {
       // TODO(MXG): Reconsider this design. Static initialization of singletons
       // seems too error prone with too little benefit. A template-based
       // implementation may be preferable.
       std::lock_guard<std::mutex> lock(initialization_mutex);
-      if(!initialized)
+      if (!initialized)
       {
         add<rmf_traffic::geometry::Box>(rmf_traffic_msgs::msg::ConvexShape::BOX);
-        add<rmf_traffic::geometry::Circle>(rmf_traffic_msgs::msg::ConvexShape::CIRCLE);
+        add<rmf_traffic::geometry::Circle>(
+          rmf_traffic_msgs::msg::ConvexShape::CIRCLE);
         initialized = true;
       }
     }
@@ -60,21 +61,21 @@ public:
 
 //==============================================================================
 ConvexShapeContext::ConvexShapeContext()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
 
 //==============================================================================
 rmf_traffic_msgs::msg::ConvexShape ConvexShapeContext::insert(
-    rmf_traffic::geometry::ConstFinalConvexShapePtr shape)
+  rmf_traffic::geometry::ConstFinalConvexShapePtr shape)
 {
   return _pimpl->insert(std::move(shape));
 }
 
 //==============================================================================
 rmf_traffic::geometry::ConstFinalConvexShapePtr ConvexShapeContext::at(
-    const rmf_traffic_msgs::msg::ConvexShape& shape) const
+  const rmf_traffic_msgs::msg::ConvexShape& shape) const
 {
   return _pimpl->at(shape);
 }
@@ -83,15 +84,15 @@ rmf_traffic::geometry::ConstFinalConvexShapePtr ConvexShapeContext::at(
 
 //==============================================================================
 geometry::ConvexShapeContext convert(
-    const rmf_traffic_msgs::msg::ConvexShapeContext& from)
+  const rmf_traffic_msgs::msg::ConvexShapeContext& from)
 {
   using namespace rmf_traffic::geometry;
 
   geometry::ConvexShapeContext context;
-  for(const auto& box : from.boxes)
+  for (const auto& box : from.boxes)
     context.insert(make_final_convex<Box>(convert(box)));
 
-  for(const auto& circle : from.circles)
+  for (const auto& circle : from.circles)
     context.insert(make_final_convex<Circle>(convert(circle)));
 
   return context;
@@ -99,7 +100,7 @@ geometry::ConvexShapeContext convert(
 
 //==============================================================================
 rmf_traffic_msgs::msg::ConvexShapeContext convert(
-    const geometry::ConvexShapeContext& _from)
+  const geometry::ConvexShapeContext& _from)
 {
   using rmf_traffic_msgs::msg::ConvexShape;
   using namespace rmf_traffic::geometry;
@@ -108,11 +109,12 @@ rmf_traffic_msgs::msg::ConvexShapeContext convert(
 
   rmf_traffic_msgs::msg::ConvexShapeContext context;
 
-  for(const auto& box : from.shapes.at(ConvexShape::BOX))
+  for (const auto& box : from.shapes.at(ConvexShape::BOX))
     context.boxes.emplace_back(convert(static_cast<const Box&>(box->source())));
 
-  for(const auto& circle : from.shapes.at(ConvexShape::CIRCLE))
-    context.circles.emplace_back(convert(static_cast<const Circle&>(circle->source())));
+  for (const auto& circle : from.shapes.at(ConvexShape::CIRCLE))
+    context.circles.emplace_back(convert(static_cast<const Circle&>(circle->
+      source())));
 
   return context;
 }

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/Shape.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/Shape.cpp
@@ -26,22 +26,22 @@ namespace geometry {
 
 //==============================================================================
 class ShapeContext::Implementation
-    : public internal::ShapeContextImpl<
-        rmf_traffic::geometry::FinalShape,
-        rmf_traffic_msgs::msg::Shape,
-        rmf_traffic_msgs::msg::ShapeContext>
+  : public internal::ShapeContextImpl<
+    rmf_traffic::geometry::FinalShape,
+    rmf_traffic_msgs::msg::Shape,
+    rmf_traffic_msgs::msg::ShapeContext>
 {
 public:
 
   Implementation()
   {
-    if(!initialized)
+    if (!initialized)
     {
       // TODO(MXG): Reconsider this design. Static initialization of singletons
       // seems too error prone with too little benefit. A template-based
       // implementation may be preferable.
       std::lock_guard<std::mutex> lock(initialization_mutex);
-      if(!initialized)
+      if (!initialized)
       {
         add<rmf_traffic::geometry::Box>(rmf_traffic_msgs::msg::Shape::BOX);
         add<rmf_traffic::geometry::Circle>(rmf_traffic_msgs::msg::Shape::CIRCLE);
@@ -60,21 +60,21 @@ public:
 
 //==============================================================================
 ShapeContext::ShapeContext()
-  : _pimpl(rmf_utils::make_impl<Implementation>())
+: _pimpl(rmf_utils::make_impl<Implementation>())
 {
   // Do nothing
 }
 
 //==============================================================================
 rmf_traffic_msgs::msg::Shape ShapeContext::insert(
-    rmf_traffic::geometry::ConstFinalShapePtr shape)
+  rmf_traffic::geometry::ConstFinalShapePtr shape)
 {
   return _pimpl->insert(std::move(shape));
 }
 
 //==============================================================================
 rmf_traffic::geometry::ConstFinalShapePtr ShapeContext::at(
-    const rmf_traffic_msgs::msg::Shape& shape) const
+  const rmf_traffic_msgs::msg::Shape& shape) const
 {
   return _pimpl->at(shape);
 }
@@ -83,15 +83,15 @@ rmf_traffic::geometry::ConstFinalShapePtr ShapeContext::at(
 
 //==============================================================================
 geometry::ShapeContext convert(
-    const rmf_traffic_msgs::msg::ShapeContext& from)
+  const rmf_traffic_msgs::msg::ShapeContext& from)
 {
   using namespace rmf_traffic::geometry;
 
   geometry::ShapeContext context;
-  for(const auto& box : from.convex_shapes.boxes)
+  for (const auto& box : from.convex_shapes.boxes)
     context.insert(make_final<Box>(convert(box)));
 
-  for(const auto& circle : from.convex_shapes.circles)
+  for (const auto& circle : from.convex_shapes.circles)
     context.insert(make_final<Circle>(convert(circle)));
 
   // TODO(MXG): Add SimplePolygon here once we're ready to support it
@@ -101,7 +101,7 @@ geometry::ShapeContext convert(
 
 //==============================================================================
 rmf_traffic_msgs::msg::ShapeContext convert(
-    const geometry::ShapeContext& _from)
+  const geometry::ShapeContext& _from)
 {
   using rmf_traffic_msgs::msg::Shape;
   using namespace rmf_traffic::geometry;
@@ -113,16 +113,16 @@ rmf_traffic_msgs::msg::ShapeContext convert(
   // TODO(MXG): Consider how this can be refactored to share the same code as
   // convert(ConvexShapeContext)
 
-  for(const auto& box : from.shapes.at(Shape::BOX))
+  for (const auto& box : from.shapes.at(Shape::BOX))
   {
     context.convex_shapes.boxes.emplace_back(
-          convert(static_cast<const Box&>(box->source())));
+      convert(static_cast<const Box&>(box->source())));
   }
 
-  for(const auto& circle : from.shapes.at(Shape::CIRCLE))
+  for (const auto& circle : from.shapes.at(Shape::CIRCLE))
   {
     context.convex_shapes.circles.emplace_back(
-          convert(static_cast<const Circle&>(circle->source())));
+      convert(static_cast<const Circle&>(circle->source())));
   }
 
   // TODO(MXG): Add SimplePolygon here once we're ready to support it

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/ShapeInternal.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/geometry/ShapeInternal.hpp
@@ -55,21 +55,21 @@ public:
   static std::vector<Caster> casters;
   static std::size_t num_shape_types;
 
-  ShapeContextImpl() { }
+  ShapeContextImpl() {}
 
   template<typename DerivedShape>
   void add(const std::size_t type_index)
   {
     casters.push_back(
-          [=](const ShapeTypePtr& shape) -> std::size_t
-    {
-      if(dynamic_cast<const DerivedShape*>(&shape->source()))
-        return type_index;
+      [=](const ShapeTypePtr& shape) -> std::size_t
+      {
+        if (dynamic_cast<const DerivedShape*>(&shape->source()))
+          return type_index;
 
-      return 0;
-    });
+        return 0;
+      });
 
-    if(type_index >= num_shape_types)
+    if (type_index >= num_shape_types)
     {
       num_shape_types = type_index+1;
       shapes.resize(num_shape_types);
@@ -78,18 +78,20 @@ public:
 
   std::size_t get_type_index(const ShapeTypePtr& shape)
   {
-    for(const auto& caster : casters)
+    for (const auto& caster : casters)
     {
       const std::size_t cast = caster(shape);
-      if(cast != 0)
+      if (cast != 0)
         return cast;
     }
 
+    // *INDENT-OFF*
     throw std::runtime_error(
-          std::string()
-          + "Failed to find a shape context type index for type ["
-          + typeid(shape->source()).name() + "] with base type ["
-          + typeid(ShapeType).name() + "]");
+      std::string()
+      + "Failed to find a shape context type index for type ["
+      + typeid(shape->source()).name() + "] with base type ["
+      + typeid(ShapeType).name() + "]");
+    // *INDENT-ON*
   }
 
   ShapeMsgType insert(ShapeTypePtr shape)
@@ -103,11 +105,11 @@ public:
     }
 
     const auto insertion =
-        entry_map.insert(std::make_pair(shape, Entry{}));
+      entry_map.insert(std::make_pair(shape, Entry{}));
 
     const bool inserted = insertion.second;
     Entry& entry = insertion.first->second;
-    if(inserted)
+    if (inserted)
     {
       entry.type = get_type_index(shape);
 

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Negotiation.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Negotiation.cpp
@@ -36,7 +36,7 @@ namespace rmf_traffic_ros2 {
 namespace schedule {
 
 std::string table_to_string(
-    const std::vector<rmf_traffic::schedule::ParticipantId>& table)
+  const std::vector<rmf_traffic::schedule::ParticipantId>& table)
 {
   std::string output;
   for (const auto p : table)
@@ -58,22 +58,23 @@ public:
     const rmf_traffic::schedule::Negotiation::TablePtr table;
 
     Responder(
-        Implementation* const impl_,
-        const rmf_traffic::schedule::Version version_,
-        rmf_traffic::schedule::Negotiation::TablePtr table_)
-      : impl(impl_),
-        conflict_version(version_),
-        table(table_)
+      Implementation* const impl_,
+      const rmf_traffic::schedule::Version version_,
+      rmf_traffic::schedule::Negotiation::TablePtr table_)
+    : impl(impl_),
+      conflict_version(version_),
+      table(table_)
     {
       // Do nothing
     }
 
     void submit(
-        std::vector<rmf_traffic::Route> itinerary,
-        std::function<UpdateVersion()> approval_callback) const final
+      std::vector<rmf_traffic::Route> itinerary,
+      std::function<UpdateVersion()> approval_callback) const final
     {
       const auto* last_version = table->version();
-      const bool accepted = table->submit(itinerary, last_version? *last_version+1 : 0);
+      const bool accepted = table->submit(itinerary,
+          last_version ? *last_version+1 : 0);
       assert(accepted);
       (void)(accepted);
       impl->approvals[conflict_version][table] = std::move(approval_callback);
@@ -96,7 +97,7 @@ public:
         // This means that the whole negotiation is completely impossible.
         // TODO(MXG): Improve this by having the planner reveal what vehicle is
         // blocking progress so we can add it to the negotiation
-        table->reject(table->version()? *table->version() : 0);
+        table->reject(table->version() ? *table->version() : 0);
         impl->publish_rejection(conflict_version, *table);
       }
     }
@@ -162,69 +163,70 @@ public:
   using TablePtr = rmf_traffic::schedule::Negotiation::TablePtr;
   using ItineraryVersion = rmf_traffic::schedule::ItineraryVersion;
   using UpdateVersion = rmf_utils::optional<ItineraryVersion>;
-  using ApprovalCallbackMap = std::unordered_map<TablePtr, std::function<UpdateVersion()>>;
+  using ApprovalCallbackMap = std::unordered_map<TablePtr,
+      std::function<UpdateVersion()>>;
   using Approvals = std::unordered_map<Version, ApprovalCallbackMap>;
   Approvals approvals;
 
   Implementation(
-      rclcpp::Node& node_,
-      const rmf_traffic::schedule::Viewer& viewer_)
-    : node(node_),
-      viewer(viewer_),
-      negotiators(std::make_shared<NegotiatorMap>())
+    rclcpp::Node& node_,
+    const rmf_traffic::schedule::Viewer& viewer_)
+  : node(node_),
+    viewer(viewer_),
+    negotiators(std::make_shared<NegotiatorMap>())
   {
     // TODO(MXG): Make the QoS configurable
     const auto qos = rclcpp::ServicesQoS().reliable();
 
     repeat_sub = node.create_subscription<Repeat>(
-          ScheduleConflictRepeatTopicName, qos,
-          [&](const Repeat::UniquePtr msg)
-    {
-      this->receive_repeat_request(*msg);
-    });
+      ScheduleConflictRepeatTopicName, qos,
+      [&](const Repeat::UniquePtr msg)
+      {
+        this->receive_repeat_request(*msg);
+      });
 
     repeat_pub = node.create_publisher<Repeat>(
-          ScheduleConflictRepeatTopicName, qos);
+      ScheduleConflictRepeatTopicName, qos);
 
     notice_sub = node.create_subscription<Notice>(
-          ScheduleConflictNoticeTopicName, qos,
-          [&](const Notice::UniquePtr msg)
-    {
-      this->receive_notice(*msg);
-    });
+      ScheduleConflictNoticeTopicName, qos,
+      [&](const Notice::UniquePtr msg)
+      {
+        this->receive_notice(*msg);
+      });
 
     notice_pub = node.create_publisher<Notice>(
-          ScheduleConflictNoticeTopicName, qos);
+      ScheduleConflictNoticeTopicName, qos);
 
     proposal_sub = node.create_subscription<Proposal>(
-          ScheduleConflictProposalTopicName, qos,
-          [&](const Proposal::UniquePtr msg)
-    {
-      this->receive_proposal(*msg);
-    });
+      ScheduleConflictProposalTopicName, qos,
+      [&](const Proposal::UniquePtr msg)
+      {
+        this->receive_proposal(*msg);
+      });
 
     proposal_pub = node.create_publisher<Proposal>(
-          ScheduleConflictProposalTopicName, qos);
+      ScheduleConflictProposalTopicName, qos);
 
     rejection_sub = node.create_subscription<Rejection>(
-          ScheduleConflictRejectionTopicName, qos,
-          [&](const Rejection::UniquePtr msg)
-    {
-      this->receive_rejection(*msg);
-    });
+      ScheduleConflictRejectionTopicName, qos,
+      [&](const Rejection::UniquePtr msg)
+      {
+        this->receive_rejection(*msg);
+      });
 
     rejection_pub = node.create_publisher<Rejection>(
-          ScheduleConflictRejectionTopicName, qos);
+      ScheduleConflictRejectionTopicName, qos);
 
     conclusion_sub = node.create_subscription<Conclusion>(
-          ScheduleConflictConclusionTopicName, qos,
-          [&](const Conclusion::UniquePtr msg)
-    {
-      this->receive_conclusion(*msg);
-    });
+      ScheduleConflictConclusionTopicName, qos,
+      [&](const Conclusion::UniquePtr msg)
+      {
+        this->receive_conclusion(*msg);
+      });
 
     ack_pub = node.create_publisher<Ack>(
-          ScheduleConflictAckTopicName, qos);
+      ScheduleConflictAckTopicName, qos);
   }
 
   void receive_repeat_request(const Repeat& msg)
@@ -252,14 +254,14 @@ public:
     to_accommodate.pop_back();
 
     const auto table = negotiate_it->second.room.negotiation.table(
-          for_participant, to_accommodate);
+      for_participant, to_accommodate);
     if (!table)
     {
       std::string error =
-          "[rmf_traffic_ros2::schedule::Negotiation] A repeat was requested "
-          "for a table that does not exist. Negotiation ["
-          + std::to_string(msg.conflict_version) + "], table ["
-          + table_to_string(msg.table) + " ]";
+        "[rmf_traffic_ros2::schedule::Negotiation] A repeat was requested "
+        "for a table that does not exist. Negotiation ["
+        + std::to_string(msg.conflict_version) + "], table ["
+        + table_to_string(msg.table) + " ]";
 
       RCLCPP_WARN(node.get_logger(), error);
 
@@ -282,8 +284,8 @@ public:
     }
 
     const auto insertion = negotiations.insert(
-        {msg.conflict_version,
-         Entry{relevant, Negotiation(viewer, msg.participants)}});
+      {msg.conflict_version,
+        Entry{relevant, Negotiation(viewer, msg.participants)}});
 
     const bool is_new = insertion.second;
     bool& participating = insertion.first->second.participating;
@@ -320,7 +322,7 @@ public:
         if (!table->submission())
         {
           it->second->respond(
-                table, Responder(this, msg.conflict_version, table));
+            table, Responder(this, msg.conflict_version, table));
         }
       }
     }
@@ -354,7 +356,7 @@ public:
         if (!respond_to->submission())
         {
           n.second->respond(
-                respond_to, Responder(this, msg.conflict_version, respond_to));
+            respond_to, Responder(this, msg.conflict_version, respond_to));
         }
 
         respond_queue.push_back(respond_to);
@@ -368,10 +370,10 @@ public:
     if (negotiate_it == negotiations.end())
     {
       RCLCPP_WARN(
-            node.get_logger(),
-            "[rmf_traffic_ros2::schedule::Negotiation::receive_proposal] "
-            "Received a proposal for an unknown negotiation: "
-            + std::to_string(msg.conflict_version));
+        node.get_logger(),
+        "[rmf_traffic_ros2::schedule::Negotiation::receive_proposal] "
+        "Received a proposal for an unknown negotiation: "
+        + std::to_string(msg.conflict_version));
       return;
     }
 
@@ -379,7 +381,7 @@ public:
     auto& room = negotiate_it->second.room;
     Negotiation& negotiation = room.negotiation;
     const auto received_table =
-        negotiation.table(msg.for_participant, msg.to_accommodate);
+      negotiation.table(msg.for_participant, msg.to_accommodate);
 
     if (!received_table)
     {
@@ -387,10 +389,10 @@ public:
       // so that the negotiation can be reconstructed after requesting some
       // repeats.
       std::string error =
-          "[rmf_traffic_ros2::schedule::Negotiation::receive_proposal] "
-          "Receieved a proposal for negotiation ["
-          + std::to_string(msg.conflict_version) + "] that builds on an "
-          "unknown table: [";
+        "[rmf_traffic_ros2::schedule::Negotiation::receive_proposal] "
+        "Receieved a proposal for negotiation ["
+        + std::to_string(msg.conflict_version) + "] that builds on an "
+        "unknown table: [";
       for (const auto p : msg.to_accommodate)
         error += " " + std::to_string(p);
       error += " " + std::to_string(msg.for_participant) + " ]";
@@ -404,7 +406,7 @@ public:
     // in them, because one of our negotiators might get added to it in the
     // future
     const bool updated =
-        received_table->submit(convert(msg.itinerary), msg.proposal_version);
+      received_table->submit(convert(msg.itinerary), msg.proposal_version);
 
     if (!updated)
       return;
@@ -428,8 +430,8 @@ public:
         if (const auto respond_to = top->respond(participant))
         {
           negotiator->respond(
-                respond_to,
-                Responder(this, msg.conflict_version, respond_to));
+            respond_to,
+            Responder(this, msg.conflict_version, respond_to));
 
           if (respond_to->submission())
             queue.push_back(respond_to);
@@ -486,11 +488,11 @@ public:
         assert(approval_callback_it != approvals.end());
         const auto& approval_callbacks = approval_callback_it->second;
 
-        for (std::size_t i=1; i <= msg.table.size(); ++i)
+        for (std::size_t i = 1; i <= msg.table.size(); ++i)
         {
           const auto table = negotiation.table(
-                std::vector<ParticipantId>(
-                  msg.table.begin(), msg.table.begin()+i));
+            std::vector<ParticipantId>(
+              msg.table.begin(), msg.table.begin()+i));
 
           if (!table)
             break;
@@ -522,7 +524,7 @@ public:
         p_ack.updating = false;
         for (const auto p : negotiation.participants())
         {
-          if (negotiators->count(p) !=0)
+          if (negotiators->count(p) != 0)
           {
             p_ack.participant = p;
             acknowledgments.push_back(p_ack);
@@ -551,8 +553,8 @@ public:
   }
 
   void publish_proposal(
-      const Version conflict_version,
-      const Negotiation::Table& table)
+    const Version conflict_version,
+    const Negotiation::Table& table)
   {
     Proposal msg;
     msg.conflict_version = conflict_version;
@@ -565,19 +567,19 @@ public:
 
     const auto& sequence = table.sequence();
     msg.to_accommodate.reserve(sequence.size()-1);
-    for (std::size_t i=0; i < sequence.size()-1; ++i)
+    for (std::size_t i = 0; i < sequence.size()-1; ++i)
       msg.to_accommodate.push_back(sequence[i]);
 
     proposal_pub->publish(msg);
   }
 
   void publish_rejection(
-      const Version conflict_version,
-      const Negotiation::Table& table)
+    const Version conflict_version,
+    const Negotiation::Table& table)
   {
     Rejection msg;
     msg.conflict_version = conflict_version;
-    msg.proposal_version = table.version()? *table.version() : 0;
+    msg.proposal_version = table.version() ? *table.version() : 0;
     msg.table = table.sequence();
     rejection_pub->publish(msg);
   }
@@ -585,10 +587,10 @@ public:
   struct Handle
   {
     Handle(
-        const ParticipantId for_participant_,
-        NegotiationMapPtr map)
-      : for_participant(for_participant_),
-        weak_map(map)
+      const ParticipantId for_participant_,
+      NegotiationMapPtr map)
+    : for_participant(for_participant_),
+      weak_map(map)
     {
       // Do nothing
     }
@@ -604,18 +606,20 @@ public:
   };
 
   std::shared_ptr<void> register_negotiator(
-      const ParticipantId for_participant,
-      NegotiatorPtr negotiator)
+    const ParticipantId for_participant,
+    NegotiatorPtr negotiator)
   {
     const auto insertion = negotiators->insert(
-          std::make_pair(for_participant, std::move(negotiator)));
+      std::make_pair(for_participant, std::move(negotiator)));
 
     if (!insertion.second)
     {
+      // *INDENT-OFF*
       throw std::runtime_error(
-            "[rmf_traffic_ros2::schedule::Negotiaton] Attempt to register a "
-            "duplicate negotiator for participant ["
-            + std::to_string(for_participant) + "]");
+        "[rmf_traffic_ros2::schedule::Negotiaton] Attempt to register a "
+        "duplicate negotiator for participant ["
+        + std::to_string(for_participant) + "]");
+      // *INDENT-ON*
     }
 
     return std::make_shared<Handle>(for_participant, negotiators);
@@ -624,17 +628,17 @@ public:
 
 //==============================================================================
 Negotiation::Negotiation(
-    rclcpp::Node& node,
-    const rmf_traffic::schedule::Viewer& viewer)
-  : _pimpl(rmf_utils::make_unique_impl<Implementation>(node, viewer))
+  rclcpp::Node& node,
+  const rmf_traffic::schedule::Viewer& viewer)
+: _pimpl(rmf_utils::make_unique_impl<Implementation>(node, viewer))
 {
   // Do nothing
 }
 
 //==============================================================================
 std::shared_ptr<void> Negotiation::register_negotiator(
-    rmf_traffic::schedule::ParticipantId for_participant,
-    std::unique_ptr<rmf_traffic::schedule::Negotiator> negotiator)
+  rmf_traffic::schedule::ParticipantId for_participant,
+  std::unique_ptr<rmf_traffic::schedule::Negotiator> negotiator)
 {
   return _pimpl->register_negotiator(for_participant, std::move(negotiator));
 }

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/NegotiationRoom.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/NegotiationRoom.cpp
@@ -26,13 +26,14 @@ namespace schedule {
 
 //==============================================================================
 NegotiationRoom::NegotiationRoom(rmf_traffic::schedule::Negotiation negotiation_)
-  : negotiation(std::move(negotiation_))
+: negotiation(std::move(negotiation_))
 {
   // Do nothing
 }
 
 //==============================================================================
-std::vector<rmf_traffic::schedule::Negotiation::TablePtr> NegotiationRoom::check_cache()
+std::vector<rmf_traffic::schedule::Negotiation::TablePtr> NegotiationRoom::
+check_cache()
 {
   std::vector<rmf_traffic::schedule::Negotiation::TablePtr> new_tables;
 
@@ -41,16 +42,16 @@ std::vector<rmf_traffic::schedule::Negotiation::TablePtr> NegotiationRoom::check
   {
     recheck = false;
 
-    for (auto it = cached_proposals.begin(); it != cached_proposals.end();)
+    for (auto it = cached_proposals.begin(); it != cached_proposals.end(); )
     {
       const auto& proposal = *it;
       const auto table = negotiation.table(
-            proposal.for_participant, proposal.to_accommodate);
+        proposal.for_participant, proposal.to_accommodate);
       if (table)
       {
         const bool updated = table->submit(
-              rmf_traffic_ros2::convert(
-                proposal.itinerary), proposal.proposal_version);
+          rmf_traffic_ros2::convert(
+            proposal.itinerary), proposal.proposal_version);
         if (updated)
           new_tables.push_back(table);
 
@@ -61,7 +62,7 @@ std::vector<rmf_traffic::schedule::Negotiation::TablePtr> NegotiationRoom::check
         ++it;
     }
 
-    for (auto it = cached_rejections.begin(); it != cached_rejections.end();)
+    for (auto it = cached_rejections.begin(); it != cached_rejections.end(); )
     {
       // TODO(MXG): This needs to account for what version of the proposal
       // is being rejected.
@@ -80,18 +81,18 @@ std::vector<rmf_traffic::schedule::Negotiation::TablePtr> NegotiationRoom::check
   } while (recheck);
 
   auto remove_it = std::remove_if(new_tables.begin(), new_tables.end(),
-                 [](const rmf_traffic::schedule::Negotiation::TablePtr& table)
-  {
-    return table->rejected();
-  });
+      [](const rmf_traffic::schedule::Negotiation::TablePtr& table)
+      {
+        return table->rejected();
+      });
   new_tables.erase(remove_it, new_tables.end());
 
   return new_tables;
 }
 
 void print_negotiation_status(
-    rmf_traffic::schedule::Version conflict_version,
-    const rmf_traffic::schedule::Negotiation& negotiation)
+  rmf_traffic::schedule::Version conflict_version,
+  const rmf_traffic::schedule::Negotiation& negotiation)
 {
   using Negotiation = rmf_traffic::schedule::Negotiation;
 
@@ -136,7 +137,7 @@ void print_negotiation_status(
     const bool finished = static_cast<bool>(t->submission());
     const bool rejected = t->rejected();
     const auto sequence = t->sequence();
-    for (std::size_t i=0; i < sequence.size(); ++i)
+    for (std::size_t i = 0; i < sequence.size(); ++i)
     {
       if (i == t->sequence().size()-1 && rejected)
         std::cout << " <" << sequence[i] << ">";

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/NegotiationRoom.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/NegotiationRoom.hpp
@@ -43,8 +43,8 @@ struct NegotiationRoom
 //==============================================================================
 // TODO(MXG): Refactor this by putting it somewhere more meaningful.
 void print_negotiation_status(
-    rmf_traffic::schedule::Version conflict_version,
-    const rmf_traffic::schedule::Negotiation& negotiation);
+  rmf_traffic::schedule::Version conflict_version,
+  const rmf_traffic::schedule::Negotiation& negotiation);
 
 } // namespace schedule
 } // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -36,7 +36,7 @@ namespace schedule {
 namespace {
 //==============================================================================
 class RectifierFactory
-    : public rmf_traffic::schedule::RectificationRequesterFactory
+  : public rmf_traffic::schedule::RectificationRequesterFactory
 {
 public:
 
@@ -60,8 +60,8 @@ public:
   };
 
   using StubMap = std::unordered_map<
-      rmf_traffic::schedule::ParticipantId,
-      std::weak_ptr<RectifierStub>
+    rmf_traffic::schedule::ParticipantId,
+    std::weak_ptr<RectifierStub>
   >;
 
   StubMap stub_map;
@@ -72,17 +72,17 @@ public:
   RectifierFactory(rclcpp::Node& node)
   {
     inconsistency_sub = node.create_subscription<InconsistencyMsg>(
-          ScheduleInconsistencyTopicName,
-          rclcpp::SystemDefaultsQoS().reliable(),
-          [&](const InconsistencyMsg::UniquePtr msg)
-    {
-      check_inconsistencies(*msg);
-    });
+      ScheduleInconsistencyTopicName,
+      rclcpp::SystemDefaultsQoS().reliable(),
+      [&](const InconsistencyMsg::UniquePtr msg)
+      {
+        check_inconsistencies(*msg);
+      });
   }
 
   std::unique_ptr<rmf_traffic::schedule::RectificationRequester> make(
-      rmf_traffic::schedule::Rectifier rectifier,
-      rmf_traffic::schedule::ParticipantId participant_id) final
+    rmf_traffic::schedule::Rectifier rectifier,
+    rmf_traffic::schedule::ParticipantId participant_id) final
   {
     auto requester = std::make_unique<Requester>(std::move(rectifier));
 
@@ -126,9 +126,9 @@ public:
 
 //==============================================================================
 RectifierFactory::Requester::Requester(
-    rmf_traffic::schedule::Rectifier rectifier_)
-  : rectifier(std::move(rectifier_)),
-    stub(std::make_shared<RectifierStub>(RectifierStub{*this}))
+  rmf_traffic::schedule::Rectifier rectifier_)
+: rectifier(std::move(rectifier_)),
+  stub(std::make_shared<RectifierStub>(RectifierStub{*this}))
 {
   // Do nothing
 }
@@ -137,7 +137,7 @@ RectifierFactory::Requester::Requester(
 
 //==============================================================================
 class Writer::Implementation
-    : public rmf_traffic::schedule::Writer
+  : public rmf_traffic::schedule::Writer
 {
 public:
 
@@ -162,39 +162,39 @@ public:
   rclcpp::Client<Unregister>::SharedPtr unregister_client;
 
   Implementation(rclcpp::Node& node)
-    : rectifier_factory(node)
+  : rectifier_factory(node)
   {
     set_pub = node.create_publisher<Set>(
-          ItinerarySetTopicName,
-          rclcpp::SystemDefaultsQoS().best_effort());
+      ItinerarySetTopicName,
+      rclcpp::SystemDefaultsQoS().best_effort());
 
     extend_pub = node.create_publisher<Extend>(
-          ItineraryExtendTopicName,
-          rclcpp::SystemDefaultsQoS().best_effort());
+      ItineraryExtendTopicName,
+      rclcpp::SystemDefaultsQoS().best_effort());
 
     delay_pub = node.create_publisher<Delay>(
-          ItineraryDelayTopicName,
-          rclcpp::SystemDefaultsQoS().best_effort());
+      ItineraryDelayTopicName,
+      rclcpp::SystemDefaultsQoS().best_effort());
 
     erase_pub = node.create_publisher<Erase>(
-          ItineraryEraseTopicName,
-          rclcpp::SystemDefaultsQoS().best_effort());
+      ItineraryEraseTopicName,
+      rclcpp::SystemDefaultsQoS().best_effort());
 
     clear_pub = node.create_publisher<Clear>(
-          ItineraryClearTopicName,
-          rclcpp::SystemDefaultsQoS().best_effort());
+      ItineraryClearTopicName,
+      rclcpp::SystemDefaultsQoS().best_effort());
 
     register_client =
-        node.create_client<Register>(RegisterParticipantSrvName);
+      node.create_client<Register>(RegisterParticipantSrvName);
 
     unregister_client =
-        node.create_client<Unregister>(UnregisterParticipantSrvName);
+      node.create_client<Unregister>(UnregisterParticipantSrvName);
   }
 
   void set(
-      const rmf_traffic::schedule::ParticipantId participant,
-      const Input& itinerary,
-      const rmf_traffic::schedule::ItineraryVersion version) final
+    const rmf_traffic::schedule::ParticipantId participant,
+    const Input& itinerary,
+    const rmf_traffic::schedule::ItineraryVersion version) final
   {
     Set msg;
     msg.participant = participant;
@@ -205,9 +205,9 @@ public:
   }
 
   void extend(
-      const rmf_traffic::schedule::ParticipantId participant,
-      const Input& routes,
-      const rmf_traffic::schedule::ItineraryVersion version) final
+    const rmf_traffic::schedule::ParticipantId participant,
+    const Input& routes,
+    const rmf_traffic::schedule::ItineraryVersion version) final
   {
     Extend msg;
     msg.participant = participant;
@@ -218,10 +218,10 @@ public:
   }
 
   void delay(
-      const rmf_traffic::schedule::ParticipantId participant,
-      const rmf_traffic::Time from,
-      const rmf_traffic::Duration duration,
-      const rmf_traffic::schedule::ItineraryVersion version) final
+    const rmf_traffic::schedule::ParticipantId participant,
+    const rmf_traffic::Time from,
+    const rmf_traffic::Duration duration,
+    const rmf_traffic::schedule::ItineraryVersion version) final
   {
     Delay msg;
     msg.participant = participant;
@@ -233,9 +233,9 @@ public:
   }
 
   void erase(
-      const rmf_traffic::schedule::ParticipantId participant,
-      const std::vector<rmf_traffic::RouteId>& routes,
-      const rmf_traffic::schedule::ItineraryVersion version) final
+    const rmf_traffic::schedule::ParticipantId participant,
+    const std::vector<rmf_traffic::RouteId>& routes,
+    const rmf_traffic::schedule::ItineraryVersion version) final
   {
     Erase msg;
     msg.participant = participant;
@@ -246,8 +246,8 @@ public:
   }
 
   void erase(
-      const rmf_traffic::schedule::ParticipantId participant,
-      const rmf_traffic::schedule::ItineraryVersion version) final
+    const rmf_traffic::schedule::ParticipantId participant,
+    const rmf_traffic::schedule::ItineraryVersion version) final
   {
     Clear msg;
     msg.participant = participant;
@@ -257,7 +257,7 @@ public:
   }
 
   rmf_traffic::schedule::ParticipantId register_participant(
-      rmf_traffic::schedule::ParticipantDescription participant_info) final
+    rmf_traffic::schedule::ParticipantDescription participant_info) final
   {
     using namespace std::chrono_literals;
 
@@ -265,49 +265,53 @@ public:
     request->description = convert(participant_info);
 
     auto future = register_client->async_send_request(request);
-    while(future.wait_for(100ms) != std::future_status::ready)
+    while (future.wait_for(100ms) != std::future_status::ready)
     {
       if (!rclcpp::ok())
       {
+        // *INDENT-OFF*
         throw std::runtime_error(
-              "[rmf_traffic_ros2::schedule::Writer] Tearing down while waiting "
-              "for a schedule participant to finish registering");
+          "[rmf_traffic_ros2::schedule::Writer] Tearing down while waiting "
+          "for a schedule participant to finish registering");
+        // *INDENT-ON*
       }
     }
 
     const auto response = future.get();
     if (!response->error.empty())
     {
+      // *INDENT-OFF*
       throw std::runtime_error(
-            "[rmf_traffic_ros2::schedule::Writer] Error while attempting to "
-            "register a participant: " + response->error);
+        "[rmf_traffic_ros2::schedule::Writer] Error while attempting to "
+        "register a participant: " + response->error);
+      // *INDENT-ON*
     }
 
     return response->participant_id;
   }
 
   void unregister_participant(
-      const rmf_traffic::schedule::ParticipantId participant) final
+    const rmf_traffic::schedule::ParticipantId participant) final
   {
     auto request = std::make_shared<Unregister::Request>();
     request->participant_id = participant;
 
     unregister_client->async_send_request(
-          request,
-          [=](const rclcpp::Client<Unregister>::SharedFuture response_future)
-    {
-      const auto response = response_future.get();
-      if (!response->error.empty())
+      request,
+      [=](const rclcpp::Client<Unregister>::SharedFuture response_future)
       {
-        throw std::runtime_error(
-              "[rmf_traffic_ros2::schedule::Writer] Error while attempting to "
-              "unregister a participant: " + response->error);
-      }
-    });
+        const auto response = response_future.get();
+        if (!response->error.empty())
+        {
+          throw std::runtime_error(
+            "[rmf_traffic_ros2::schedule::Writer] Error while attempting to "
+            "unregister a participant: " + response->error);
+        }
+      });
   }
 
   std::future<rmf_traffic::schedule::Participant> make_participant(
-      rmf_traffic::schedule::ParticipantDescription description)
+    rmf_traffic::schedule::ParticipantDescription description)
   {
     // TODO(MXG): This implementation assumes that the async promise will be
     // finished before the Writer instance is destructed. If that is not true,
@@ -321,13 +325,13 @@ public:
     std::promise<rmf_traffic::schedule::Participant> promise;
     auto future = promise.get_future();
     std::thread worker(
-          [this](
-          rmf_traffic::schedule::ParticipantDescription description,
-          std::promise<rmf_traffic::schedule::Participant> promise)
-    {
-      promise.set_value(rmf_traffic::schedule::make_participant(
-            std::move(description), *this, &rectifier_factory));
-    }, std::move(description), std::move(promise));
+      [this](
+        rmf_traffic::schedule::ParticipantDescription description,
+        std::promise<rmf_traffic::schedule::Participant> promise)
+      {
+        promise.set_value(rmf_traffic::schedule::make_participant(
+          std::move(description), *this, &rectifier_factory));
+      }, std::move(description), std::move(promise));
 
     worker.detach();
 
@@ -335,25 +339,25 @@ public:
   }
 
   void async_make_participant(
-      rmf_traffic::schedule::ParticipantDescription description,
-      std::function<void(rmf_traffic::schedule::Participant)> ready_callback)
+    rmf_traffic::schedule::ParticipantDescription description,
+    std::function<void(rmf_traffic::schedule::Participant)> ready_callback)
   {
     std::thread worker(
-          [description = std::move(description),
-           this,
-           ready_callback = std::move(ready_callback)]()
-    {
-      // TODO(MXG): We could probably make an implementation of the
-      // RectifierFactory that allows us to pass the ready_callback along to
-      // the service call so that it gets triggered when the service response is
-      // received. That way we don't need to create an additional thread here
-      // and worry about the threat of race conditions.
-      auto participant = rmf_traffic::schedule::make_participant(
-            std::move(description), *this, &rectifier_factory);
+      [description = std::move(description),
+      this,
+      ready_callback = std::move(ready_callback)]()
+      {
+        // TODO(MXG): We could probably make an implementation of the
+        // RectifierFactory that allows us to pass the ready_callback along to
+        // the service call so that it gets triggered when the service response is
+        // received. That way we don't need to create an additional thread here
+        // and worry about the threat of race conditions.
+        auto participant = rmf_traffic::schedule::make_participant(
+          std::move(description), *this, &rectifier_factory);
 
-      if (ready_callback)
-        ready_callback(std::move(participant));
-    });
+        if (ready_callback)
+          ready_callback(std::move(participant));
+      });
 
     worker.detach();
   }
@@ -370,7 +374,7 @@ std::shared_ptr<Writer> Writer::make(rclcpp::Node& node)
 bool Writer::ready() const
 {
   return _pimpl->register_client->service_is_ready()
-      && _pimpl->unregister_client->service_is_ready();
+    && _pimpl->unregister_client->service_is_ready();
 }
 
 //==============================================================================
@@ -386,33 +390,33 @@ bool Writer::wait_for_service(rmf_traffic::Time stop) const
   bool ready = true;
 
   ready &= _pimpl->register_client->wait_for_service(
-        stop - std::chrono::steady_clock::now());
+    stop - std::chrono::steady_clock::now());
 
   ready &= _pimpl->unregister_client->wait_for_service(
-        stop - std::chrono::steady_clock::now());
+    stop - std::chrono::steady_clock::now());
 
   return ready;
 }
 
 //==============================================================================
 std::future<rmf_traffic::schedule::Participant> Writer::make_participant(
-    rmf_traffic::schedule::ParticipantDescription description)
+  rmf_traffic::schedule::ParticipantDescription description)
 {
   return _pimpl->make_participant(std::move(description));
 }
 
 //==============================================================================
 void Writer::async_make_participant(
-    rmf_traffic::schedule::ParticipantDescription description,
-    std::function<void(rmf_traffic::schedule::Participant)> ready_callback)
+  rmf_traffic::schedule::ParticipantDescription description,
+  std::function<void(rmf_traffic::schedule::Participant)> ready_callback)
 {
   _pimpl->async_make_participant(
-        std::move(description), std::move(ready_callback));
+    std::move(description), std::move(ready_callback));
 }
 
 //==============================================================================
 Writer::Writer(rclcpp::Node& node)
-  : _pimpl(rmf_utils::make_unique_impl<Implementation>(node))
+: _pimpl(rmf_utils::make_unique_impl<Implementation>(node))
 {
   // Do nothing
 }

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -303,9 +303,11 @@ public:
         const auto response = response_future.get();
         if (!response->error.empty())
         {
+          // *INDENT-OFF*
           throw std::runtime_error(
             "[rmf_traffic_ros2::schedule::Writer] Error while attempting to "
             "unregister a participant: " + response->error);
+          // *INDENT-ON*
         }
       });
   }

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Change.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Change.cpp
@@ -24,14 +24,14 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::schedule::Change::Add::Item convert(
-    const rmf_traffic_msgs::msg::ScheduleChangeAdd& from)
+  const rmf_traffic_msgs::msg::ScheduleChangeAdd& from)
 {
   return {from.id, std::make_shared<rmf_traffic::Route>(convert(from.route))};
 }
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleChangeAdd convert(
-    const rmf_traffic::schedule::Change::Add::Item& from)
+  const rmf_traffic::schedule::Change::Add::Item& from)
 {
   if (!from.route)
     throw std::runtime_error("Cannot convert a nullptr route into a message");
@@ -44,7 +44,7 @@ rmf_traffic_msgs::msg::ScheduleChangeAdd convert(
 
 //==============================================================================
 rmf_traffic::schedule::Change::Delay convert(
-    const rmf_traffic_msgs::msg::ScheduleChangeDelay& from)
+  const rmf_traffic_msgs::msg::ScheduleChangeDelay& from)
 {
   return rmf_traffic::schedule::Change::Delay{
     rmf_traffic::Time(rmf_traffic::Duration(from.from_time)),
@@ -54,7 +54,7 @@ rmf_traffic::schedule::Change::Delay convert(
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleChangeDelay convert(
-    const rmf_traffic::schedule::Change::Delay& from)
+  const rmf_traffic::schedule::Change::Delay& from)
 {
   rmf_traffic_msgs::msg::ScheduleChangeDelay output;
   output.from_time = from.from().time_since_epoch().count();
@@ -64,7 +64,7 @@ rmf_traffic_msgs::msg::ScheduleChangeDelay convert(
 
 //==============================================================================
 rmf_traffic::schedule::Change::RegisterParticipant convert(
-    const rmf_traffic_msgs::msg::ScheduleRegister& from)
+  const rmf_traffic_msgs::msg::ScheduleRegister& from)
 {
   return rmf_traffic::schedule::Change::RegisterParticipant{
     from.participant_id,
@@ -74,7 +74,7 @@ rmf_traffic::schedule::Change::RegisterParticipant convert(
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleRegister convert(
-    const rmf_traffic::schedule::Change::RegisterParticipant& from)
+  const rmf_traffic::schedule::Change::RegisterParticipant& from)
 {
   rmf_traffic_msgs::msg::ScheduleRegister output;
   output.participant_id = from.id();
@@ -84,14 +84,14 @@ rmf_traffic_msgs::msg::ScheduleRegister convert(
 
 //==============================================================================
 rmf_traffic::schedule::Change::Cull convert(
-    const rmf_traffic_msgs::msg::ScheduleChangeCull& from)
+  const rmf_traffic_msgs::msg::ScheduleChangeCull& from)
 {
   return rmf_traffic::Time(rmf_traffic::Duration(from.time));
 }
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleChangeCull convert(
-    const rmf_traffic::schedule::Change::Cull& from)
+  const rmf_traffic::schedule::Change::Cull& from)
 {
   rmf_traffic_msgs::msg::ScheduleChangeCull output;
   output.time = from.time().time_since_epoch().count();

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Inconsistencies.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Inconsistencies.cpp
@@ -21,7 +21,7 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleInconsistency convert(
-    const rmf_traffic::schedule::Inconsistencies::Element& from)
+  const rmf_traffic::schedule::Inconsistencies::Element& from)
 {
   rmf_traffic_msgs::msg::ScheduleInconsistency msg;
   msg.participant = from.participant;

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Itinerary.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Itinerary.cpp
@@ -22,7 +22,7 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 std::vector<rmf_traffic_msgs::msg::Route> convert(
-    const rmf_traffic::schedule::Itinerary& from)
+  const rmf_traffic::schedule::Itinerary& from)
 {
   std::vector<rmf_traffic_msgs::msg::Route> output;
   for (const auto& r : from)

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_ParticipantDescription.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_ParticipantDescription.cpp
@@ -22,20 +22,20 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::schedule::ParticipantDescription convert(
-    const rmf_traffic_msgs::msg::ParticipantDescription& from)
+  const rmf_traffic_msgs::msg::ParticipantDescription& from)
 {
   return rmf_traffic::schedule::ParticipantDescription{
     from.name,
     from.owner,
     static_cast<rmf_traffic::schedule::ParticipantDescription::Rx>(
-          from.responsiveness),
+      from.responsiveness),
     convert(from.profile)
   };
 }
 
 //==============================================================================
 rmf_traffic_msgs::msg::ParticipantDescription convert(
-    const rmf_traffic::schedule::ParticipantDescription& from)
+  const rmf_traffic::schedule::ParticipantDescription& from)
 {
   rmf_traffic_msgs::msg::ParticipantDescription output;
   output.name = from.name();

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Patch.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Patch.cpp
@@ -25,15 +25,15 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::schedule::Patch::Participant convert(
-    const rmf_traffic_msgs::msg::ScheduleParticipantPatch& from);
+  const rmf_traffic_msgs::msg::ScheduleParticipantPatch& from);
 
 //==============================================================================
 
 //==============================================================================
 template<typename T_out, typename T_in>
 void convert_vector(
-    std::vector<T_out>& output,
-    const std::vector<T_in>& input)
+  std::vector<T_out>& output,
+  const std::vector<T_in>& input)
 {
   output.reserve(input.size());
   for (const auto& i : input)
@@ -43,7 +43,7 @@ void convert_vector(
 //==============================================================================
 template<typename T_out, typename T_in>
 std::vector<T_out> convert_vector(
-    const std::vector<T_in>& input)
+  const std::vector<T_in>& input)
 {
   std::vector<T_out> output;
   convert_vector(output, input);
@@ -52,23 +52,23 @@ std::vector<T_out> convert_vector(
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleParticipantPatch convert(
-    const rmf_traffic::schedule::Patch::Participant& from)
+  const rmf_traffic::schedule::Patch::Participant& from)
 {
   rmf_traffic_msgs::msg::ScheduleParticipantPatch output;
   output.participant_id = from.participant_id();
 
   output.erasures = from.erasures().ids();
   output.additions = convert_vector<rmf_traffic_msgs::msg::ScheduleChangeAdd>(
-        from.additions().items());
+    from.additions().items());
   output.delays = convert_vector<rmf_traffic_msgs::msg::ScheduleChangeDelay>(
-        from.delays());
+    from.delays());
 
   return output;
 }
 
 //==============================================================================
 rmf_traffic::schedule::Patch::Participant convert(
-    const rmf_traffic_msgs::msg::ScheduleParticipantPatch& from)
+  const rmf_traffic_msgs::msg::ScheduleParticipantPatch& from)
 {
   return rmf_traffic::schedule::Patch::Participant{
     from.participant_id,
@@ -82,7 +82,7 @@ rmf_traffic::schedule::Patch::Participant convert(
 
 //==============================================================================
 rmf_traffic_msgs::msg::SchedulePatch convert(
-    const rmf_traffic::schedule::Patch& from)
+  const rmf_traffic::schedule::Patch& from)
 {
   rmf_traffic_msgs::msg::SchedulePatch output;
 
@@ -105,7 +105,7 @@ rmf_traffic_msgs::msg::SchedulePatch convert(
 
 //==============================================================================
 rmf_traffic::schedule::Patch convert(
-    const rmf_traffic_msgs::msg::SchedulePatch& from)
+  const rmf_traffic_msgs::msg::SchedulePatch& from)
 {
   // TODO(MXG): Fix the Patch API to make this more elegant
   std::vector<rmf_traffic::schedule::Change::UnregisterParticipant> unregister;
@@ -119,7 +119,8 @@ rmf_traffic::schedule::Patch convert(
 
   return rmf_traffic::schedule::Patch{
     std::move(unregister),
-    convert_vector<rmf_traffic::schedule::Change::RegisterParticipant>(from.register_participants),
+    convert_vector<rmf_traffic::schedule::Change::RegisterParticipant>(
+      from.register_participants),
     convert_vector<rmf_traffic::schedule::Patch::Participant>(from.participants),
     std::move(cull),
     from.latest_version

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Query.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Query.cpp
@@ -34,27 +34,27 @@ Eigen::Isometry2d to_eigen(const geometry_msgs::msg::Pose2D& pose)
 
 //==============================================================================
 rmf_traffic::geometry::Space parse_space(
-    const rmf_traffic_msgs::msg::Space& space,
-    const rmf_traffic_ros2::geometry::ShapeContext& context)
+  const rmf_traffic_msgs::msg::Space& space,
+  const rmf_traffic_ros2::geometry::ShapeContext& context)
 {
   return {context.at(space.shape), to_eigen(space.pose)};
 }
 
 //==============================================================================
 rmf_traffic::Region parse_region(
-    const rmf_traffic_msgs::msg::Region& region,
-    const rmf_traffic_ros2::geometry::ShapeContext& context)
+  const rmf_traffic_msgs::msg::Region& region,
+  const rmf_traffic_ros2::geometry::ShapeContext& context)
 {
   using namespace rmf_traffic;
   Region output(region.map, {});
 
-  for(const auto& space : region.spaces)
+  for (const auto& space : region.spaces)
     output.push_back(parse_space(space, context));
 
-  if(region.timespan.has_lower_bound)
+  if (region.timespan.has_lower_bound)
     output.set_lower_time_bound(Time(Duration(region.timespan.lower_bound)));
 
-  if(region.timespan.has_upper_bound)
+  if (region.timespan.has_upper_bound)
     output.set_upper_time_bound(Time(Duration(region.timespan.upper_bound)));
 
   return output;
@@ -62,13 +62,13 @@ rmf_traffic::Region parse_region(
 
 //==============================================================================
 rmf_traffic::schedule::Query::Spacetime parse_regions(
-    const rmf_traffic_msgs::msg::ScheduleQuerySpacetime& from)
+  const rmf_traffic_msgs::msg::ScheduleQuerySpacetime& from)
 {
   const rmf_traffic_ros2::geometry::ShapeContext context =
-      convert(from.shape_context);
+    convert(from.shape_context);
 
   std::vector<rmf_traffic::Region> regions;
-  for(const auto& region : from.regions)
+  for (const auto& region : from.regions)
     regions.emplace_back(parse_region(region, context));
 
   return regions;
@@ -76,17 +76,17 @@ rmf_traffic::schedule::Query::Spacetime parse_regions(
 
 //==============================================================================
 rmf_traffic::schedule::Query::Spacetime parse_timespan(
-    const rmf_traffic_msgs::msg::ScheduleQuerySpacetime& from)
+  const rmf_traffic_msgs::msg::ScheduleQuerySpacetime& from)
 {
   using namespace rmf_traffic;
 
   rmf_traffic::schedule::Query::Spacetime output;
   auto& timespan = output.query_timespan(from.timespan.maps);
 
-  if(from.timespan.has_lower_bound)
+  if (from.timespan.has_lower_bound)
     timespan.set_lower_time_bound(Time{Duration{from.timespan.lower_bound}});
 
-  if(from.timespan.has_upper_bound)
+  if (from.timespan.has_upper_bound)
     timespan.set_upper_time_bound(Time{Duration{from.timespan.upper_bound}});
 
   return output;
@@ -95,18 +95,20 @@ rmf_traffic::schedule::Query::Spacetime parse_timespan(
 
 //==============================================================================
 rmf_traffic::schedule::Query::Spacetime convert(
-    const rmf_traffic_msgs::msg::ScheduleQuerySpacetime& from)
+  const rmf_traffic_msgs::msg::ScheduleQuerySpacetime& from)
 {
-  if(rmf_traffic_msgs::msg::ScheduleQuerySpacetime::ALL == from.type)
+  if (rmf_traffic_msgs::msg::ScheduleQuerySpacetime::ALL == from.type)
     return rmf_traffic::schedule::Query::Spacetime();
-  else if(rmf_traffic_msgs::msg::ScheduleQuerySpacetime::REGIONS == from.type)
+  else if (rmf_traffic_msgs::msg::ScheduleQuerySpacetime::REGIONS == from.type)
     return parse_regions(from);
-  else if(rmf_traffic_msgs::msg::ScheduleQuerySpacetime::TIMESPAN == from.type)
+  else if (rmf_traffic_msgs::msg::ScheduleQuerySpacetime::TIMESPAN == from.type)
     return parse_timespan(from);
 
+  // *INDENT-OFF*
   throw std::runtime_error(
-        "Invalid rmf_traffic_msgs/ScheduleQuerySpacetime type ["
-        + std::to_string(from.type) + "]");
+    "Invalid rmf_traffic_msgs/ScheduleQuerySpacetime type ["
+    + std::to_string(from.type) + "]");
+  // *INDENT-ON*
 }
 
 namespace {
@@ -123,11 +125,11 @@ geometry_msgs::msg::Pose2D from_eigen(const Eigen::Isometry2d& pose)
 
 //==============================================================================
 rmf_traffic_msgs::msg::Timespan convert_timespan(
-    const rmf_traffic::Time* lower_bound,
-    const rmf_traffic::Time* upper_bound)
+  const rmf_traffic::Time* lower_bound,
+  const rmf_traffic::Time* upper_bound)
 {
   rmf_traffic_msgs::msg::Timespan msg;
-  if(lower_bound)
+  if (lower_bound)
   {
     msg.has_lower_bound = true;
     msg.lower_bound = lower_bound->time_since_epoch().count();
@@ -135,7 +137,7 @@ rmf_traffic_msgs::msg::Timespan convert_timespan(
   else
     msg.has_lower_bound = false;
 
-  if(upper_bound)
+  if (upper_bound)
   {
     msg.has_upper_bound = true;
     msg.upper_bound = upper_bound->time_since_epoch().count();
@@ -148,20 +150,20 @@ rmf_traffic_msgs::msg::Timespan convert_timespan(
 
 //==============================================================================
 void convert_regions(
-    rmf_traffic_msgs::msg::ScheduleQuerySpacetime& msg,
-    const rmf_traffic::schedule::Query::Spacetime::Regions& from)
+  rmf_traffic_msgs::msg::ScheduleQuerySpacetime& msg,
+  const rmf_traffic::schedule::Query::Spacetime::Regions& from)
 {
   geometry::ShapeContext shape_context;
-  for(const auto& region : from)
+  for (const auto& region : from)
   {
     rmf_traffic_msgs::msg::Region region_msg;
     region_msg.map = region.get_map();
 
     region_msg.timespan = convert_timespan(
-          region.get_lower_time_bound(),
-          region.get_upper_time_bound());
+      region.get_lower_time_bound(),
+      region.get_upper_time_bound());
 
-    for(const auto& space : region)
+    for (const auto& space : region)
     {
       rmf_traffic_msgs::msg::Space space_msg;
       space_msg.shape = shape_context.insert(space.get_shape());
@@ -177,26 +179,26 @@ void convert_regions(
 
 //==============================================================================
 void convert_timespan(
-    rmf_traffic_msgs::msg::ScheduleQuerySpacetime& msg,
-    const rmf_traffic::schedule::Query::Spacetime::Timespan& from)
+  rmf_traffic_msgs::msg::ScheduleQuerySpacetime& msg,
+  const rmf_traffic::schedule::Query::Spacetime::Timespan& from)
 {
   msg.timespan = convert_timespan(
-        from.get_lower_time_bound(),
-        from.get_upper_time_bound());
+    from.get_lower_time_bound(),
+    from.get_upper_time_bound());
 }
 } // anonymous namespace
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleQuerySpacetime convert(
-    const rmf_traffic::schedule::Query::Spacetime& from)
+  const rmf_traffic::schedule::Query::Spacetime& from)
 {
   rmf_traffic_msgs::msg::ScheduleQuerySpacetime msg;
   const auto mode = from.get_mode();
   msg.type = static_cast<uint16_t>(mode);
 
-  if(rmf_traffic::schedule::Query::Spacetime::Mode::Regions == mode)
+  if (rmf_traffic::schedule::Query::Spacetime::Mode::Regions == mode)
     convert_regions(msg, *from.regions());
-  else if(rmf_traffic::schedule::Query::Spacetime::Mode::Timespan == mode)
+  else if (rmf_traffic::schedule::Query::Spacetime::Mode::Timespan == mode)
     convert_timespan(msg, *from.timespan());
 
   return msg;
@@ -204,7 +206,7 @@ rmf_traffic_msgs::msg::ScheduleQuerySpacetime convert(
 
 //==============================================================================
 rmf_traffic::schedule::Query::Participants convert(
-    const rmf_traffic_msgs::msg::ScheduleQueryParticipants& from)
+  const rmf_traffic_msgs::msg::ScheduleQueryParticipants& from)
 {
   using Participants = rmf_traffic::schedule::Query::Participants;
 
@@ -215,15 +217,17 @@ rmf_traffic::schedule::Query::Participants convert(
   else if (from.EXCLUDE == from.type)
     return Participants::make_all_except(from.ids);
 
+  // *INDENT-OFF*
   throw std::runtime_error(
-        "[rmf_traffic_ros2::convert] Invalid type value for "
-        "rmf_traffic::schedule::Query::Participants: " +
-        std::to_string(from.type));
+    "[rmf_traffic_ros2::convert] Invalid type value for "
+    "rmf_traffic::schedule::Query::Participants: " +
+    std::to_string(from.type));
+  // *INDENT-ON*
 }
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleQueryParticipants convert(
-    const rmf_traffic::schedule::Query::Participants& from)
+  const rmf_traffic::schedule::Query::Participants& from)
 {
   using Participants = rmf_traffic::schedule::Query::Participants;
 
@@ -242,7 +246,7 @@ rmf_traffic_msgs::msg::ScheduleQueryParticipants convert(
 
 //==============================================================================
 rmf_traffic::schedule::Query convert(
-    const rmf_traffic_msgs::msg::ScheduleQuery& from)
+  const rmf_traffic_msgs::msg::ScheduleQuery& from)
 {
   auto output = rmf_traffic::schedule::query_all();
   output.spacetime() = convert(from.spacetime);
@@ -253,7 +257,7 @@ rmf_traffic::schedule::Query convert(
 
 //==============================================================================
 rmf_traffic_msgs::msg::ScheduleQuery convert(
-    const rmf_traffic::schedule::Query& from)
+  const rmf_traffic::schedule::Query& from)
 {
   rmf_traffic_msgs::msg::ScheduleQuery output;
   output.spacetime = convert(from.spacetime());

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/convert_Writer.cpp
@@ -22,16 +22,16 @@ namespace rmf_traffic_ros2 {
 
 //==============================================================================
 rmf_traffic::schedule::Writer::Input convert(
-    const std::vector<rmf_traffic_msgs::msg::ScheduleWriterItem>& from)
+  const std::vector<rmf_traffic_msgs::msg::ScheduleWriterItem>& from)
 {
   rmf_traffic::schedule::Writer::Input output;
   for (const auto& item : from)
   {
     output.emplace_back(
-          rmf_traffic::schedule::Writer::Item{
-            item.id,
-            std::make_shared<rmf_traffic::Route>(convert(item.route))
-          });
+      rmf_traffic::schedule::Writer::Item{
+        item.id,
+        std::make_shared<rmf_traffic::Route>(convert(item.route))
+      });
   }
 
   return output;
@@ -39,7 +39,7 @@ rmf_traffic::schedule::Writer::Input convert(
 
 //==============================================================================
 std::vector<rmf_traffic_msgs::msg::ScheduleWriterItem> convert(
-    const rmf_traffic::schedule::Writer::Input& from)
+  const rmf_traffic::schedule::Writer::Input& from)
 {
   std::vector<rmf_traffic_msgs::msg::ScheduleWriterItem> output;
   for (const auto& item : from)

--- a/rmf_traffic_ros2/src/rmf_traffic_schedule/ScheduleNode.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_schedule/ScheduleNode.cpp
@@ -38,8 +38,8 @@ namespace rmf_traffic_schedule {
 
 //==============================================================================
 std::vector<ScheduleNode::ConflictSet> get_conflicts(
-    const rmf_traffic::schedule::Viewer::View& view_changes,
-    const rmf_traffic::schedule::Viewer& viewer)
+  const rmf_traffic::schedule::Viewer::View& view_changes,
+  const rmf_traffic::schedule::Viewer& viewer)
 {
   std::vector<ScheduleNode::ConflictSet> conflicts;
   const auto& participants = viewer.participant_ids();
@@ -62,10 +62,10 @@ std::vector<ScheduleNode::ConflictSet> get_conflicts(
           continue;
 
         if (rmf_traffic::DetectConflict::between(
-              vc->description.profile(),
-              vc->route.trajectory(),
-              description.profile(),
-              route->trajectory()))
+            vc->description.profile(),
+            vc->route.trajectory(),
+            description.profile(),
+            route->trajectory()))
         {
           conflicts.push_back({participant, vc->participant});
         }
@@ -78,210 +78,197 @@ std::vector<ScheduleNode::ConflictSet> get_conflicts(
 
 //==============================================================================
 ScheduleNode::ScheduleNode()
-  : Node("rmf_traffic_schedule_node"),
-    active_conflicts(database)
+: Node("rmf_traffic_schedule_node"),
+  active_conflicts(database)
 {
   // TODO(MXG): As soon as possible, all of these services should be made
   // multi-threaded so they can be parallel processed.
 
-  register_query_service =
-      create_service<RegisterQuery>(
-        rmf_traffic_ros2::RegisterQueryServiceName,
-        [=](const std::shared_ptr<rmw_request_id_t> request_header,
-            const RegisterQuery::Request::SharedPtr request,
-            const RegisterQuery::Response::SharedPtr response)
-        { this->register_query(request_header, request, response); });
+  register_query_service = create_service<RegisterQuery>(
+    rmf_traffic_ros2::RegisterQueryServiceName,
+    [=](const std::shared_ptr<rmw_request_id_t> request_header,
+    const RegisterQuery::Request::SharedPtr request,
+    const RegisterQuery::Response::SharedPtr response)
+    { this->register_query(request_header, request, response); });
 
-  unregister_query_service =
-      create_service<UnregisterQuery>(
-        rmf_traffic_ros2::UnregisterQueryServiceName,
-        [=](const std::shared_ptr<rmw_request_id_t> request_header,
-            const UnregisterQuery::Request::SharedPtr request,
-            const UnregisterQuery::Response::SharedPtr response)
-        { this->unregister_query(request_header, request, response); });
+  unregister_query_service = create_service<UnregisterQuery>(
+    rmf_traffic_ros2::UnregisterQueryServiceName,
+    [=](const std::shared_ptr<rmw_request_id_t> request_header,
+    const UnregisterQuery::Request::SharedPtr request,
+    const UnregisterQuery::Response::SharedPtr response)
+    { this->unregister_query(request_header, request, response); });
 
-  register_participant_service =
-      create_service<RegisterParticipant>(
-        rmf_traffic_ros2::RegisterParticipantSrvName,
-        [=](const request_id_ptr request_header,
-            const RegisterParticipant::Request::SharedPtr request,
-            const RegisterParticipant::Response::SharedPtr response)
-        { this->register_participant(request_header, request, response); });
+  register_participant_service = create_service<RegisterParticipant>(
+    rmf_traffic_ros2::RegisterParticipantSrvName,
+    [=](const request_id_ptr request_header,
+    const RegisterParticipant::Request::SharedPtr request,
+    const RegisterParticipant::Response::SharedPtr response)
+    { this->register_participant(request_header, request, response); });
 
-  unregister_participant_service =
-      create_service<UnregisterParticipant>(
-        rmf_traffic_ros2::UnregisterParticipantSrvName,
-        [=](const request_id_ptr request_header,
-            const UnregisterParticipant::Request::SharedPtr request,
-            const UnregisterParticipant::Response::SharedPtr response)
-        { this->unregister_participant(request_header, request, response); });
+  unregister_participant_service = create_service<UnregisterParticipant>(
+    rmf_traffic_ros2::UnregisterParticipantSrvName,
+    [=](const request_id_ptr request_header,
+    const UnregisterParticipant::Request::SharedPtr request,
+    const UnregisterParticipant::Response::SharedPtr response)
+    { this->unregister_participant(request_header, request, response); });
 
-  mirror_update_service =
-      create_service<MirrorUpdate>(
-        rmf_traffic_ros2::MirrorUpdateServiceName,
-        [=](const std::shared_ptr<rmw_request_id_t> request_header,
-            const MirrorUpdate::Request::SharedPtr request,
-            const MirrorUpdate::Response::SharedPtr response)
-        { this->mirror_update(request_header, request, response); });
+  mirror_update_service = create_service<MirrorUpdate>(
+    rmf_traffic_ros2::MirrorUpdateServiceName,
+    [=](const std::shared_ptr<rmw_request_id_t> request_header,
+    const MirrorUpdate::Request::SharedPtr request,
+    const MirrorUpdate::Response::SharedPtr response)
+    { this->mirror_update(request_header, request, response); });
 
-  mirror_wakeup_publisher =
-      create_publisher<MirrorWakeup>(
-        rmf_traffic_ros2::MirrorWakeupTopicName,
-        rclcpp::SystemDefaultsQoS());
+  mirror_wakeup_publisher = create_publisher<MirrorWakeup>(
+    rmf_traffic_ros2::MirrorWakeupTopicName,
+    rclcpp::SystemDefaultsQoS());
 
-  conflict_publisher =
-      create_publisher<ScheduleConflictNotice>(
-        rmf_traffic_ros2::ScheduleConflictNoticeTopicName,
-        rclcpp::SystemDefaultsQoS());
+  conflict_publisher = create_publisher<ScheduleConflictNotice>(
+    rmf_traffic_ros2::ScheduleConflictNoticeTopicName,
+    rclcpp::SystemDefaultsQoS());
 
-  itinerary_set_sub =
-      create_subscription<ItinerarySet>(
-        rmf_traffic_ros2::ItinerarySetTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort(),
-        [=](const ItinerarySet::UniquePtr msg)
-  {
-    this->itinerary_set(*msg);
-  });
+  itinerary_set_sub = create_subscription<ItinerarySet>(
+    rmf_traffic_ros2::ItinerarySetTopicName,
+    rclcpp::SystemDefaultsQoS().best_effort(),
+    [=](const ItinerarySet::UniquePtr msg)
+    {
+      this->itinerary_set(*msg);
+    });
 
-  itinerary_extend_sub =
-      create_subscription<ItineraryExtend>(
-        rmf_traffic_ros2::ItineraryExtendTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort(),
-        [=](const ItineraryExtend::UniquePtr msg)
-  {
-    this->itinerary_extend(*msg);
-  });
+  itinerary_extend_sub = create_subscription<ItineraryExtend>(
+    rmf_traffic_ros2::ItineraryExtendTopicName,
+    rclcpp::SystemDefaultsQoS().best_effort(),
+    [=](const ItineraryExtend::UniquePtr msg)
+    {
+      this->itinerary_extend(*msg);
+    });
 
-  itinerary_delay_sub =
-      create_subscription<ItineraryDelay>(
-        rmf_traffic_ros2::ItineraryDelayTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort(),
-        [=](const ItineraryDelay::UniquePtr msg)
-  {
-    this->itinerary_delay(*msg);
-  });
+  itinerary_delay_sub = create_subscription<ItineraryDelay>(
+    rmf_traffic_ros2::ItineraryDelayTopicName,
+    rclcpp::SystemDefaultsQoS().best_effort(),
+    [=](const ItineraryDelay::UniquePtr msg)
+    {
+      this->itinerary_delay(*msg);
+    });
 
-  itinerary_erase_sub =
-      create_subscription<ItineraryErase>(
-        rmf_traffic_ros2::ItineraryEraseTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort(),
-        [=](const ItineraryErase::UniquePtr msg)
-  {
-    this->itinerary_erase(*msg);
-  });
+  itinerary_erase_sub = create_subscription<ItineraryErase>(
+    rmf_traffic_ros2::ItineraryEraseTopicName,
+    rclcpp::SystemDefaultsQoS().best_effort(),
+    [=](const ItineraryErase::UniquePtr msg)
+    {
+      this->itinerary_erase(*msg);
+    });
 
-  itinerary_clear_sub =
-      create_subscription<ItineraryClear>(
-        rmf_traffic_ros2::ItineraryClearTopicName,
-        rclcpp::SystemDefaultsQoS().best_effort(),
-        [=](const ItineraryClear::UniquePtr msg)
-  {
-    this->itinerary_clear(*msg);
-  });
+  itinerary_clear_sub = create_subscription<ItineraryClear>(
+    rmf_traffic_ros2::ItineraryClearTopicName,
+    rclcpp::SystemDefaultsQoS().best_effort(),
+    [=](const ItineraryClear::UniquePtr msg)
+    {
+      this->itinerary_clear(*msg);
+    });
 
-  inconsistency_pub =
-      create_publisher<InconsistencyMsg>(
-        rmf_traffic_ros2::ScheduleInconsistencyTopicName,
-        rclcpp::SystemDefaultsQoS().reliable());
+  inconsistency_pub = create_publisher<InconsistencyMsg>(
+    rmf_traffic_ros2::ScheduleInconsistencyTopicName,
+    rclcpp::SystemDefaultsQoS().reliable());
 
   const auto negotiation_qos = rclcpp::ServicesQoS().reliable();
   conflict_ack_sub = create_subscription<ConflictAck>(
-        rmf_traffic_ros2::ScheduleConflictAckTopicName, negotiation_qos,
-        [&](const ConflictAck::UniquePtr msg)
-  {
-    this->receive_conclusion_ack(*msg);
-  });
+    rmf_traffic_ros2::ScheduleConflictAckTopicName, negotiation_qos,
+    [&](const ConflictAck::UniquePtr msg)
+    {
+      this->receive_conclusion_ack(*msg);
+    });
 
   conflict_notice_pub = create_publisher<ConflictNotice>(
-        rmf_traffic_ros2::ScheduleConflictNoticeTopicName, negotiation_qos);
+    rmf_traffic_ros2::ScheduleConflictNoticeTopicName, negotiation_qos);
 
   conflict_proposal_sub = create_subscription<ConflictProposal>(
-        rmf_traffic_ros2::ScheduleConflictProposalTopicName, negotiation_qos,
-        [&](const ConflictProposal::UniquePtr msg)
-  {
-    this->receive_proposal(*msg);
-  });
+    rmf_traffic_ros2::ScheduleConflictProposalTopicName, negotiation_qos,
+    [&](const ConflictProposal::UniquePtr msg)
+    {
+      this->receive_proposal(*msg);
+    });
 
   conflict_rejection_sub = create_subscription<ConflictRejection>(
-        rmf_traffic_ros2::ScheduleConflictRejectionTopicName, negotiation_qos,
-        [&](const ConflictRejection::UniquePtr msg)
-  {
-    this->receive_rejection(*msg);
-  });
+    rmf_traffic_ros2::ScheduleConflictRejectionTopicName, negotiation_qos,
+    [&](const ConflictRejection::UniquePtr msg)
+    {
+      this->receive_rejection(*msg);
+    });
 
   conflict_conclusion_pub = create_publisher<ConflictConclusion>(
-        rmf_traffic_ros2::ScheduleConflictConclusionTopicName, negotiation_qos);
+    rmf_traffic_ros2::ScheduleConflictConclusionTopicName, negotiation_qos);
 
   conflict_check_quit = false;
   conflict_check_thread = std::thread(
-        [&]()
-  {
-    rmf_traffic::schedule::Mirror mirror;
-    const auto query_all = rmf_traffic::schedule::query_all();
-    Version last_checked_version = 0;
-
-    while (rclcpp::ok() && !conflict_check_quit)
+    [&]()
     {
-      rmf_utils::optional<rmf_traffic::schedule::Patch> next_patch;
-      rmf_traffic::schedule::Viewer::View view_changes;
+      rmf_traffic::schedule::Mirror mirror;
+      const auto query_all = rmf_traffic::schedule::query_all();
+      Version last_checked_version = 0;
 
-      // Use this scope to minimize how long we lock the database for
+      while (rclcpp::ok() && !conflict_check_quit)
       {
-        std::unique_lock<std::mutex> lock(database_mutex);
-        conflict_check_cv.wait_for(lock, std::chrono::milliseconds(100), [&]()
-        {
-          return (database.latest_version() > last_checked_version)
-              && !conflict_check_quit;
-        });
+        rmf_utils::optional<rmf_traffic::schedule::Patch> next_patch;
+        rmf_traffic::schedule::Viewer::View view_changes;
 
-        if (database.latest_version() == last_checked_version
-            || conflict_check_quit)
+        // Use this scope to minimize how long we lock the database for
         {
-          // This is a casual wakeup to check if we're supposed to quit yet
-          continue;
+          std::unique_lock<std::mutex> lock(database_mutex);
+          conflict_check_cv.wait_for(lock, std::chrono::milliseconds(100), [&]()
+          {
+            return (database.latest_version() > last_checked_version)
+            && !conflict_check_quit;
+          });
+
+          if (database.latest_version() == last_checked_version
+          || conflict_check_quit)
+          {
+            // This is a casual wakeup to check if we're supposed to quit yet
+            continue;
+          }
+
+          next_patch = database.changes(query_all, last_checked_version);
+
+          // TODO(MXG): Check whether the database really needs to remain locked
+          // during this update.
+          try
+          {
+            mirror.update(*next_patch);
+            view_changes = database.query(query_all, last_checked_version);
+            last_checked_version = next_patch->latest_version();
+          }
+          catch (const std::exception& e)
+          {
+            RCLCPP_ERROR(get_logger(), e.what());
+            continue;
+          }
         }
 
-        next_patch = database.changes(query_all, last_checked_version);
-
-        // TODO(MXG): Check whether the database really needs to remain locked
-        // during this update.
-        try
+        const auto conflicts = get_conflicts(view_changes, mirror);
+        std::unordered_map<Version, const Negotiation*> new_negotiations;
+        for (const auto& conflict : conflicts)
         {
-          mirror.update(*next_patch);
-          view_changes = database.query(query_all, last_checked_version);
-          last_checked_version = next_patch->latest_version();
+          std::unique_lock<std::mutex> lock(active_conflicts_mutex);
+          const auto new_negotiation = active_conflicts.insert(conflict);
+
+          if (new_negotiation)
+            new_negotiations[new_negotiation->first] = new_negotiation->second;
         }
-        catch(const std::exception& e)
+
+        for (const auto& n : new_negotiations)
         {
-          RCLCPP_ERROR(get_logger(), e.what());
-          continue;
+          ConflictNotice msg;
+          msg.conflict_version = n.first;
+
+          const auto& participants = n.second->participants();
+          msg.participants = ConflictNotice::_participants_type(
+            participants.begin(), participants.end());
+
+          conflict_notice_pub->publish(msg);
         }
       }
-
-      const auto conflicts = get_conflicts(view_changes, mirror);
-      std::unordered_map<Version, const Negotiation*> new_negotiations;
-      for (const auto& conflict : conflicts)
-      {
-        std::unique_lock<std::mutex> lock(active_conflicts_mutex);
-        const auto new_negotiation = active_conflicts.insert(conflict);
-
-        if (new_negotiation)
-          new_negotiations[new_negotiation->first] = new_negotiation->second;
-      }
-
-      for (const auto& n : new_negotiations)
-      {
-        ConflictNotice msg;
-        msg.conflict_version = n.first;
-
-        const auto& participants = n.second->participants();
-        msg.participants = ConflictNotice::_participants_type(
-              participants.begin(), participants.end());
-
-        conflict_notice_pub->publish(msg);
-      }
-    }
-  });
+    });
 }
 
 //==============================================================================
@@ -294,9 +281,9 @@ ScheduleNode::~ScheduleNode()
 
 //==============================================================================
 void ScheduleNode::register_query(
-    const std::shared_ptr<rmw_request_id_t>& /*request_header*/,
-    const RegisterQuery::Request::SharedPtr& request,
-    const RegisterQuery::Response::SharedPtr& response)
+  const std::shared_ptr<rmw_request_id_t>& /*request_header*/,
+  const RegisterQuery::Request::SharedPtr& request,
+  const RegisterQuery::Response::SharedPtr& response)
 {
   uint64_t query_id = last_query_id;
   uint64_t attempts = 0;
@@ -304,44 +291,44 @@ void ScheduleNode::register_query(
   {
     ++query_id;
     ++attempts;
-    if(attempts == std::numeric_limits<uint64_t>::max())
+    if (attempts == std::numeric_limits<uint64_t>::max())
     {
       // I suspect a computer would run out of RAM before we reach this point,
       // but there's no harm in double-checking.
       response->error = "No more space for additional queries to be registered";
       RCLCPP_ERROR(
-            get_logger(),
-            "[ScheduleNode::register_query] " + response->error);
+        get_logger(),
+        "[ScheduleNode::register_query] " + response->error);
       return;
     }
-  } while(registered_queries.find(query_id) != registered_queries.end());
+  } while (registered_queries.find(query_id) != registered_queries.end());
 
   last_query_id = query_id;
   registered_queries.insert(
-        std::make_pair(query_id, rmf_traffic_ros2::convert(request->query)));
+    std::make_pair(query_id, rmf_traffic_ros2::convert(request->query)));
 
   response->query_id = query_id;
   RCLCPP_INFO(
-        get_logger(),
-        "[" + std::to_string(query_id) + "] Registered query");
+    get_logger(),
+    "[" + std::to_string(query_id) + "] Registered query");
 }
 
 //==============================================================================
 void ScheduleNode::unregister_query(
-    const std::shared_ptr<rmw_request_id_t>& /*request_header*/,
-    const UnregisterQuery::Request::SharedPtr& request,
-    const UnregisterQuery::Response::SharedPtr& response)
+  const std::shared_ptr<rmw_request_id_t>& /*request_header*/,
+  const UnregisterQuery::Request::SharedPtr& request,
+  const UnregisterQuery::Response::SharedPtr& response)
 {
   const auto it = registered_queries.find(request->query_id);
-  if(it == registered_queries.end())
+  if (it == registered_queries.end())
   {
     response->error = "No query found with the id ["
-        + std::to_string(request->query_id) + "]";
+      + std::to_string(request->query_id) + "]";
     response->confirmation = false;
 
     RCLCPP_WARN(
-          get_logger(),
-          "[ScheduleNode::unregister_query] " + response->error);
+      get_logger(),
+      "[ScheduleNode::unregister_query] " + response->error);
     return;
   }
 
@@ -349,15 +336,15 @@ void ScheduleNode::unregister_query(
   response->confirmation = true;
 
   RCLCPP_INFO(
-        get_logger(),
-        "[" + std::to_string(request->query_id) + "] Unregistered query");
+    get_logger(),
+    "[" + std::to_string(request->query_id) + "] Unregistered query");
 }
 
 //==============================================================================
 void ScheduleNode::register_participant(
-    const request_id_ptr& /*request_header*/,
-    const RegisterParticipant::Request::SharedPtr& request,
-    const RegisterParticipant::Response::SharedPtr& response)
+  const request_id_ptr& /*request_header*/,
+  const RegisterParticipant::Request::SharedPtr& request,
+  const RegisterParticipant::Response::SharedPtr& response)
 {
   std::unique_lock<std::mutex> lock(database_mutex);
 
@@ -365,29 +352,29 @@ void ScheduleNode::register_participant(
   try
   {
     response->participant_id = database.register_participant(
-          rmf_traffic_ros2::convert(request->description));
+      rmf_traffic_ros2::convert(request->description));
 
     RCLCPP_INFO(
-          get_logger(),
-          "Registered participant [" + std::to_string(response->participant_id)
-          + "] named [" + request->description.name + "] owned by ["
-          + request->description.owner + "]");
+      get_logger(),
+      "Registered participant [" + std::to_string(response->participant_id)
+      + "] named [" + request->description.name + "] owned by ["
+      + request->description.owner + "]");
   }
   catch (const std::exception& e)
   {
     RCLCPP_ERROR(
-          get_logger(),
-          "Failed to register participant [" + request->description.name
-          + "] owned by [" + request->description.owner + "]:" + e.what());
+      get_logger(),
+      "Failed to register participant [" + request->description.name
+      + "] owned by [" + request->description.owner + "]:" + e.what());
     response->error = e.what();
   }
 }
 
 //==============================================================================
 void ScheduleNode::unregister_participant(
-    const request_id_ptr& /*request_header*/,
-    const UnregisterParticipant::Request::SharedPtr& request,
-    const UnregisterParticipant::Response::SharedPtr& response)
+  const request_id_ptr& /*request_header*/,
+  const UnregisterParticipant::Request::SharedPtr& request,
+  const UnregisterParticipant::Response::SharedPtr& response)
 {
   std::unique_lock<std::mutex> lock(database_mutex);
 
@@ -395,9 +382,9 @@ void ScheduleNode::unregister_participant(
   if (!p)
   {
     response->error =
-        "Failed to unregister participant ["
-        + std::to_string(request->participant_id) + "] because no "
-        "participant has that ID";
+      "Failed to unregister participant ["
+      + std::to_string(request->participant_id) + "] because no "
+      "participant has that ID";
     response->confirmation = false;
 
     RCLCPP_ERROR(get_logger(), response->error);
@@ -415,16 +402,16 @@ void ScheduleNode::unregister_participant(
     response->confirmation = true;
 
     RCLCPP_INFO(
-          get_logger(),
-          "Unregistered participant [" + std::to_string(request->participant_id)
-          +"] named [" + name + "] owned by [" + owner + "]");
+      get_logger(),
+      "Unregistered participant [" + std::to_string(request->participant_id)
+      +"] named [" + name + "] owned by [" + owner + "]");
   }
   catch (const std::exception& e)
   {
     RCLCPP_ERROR(
-          get_logger(),
-          "Failed to unregister participant ["
-          + std::to_string(request->participant_id) + "]:" + e.what());
+      get_logger(),
+      "Failed to unregister participant ["
+      + std::to_string(request->participant_id) + "]:" + e.what());
     response->error = e.what();
     response->confirmation = false;
   }
@@ -432,18 +419,18 @@ void ScheduleNode::unregister_participant(
 
 //==============================================================================
 void ScheduleNode::mirror_update(
-    const std::shared_ptr<rmw_request_id_t>& /*request_header*/,
-    const MirrorUpdate::Request::SharedPtr& request,
-    const MirrorUpdate::Response::SharedPtr& response)
+  const std::shared_ptr<rmw_request_id_t>& /*request_header*/,
+  const MirrorUpdate::Request::SharedPtr& request,
+  const MirrorUpdate::Response::SharedPtr& response)
 {
   const auto query_it = registered_queries.find(request->query_id);
-  if(query_it == registered_queries.end())
+  if (query_it == registered_queries.end())
   {
     response->error = "Unrecognized query_id: "
-        + std::to_string(request->query_id);
+      + std::to_string(request->query_id);
     RCLCPP_WARN(
-          get_logger(),
-          "[ScheduleNode::mirror_update] " + response->error);
+      get_logger(),
+      "[ScheduleNode::mirror_update] " + response->error);
     return;
   }
 
@@ -452,7 +439,7 @@ void ScheduleNode::mirror_update(
     version = request->latest_mirror_version;
 
   response->patch =
-      rmf_traffic_ros2::convert(database.changes(query_it->second, version));
+    rmf_traffic_ros2::convert(database.changes(query_it->second, version));
 }
 
 //==============================================================================
@@ -460,9 +447,9 @@ void ScheduleNode::itinerary_set(const ItinerarySet& set)
 {
   std::unique_lock<std::mutex> lock(database_mutex);
   database.set(
-        set.participant,
-        rmf_traffic_ros2::convert(set.itinerary),
-        set.itinerary_version);
+    set.participant,
+    rmf_traffic_ros2::convert(set.itinerary),
+    set.itinerary_version);
 
   publish_inconsistencies(set.participant);
 
@@ -476,15 +463,15 @@ void ScheduleNode::itinerary_extend(const ItineraryExtend& extend)
 {
   std::unique_lock<std::mutex> lock(database_mutex);
   database.extend(
-        extend.participant,
-        rmf_traffic_ros2::convert(extend.routes),
-        extend.itinerary_version);
+    extend.participant,
+    rmf_traffic_ros2::convert(extend.routes),
+    extend.itinerary_version);
 
   publish_inconsistencies(extend.participant);
 
   std::lock_guard<std::mutex> lock2(active_conflicts_mutex);
   active_conflicts.check(
-        extend.participant, database.itinerary_version(extend.participant));
+    extend.participant, database.itinerary_version(extend.participant));
   wakeup_mirrors();
 }
 
@@ -493,16 +480,16 @@ void ScheduleNode::itinerary_delay(const ItineraryDelay& delay)
 {
   std::unique_lock<std::mutex> lock(database_mutex);
   database.delay(
-        delay.participant,
-        rmf_traffic::Time(rmf_traffic::Duration(delay.from_time)),
-        rmf_traffic::Duration(delay.delay),
-        delay.itinerary_version);
+    delay.participant,
+    rmf_traffic::Time(rmf_traffic::Duration(delay.from_time)),
+    rmf_traffic::Duration(delay.delay),
+    delay.itinerary_version);
 
   publish_inconsistencies(delay.participant);
 
   std::lock_guard<std::mutex> lock2(active_conflicts_mutex);
   active_conflicts.check(
-        delay.participant, database.itinerary_version(delay.participant));
+    delay.participant, database.itinerary_version(delay.participant));
   wakeup_mirrors();
 }
 
@@ -511,16 +498,16 @@ void ScheduleNode::itinerary_erase(const ItineraryErase& erase)
 {
   std::unique_lock<std::mutex> lock(database_mutex);
   database.erase(
-        erase.participant,
-        std::vector<rmf_traffic::RouteId>(
-          erase.routes.begin(), erase.routes.end()),
-        erase.itinerary_version);
+    erase.participant,
+    std::vector<rmf_traffic::RouteId>(
+      erase.routes.begin(), erase.routes.end()),
+    erase.itinerary_version);
 
   publish_inconsistencies(erase.participant);
 
   std::lock_guard<std::mutex> lock2(active_conflicts_mutex);
   active_conflicts.check(
-        erase.participant, database.itinerary_version(erase.participant));
+    erase.participant, database.itinerary_version(erase.participant));
   wakeup_mirrors();
 }
 
@@ -534,13 +521,13 @@ void ScheduleNode::itinerary_clear(const ItineraryClear& clear)
 
   std::lock_guard<std::mutex> lock2(active_conflicts_mutex);
   active_conflicts.check(
-        clear.participant, database.itinerary_version(clear.participant));
+    clear.participant, database.itinerary_version(clear.participant));
   wakeup_mirrors();
 }
 
 //==============================================================================
 void ScheduleNode::publish_inconsistencies(
-    rmf_traffic::schedule::ParticipantId id)
+  rmf_traffic::schedule::ParticipantId id)
 {
   // TODO(MXG): This approach is likely to send out a lot of redundant
   // inconsistency reports. We should try to be smarter about how
@@ -565,8 +552,8 @@ void ScheduleNode::wakeup_mirrors()
 
 //==============================================================================
 void print_conclusion(
-    const std::unordered_map<
-        ScheduleNode::Version, ScheduleNode::ConflictRecord::Wait>& _awaiting)
+  const std::unordered_map<
+    ScheduleNode::Version, ScheduleNode::ConflictRecord::Wait>& _awaiting)
 {
   // TODO(MXG): Instead of printing this conclusion information to the terminal,
   // we should periodically output a heartbeat with metadata on the current
@@ -582,7 +569,8 @@ void print_conclusion(
   for (const auto& entry : _awaiting)
   {
     negotiations[entry.second.negotiation_version]
-        .push_back({entry.first, entry.second.itinerary_update_version.has_value()});
+    .push_back({entry.first,
+        entry.second.itinerary_update_version.has_value()});
   }
 
   std::cout << "\n --- Awaiting acknowledgment of conclusions:";
@@ -612,12 +600,12 @@ void ScheduleNode::receive_conclusion_ack(const ConflictAck& msg)
     if (ack.updating)
     {
       active_conflicts.acknowledge(
-            msg.conflict_version, ack.participant, ack.itinerary_version);
+        msg.conflict_version, ack.participant, ack.itinerary_version);
     }
     else
     {
       active_conflicts.acknowledge(
-            msg.conflict_version, ack.participant, rmf_utils::nullopt);
+        msg.conflict_version, ack.participant, rmf_utils::nullopt);
     }
   }
 
@@ -629,14 +617,14 @@ void ScheduleNode::receive_proposal(const ConflictProposal& msg)
 {
   std::unique_lock<std::mutex> lock(active_conflicts_mutex);
   auto* negotiation_room =
-      active_conflicts.negotiation(msg.conflict_version);
+    active_conflicts.negotiation(msg.conflict_version);
 
   if (!negotiation_room)
   {
     RCLCPP_WARN(
-          get_logger(),
-          "Received proposal for unknown negotiation ["
-          + std::to_string(msg.conflict_version) + "]");
+      get_logger(),
+      "Received proposal for unknown negotiation ["
+      + std::to_string(msg.conflict_version) + "]");
     return;
   }
 
@@ -648,8 +636,8 @@ void ScheduleNode::receive_proposal(const ConflictProposal& msg)
   if (!table)
   {
     std::string error = "Received proposal in negotiation ["
-        + std::to_string(msg.conflict_version) + "] for participant ["
-        + std::to_string(msg.for_participant) + "] on unknown table [";
+      + std::to_string(msg.conflict_version) + "] for participant ["
+      + std::to_string(msg.for_participant) + "] on unknown table [";
     for (const auto p : msg.to_accommodate)
       error += " " + std::to_string(p) + " ";
     error += "]";
@@ -663,14 +651,15 @@ void ScheduleNode::receive_proposal(const ConflictProposal& msg)
   negotiation_room->check_cache();
 
   // TODO(MXG): This should be removed once we have a negotiation visualizer
-  rmf_traffic_ros2::schedule::print_negotiation_status(msg.conflict_version, negotiation);
+  rmf_traffic_ros2::schedule::print_negotiation_status(msg.conflict_version,
+    negotiation);
 
   if (negotiation.ready())
   {
     // TODO(MXG): If the negotiation is not complete yet, give some time for
     // more proposals to arrive before choosing one.
     const auto choose =
-        negotiation.evaluate(rmf_traffic::schedule::QuickestFinishEvaluator());
+      negotiation.evaluate(rmf_traffic::schedule::QuickestFinishEvaluator());
     assert(choose);
 
     active_conflicts.conclude(msg.conflict_version);
@@ -681,7 +670,7 @@ void ScheduleNode::receive_proposal(const ConflictProposal& msg)
     conclusion.table = choose->sequence();
 
     std::string output = "Resolved negotiation ["
-        + std::to_string(msg.conflict_version) + ":";
+      + std::to_string(msg.conflict_version) + ":";
 
     for (const auto p : conclusion.table)
       output += " " + std::to_string(p);
@@ -715,9 +704,9 @@ void ScheduleNode::receive_rejection(const ConflictRejection& msg)
   if (!negotiation_room)
   {
     RCLCPP_WARN(
-          get_logger(),
-          "Received rejection for unknown negotiation ["
-          + std::to_string(msg.conflict_version) + "]");
+      get_logger(),
+      "Received rejection for unknown negotiation ["
+      + std::to_string(msg.conflict_version) + "]");
     return;
   }
 
@@ -727,7 +716,7 @@ void ScheduleNode::receive_rejection(const ConflictRejection& msg)
   if (!table)
   {
     std::string error = "Received rejection in negotiation ["
-        + std::to_string(msg.conflict_version) + "] for unknown table [";
+      + std::to_string(msg.conflict_version) + "] for unknown table [";
     for (const auto p : msg.table)
       error += " " + std::to_string(p) + " ";
     error += "]";
@@ -741,7 +730,8 @@ void ScheduleNode::receive_rejection(const ConflictRejection& msg)
   negotiation_room->check_cache();
 
   // TODO(MXG): This should be removed once we have a negotiation visualizer
-  rmf_traffic_ros2::schedule::print_negotiation_status(msg.conflict_version, negotiation);
+  rmf_traffic_ros2::schedule::print_negotiation_status(msg.conflict_version,
+    negotiation);
 
   if (negotiation.complete())
   {

--- a/rmf_traffic_ros2/src/rmf_traffic_schedule/ScheduleNode.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_schedule/ScheduleNode.hpp
@@ -73,9 +73,9 @@ public:
   using RegisterQueryService = rclcpp::Service<RegisterQuery>;
 
   void register_query(
-      const request_id_ptr& request_header,
-      const RegisterQuery::Request::SharedPtr& request,
-      const RegisterQuery::Response::SharedPtr& response);
+    const request_id_ptr& request_header,
+    const RegisterQuery::Request::SharedPtr& request,
+    const RegisterQuery::Response::SharedPtr& response);
 
   RegisterQueryService::SharedPtr register_query_service;
 
@@ -84,9 +84,9 @@ public:
   using UnregisterQueryService = rclcpp::Service<UnregisterQuery>;
 
   void unregister_query(
-      const request_id_ptr& request_header,
-      const UnregisterQuery::Request::SharedPtr& request,
-      const UnregisterQuery::Response::SharedPtr& response);
+    const request_id_ptr& request_header,
+    const UnregisterQuery::Request::SharedPtr& request,
+    const UnregisterQuery::Response::SharedPtr& response);
 
   UnregisterQueryService::SharedPtr unregister_query_service;
 
@@ -95,9 +95,9 @@ public:
   using RegisterParticipantSrv = rclcpp::Service<RegisterParticipant>;
 
   void register_participant(
-      const request_id_ptr& request_header,
-      const RegisterParticipant::Request::SharedPtr& request,
-      const RegisterParticipant::Response::SharedPtr& response);
+    const request_id_ptr& request_header,
+    const RegisterParticipant::Request::SharedPtr& request,
+    const RegisterParticipant::Response::SharedPtr& response);
 
   RegisterParticipantSrv::SharedPtr register_participant_service;
 
@@ -106,9 +106,9 @@ public:
   using UnregisterParticipantSrv = rclcpp::Service<UnregisterParticipant>;
 
   void unregister_participant(
-      const request_id_ptr& request_header,
-      const UnregisterParticipant::Request::SharedPtr& request,
-      const UnregisterParticipant::Response::SharedPtr& response);
+    const request_id_ptr& request_header,
+    const UnregisterParticipant::Request::SharedPtr& request,
+    const UnregisterParticipant::Response::SharedPtr& response);
 
   UnregisterParticipantSrv::SharedPtr unregister_participant_service;
 
@@ -117,9 +117,9 @@ public:
   using MirrorUpdateService = rclcpp::Service<MirrorUpdate>;
 
   void mirror_update(
-      const request_id_ptr& request_header,
-      const MirrorUpdate::Request::SharedPtr& request,
-      const MirrorUpdate::Response::SharedPtr& response);
+    const request_id_ptr& request_header,
+    const MirrorUpdate::Request::SharedPtr& request,
+    const MirrorUpdate::Response::SharedPtr& response);
 
   MirrorUpdateService::SharedPtr mirror_update_service;
 
@@ -130,7 +130,8 @@ public:
 
 
   using ScheduleConflictNotice = rmf_traffic_msgs::msg::ScheduleConflictNotice;
-  using ScheduleConflictNoticePublisher = rclcpp::Publisher<ScheduleConflictNotice>;
+  using ScheduleConflictNoticePublisher =
+    rclcpp::Publisher<ScheduleConflictNotice>;
   ScheduleConflictNoticePublisher::SharedPtr conflict_publisher;
 
 
@@ -165,7 +166,7 @@ public:
   rmf_traffic::schedule::Database database;
 
   using QueryMap =
-      std::unordered_map<uint64_t, rmf_traffic::schedule::Query>;
+    std::unordered_map<uint64_t, rmf_traffic::schedule::Query>;
   // TODO(MXG): Have a way to make query registrations expire after they have
   // not been used for some set amount of time (e.g. 24 hours? 48 hours?).
   std::size_t last_query_id = 0;
@@ -219,7 +220,7 @@ public:
     };
 
     ConflictRecord(const rmf_traffic::schedule::Viewer& viewer)
-      : _viewer(viewer)
+    : _viewer(viewer)
     {
       // Do nothing
     }
@@ -258,10 +259,10 @@ public:
         return rmf_utils::nullopt;
 
       const Version negotiation_version = existing_negotiation ?
-            *existing_negotiation : _next_negotiation_version++;
+        *existing_negotiation : _next_negotiation_version++;
 
       const auto insertion = _negotiations.insert(
-            std::make_pair(negotiation_version, rmf_utils::nullopt));
+        std::make_pair(negotiation_version, rmf_utils::nullopt));
 
       for (const auto p : add_to_negotiation)
         _version[p] = negotiation_version;
@@ -270,8 +271,8 @@ public:
       if (!update_negotiation)
       {
         update_negotiation = rmf_traffic::schedule::Negotiation(
-              _viewer, std::vector<ParticipantId>(
-                add_to_negotiation.begin(), add_to_negotiation.end()));
+          _viewer, std::vector<ParticipantId>(
+            add_to_negotiation.begin(), add_to_negotiation.end()));
       }
       else
       {
@@ -300,12 +301,12 @@ public:
         return;
 
       const auto& participants =
-          negotiation_it->second->negotiation.participants();
+        negotiation_it->second->negotiation.participants();
 
       for (const auto p : participants)
       {
         const auto insertion =
-            _waiting.insert({p, Wait{version, rmf_utils::nullopt}});
+          _waiting.insert({p, Wait{version, rmf_utils::nullopt}});
 
         assert(insertion.second);
         (void)(insertion);
@@ -318,9 +319,9 @@ public:
     // Tell the ConflictRecord what ItineraryVersion will resolve this
     // negotiation.
     void acknowledge(
-        const Version negotiation_version,
-        const ParticipantId p,
-        const rmf_utils::optional<ItineraryVersion> update_version)
+      const Version negotiation_version,
+      const ParticipantId p,
+      const rmf_utils::optional<ItineraryVersion> update_version)
     {
       const auto wait_it = _waiting.find(p);
       if (wait_it == _waiting.end())
@@ -372,7 +373,8 @@ public:
 
 //  private:
     std::unordered_map<ParticipantId, Version> _version;
-    std::unordered_map<Version, rmf_utils::optional<NegotiationRoom>> _negotiations;
+    std::unordered_map<Version,
+      rmf_utils::optional<NegotiationRoom>> _negotiations;
     std::unordered_map<ParticipantId, Wait> _waiting;
     const rmf_traffic::schedule::Viewer& _viewer;
     Version _next_negotiation_version = 0;

--- a/rmf_traffic_ros2/src/rmf_traffic_schedule/main.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_schedule/main.cpp
@@ -26,14 +26,14 @@ int main(int argc, char* argv[])
   const auto node = std::make_shared<rmf_traffic_schedule::ScheduleNode>();
 
   RCLCPP_INFO(
-        node->get_logger(),
-        "Beginning traffic schedule node");
+    node->get_logger(),
+    "Beginning traffic schedule node");
 
   rclcpp::spin(node);
 
   RCLCPP_INFO(
-        node->get_logger(),
-        "Closing down traffic schedule node");
+    node->get_logger(),
+    "Closing down traffic schedule node");
 
   rclcpp::shutdown();
 }

--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -39,6 +39,11 @@ install(
   EXPORT  rmf_utils
 )
 
+install(
+  FILES test/format/rmf_code_style.cfg
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/format
+)
+
 add_subdirectory(test/unit)
 add_subdirectory(cmake/ament_cmake_catch2)
 add_subdirectory(cmake/rmf_cmake_uncrustify)

--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -41,5 +41,6 @@ install(
 
 add_subdirectory(test/unit)
 add_subdirectory(cmake/ament_cmake_catch2)
+add_subdirectory(cmake/rmf_cmake_uncrustify)
 
 ament_package()

--- a/rmf_utils/cmake/rmf_cmake_uncrustify/CMakeLists.txt
+++ b/rmf_utils/cmake/rmf_cmake_uncrustify/CMakeLists.txt
@@ -1,0 +1,24 @@
+
+cmake_minimum_required(VERSION 3.5)
+
+project(rmf_cmake_uncrustify NONE)
+
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_test REQUIRED)
+
+ament_package(
+  CONFIG_EXTRAS "rmf_cmake_uncrustify-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_copyright REQUIRED)
+  ament_copyright()
+
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  ament_lint_cmake()
+endif()

--- a/rmf_utils/cmake/rmf_cmake_uncrustify/cmake/rmf_cmake_uncrustify_lint_hook.cmake
+++ b/rmf_utils/cmake/rmf_cmake_uncrustify/cmake/rmf_cmake_uncrustify_lint_hook.cmake
@@ -1,0 +1,28 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+file(GLOB_RECURSE _source_files FOLLOW_SYMLINKS
+  "*.c"
+  "*.cc"
+  "*.cpp"
+  "*.cxx"
+  "*.h"
+  "*.hh"
+  "*.hpp"
+  "*.hxx"
+)
+if(_source_files)
+  message(STATUS "Added test 'uncrustify' to check C / C++ code style")
+  rmf_uncrustify()
+endif()

--- a/rmf_utils/cmake/rmf_cmake_uncrustify/cmake/rmf_uncrustify.cmake
+++ b/rmf_utils/cmake/rmf_cmake_uncrustify/cmake/rmf_uncrustify.cmake
@@ -1,0 +1,70 @@
+# Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Add a test to check the code for compliance with uncrustify.
+#
+# The default configuration file used for uncrustify is located at
+# configuration/ament_code_style.cfg within the ament_uncrustify directory.
+# The default configuration file can be overridden by the
+# argument 'CONFIG_FILE'.
+#
+# :param TESTNAME: the name of the test, default: "uncrustify"
+# :type TESTNAME: string
+# :param CONFIG_FILE: the path of the configuration file for
+#   ament_uncrustify to consider
+# :type CONFIG_FILE: string
+# :param MAX_LINE_LENGTH: override the maximum line length,
+#   the default is defined in ament_uncrustify
+# :type MAX_LINE_LENGTH: integer
+# :param ARGN: the files or directories to check
+# :type ARGN: list of strings
+#
+# @public
+#
+function(rmf_uncrustify)
+  cmake_parse_arguments(ARG "" "MAX_LINE_LENGTH;TESTNAME;CONFIG_FILE" "" ${ARGN})
+  if(NOT ARG_TESTNAME)
+    set(ARG_TESTNAME "uncrustify")
+  endif()
+
+  find_program(ament_uncrustify_BIN NAMES "ament_uncrustify")
+  if(NOT ament_uncrustify_BIN)
+    message(FATAL_ERROR "rmf_uncrustify() could not find program 'ament_uncrustify'")
+  endif()
+
+  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(cmd "${ament_uncrustify_BIN}" "--xunit-file" "${result_file}")
+  if(DEFINED ARG_MAX_LINE_LENGTH)
+    list(APPEND cmd "--linelength" "${ARG_MAX_LINE_LENGTH}")
+  endif()
+  if(ARG_CONFIG_FILE)
+    list(APPEND cmd "-c" "${ARG_CONFIG_FILE}")
+  endif()
+  list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
+
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/ament_uncrustify")
+  ament_add_test(
+    "${ARG_TESTNAME}"
+    COMMAND ${cmd}
+    OUTPUT_FILE "${CMAKE_BINARY_DIR}/rmf_uncrustify/${ARG_TESTNAME}.txt"
+    RESULT_FILE "${result_file}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+  set_tests_properties(
+    "${ARG_TESTNAME}"
+    PROPERTIES
+    LABELS "uncrustify;linter"
+  )
+endfunction()

--- a/rmf_utils/cmake/rmf_cmake_uncrustify/package.xml
+++ b/rmf_utils/cmake/rmf_cmake_uncrustify/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>rmf_cmake_uncrustify</name>
+  <version>0.8.1</version>
+  <description>
+    ament_cmake_uncrustify with support for parsing a config file.
+    </description>
+  <maintainer email="yadunund@openrobotics.org">Yadunund Vijay</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_test</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
+  <buildtool_export_depend>ament_uncrustify</buildtool_export_depend>
+
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rmf_utils/cmake/rmf_cmake_uncrustify/rmf_cmake_uncrustify-extras.cmake
+++ b/rmf_utils/cmake/rmf_cmake_uncrustify/rmf_cmake_uncrustify-extras.cmake
@@ -1,0 +1,25 @@
+
+# Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# copied from ament_cmake_uncrustify/ament_cmake_uncrustify-extras.cmake
+
+# copied from ament_cmake_uncrustify/ament_cmake_uncrustify-extras.cmake
+
+find_package(ament_cmake_test QUIET REQUIRED)
+
+include("${rmf_cmake_uncrustify_DIR}/rmf_uncrustify.cmake")
+
+ament_register_extension("ament_lint_auto" "rmf_cmake_uncrustify"
+  "rmf_cmake_uncrustify_lint_hook.cmake")

--- a/rmf_utils/test/format/rmf_code_style.cfg
+++ b/rmf_utils/test/format/rmf_code_style.cfg
@@ -1,0 +1,2310 @@
+# Uncrustify-0.68
+
+#
+# General options
+#
+
+# The type of line endings. Default=Auto.
+newlines                        = auto     # auto/lf/crlf/cr
+
+# The original size of tabs in the input. Default=8.
+input_tab_size                  = 2        # unsigned number
+
+# The size of tabs in the output (only used if align_with_tabs=true). Default=8.
+output_tab_size                 = 2        # unsigned number
+
+# The ASCII value of the string escape char, usually 92 (\) or 94 (^). (Pawn).
+string_escape_char              = 92       # unsigned number
+
+# Alternate string escape char for Pawn. Only works right before the quote char.
+string_escape_char2             = 0        # unsigned number
+
+# Replace tab characters found in string literals with the escape sequence \t instead.
+string_replace_tab_chars        = false    # false/true
+
+# Allow interpreting '>=' and '>>=' as part of a template in 'void f(list<list<B>>=val);'.
+# If True, 'assert(x<0 && y>=3)' will be broken. Default=False
+# Improvements to template detection may make this option obsolete.
+tok_split_gte                   = false    # false/true
+
+# Override the default ' *INDENT-OFF*' in comments for disabling processing of part of the file.
+disable_processing_cmt          = " *INDENT-OFF*"      # string
+
+# Override the default ' *INDENT-ON*' in comments for enabling processing of part of the file.
+enable_processing_cmt           = " *INDENT-ON*"     # string
+
+# Enable parsing of digraphs. Default=False.
+enable_digraphs                 = false    # false/true
+
+# Control what to do with the UTF-8 BOM (recommend 'remove').
+utf8_bom                        = ignore   # ignore/add/remove/force
+
+# If the file contains bytes with values between 128 and 255, but is not UTF-8, then output as UTF-8.
+utf8_byte                       = false    # false/true
+
+# Force the output encoding to UTF-8.
+utf8_force                      = false    # false/true
+
+#
+# Spacing options
+#
+
+# Add or remove space around arithmetic operator '+', '-', '/', '*', etc
+# also '>>>' '<<' '>>' '%' '|'.
+sp_arith                        = ignore    # ignore/add/remove/force
+
+# Add or remove space around arithmetic operator '+' and '-'. Overrides sp_arith
+sp_arith_additive               = ignore    # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=', '+=', etc.
+sp_assign                       = force    # ignore/add/remove/force
+
+# Add or remove space around '=' in C++11 lambda capture specifications. Overrides sp_assign.
+sp_cpp_lambda_assign            = remove   # ignore/add/remove/force
+
+# Add or remove space after the capture specification in C++11 lambda.
+sp_cpp_lambda_paren             = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment operator '=' in a prototype.
+sp_assign_default               = ignore   # ignore/add/remove/force
+
+# Add or remove space before assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_before_assign                = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment operator '=', '+=', etc. Overrides sp_assign.
+sp_after_assign                 = ignore   # ignore/add/remove/force
+
+# Add or remove space in 'NS_ENUM ('.
+sp_enum_paren                   = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment '=' in enum.
+sp_enum_assign                  = ignore   # ignore/add/remove/force
+
+# Add or remove space before assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_before_assign           = ignore   # ignore/add/remove/force
+
+# Add or remove space after assignment '=' in enum. Overrides sp_enum_assign.
+sp_enum_after_assign            = ignore   # ignore/add/remove/force
+
+# Add or remove space around assignment ':' in enum.
+sp_enum_colon                   = ignore   # ignore/add/remove/force
+
+# Add or remove space around preprocessor '##' concatenation operator. Default=Add.
+sp_pp_concat                    = ignore    # ignore/add/remove/force
+
+# Add or remove space after preprocessor '#' stringify operator. Also affects the '#@' charizing operator.
+sp_pp_stringify                 = remove   # ignore/add/remove/force
+
+# Add or remove space before preprocessor '#' stringify operator as in '#define x(y) L#y'.
+sp_before_pp_stringify          = ignore   # ignore/add/remove/force
+
+# Add or remove space around boolean operators '&&' and '||'.
+sp_bool                         = ignore    # ignore/add/remove/force
+
+# Add or remove space around compare operator '<', '>', '==', etc.
+sp_compare                      = add    # ignore/add/remove/force
+
+# Add or remove space inside '(' and ')'.
+sp_inside_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between nested parens: '((' vs ') )'.
+sp_paren_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between back-to-back parens: ')(' vs ') ('.
+sp_cparen_oparen                = ignore   # ignore/add/remove/force
+
+# Whether to balance spaces inside nested parens.
+sp_balance_nested_parens        = false    # false/true
+
+# Add or remove space between ')' and '{'.
+sp_paren_brace                  = ignore    # ignore/add/remove/force
+
+# Add or remove space between nested braces, i.e. '{{' vs '{ {'.
+sp_brace_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove space before pointer star '*'.
+sp_before_ptr_star              = remove    # ignore/add/remove/force
+
+# Add or remove space before pointer star '*' that isn't followed by a variable name
+# If set to 'ignore', sp_before_ptr_star is used instead.
+sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force
+
+# Add or remove space between pointer stars '*'.
+sp_between_ptr_star             = remove   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a word.
+sp_after_ptr_star               = add    # ignore/add/remove/force
+
+# Add or remove space after pointer caret '^', if followed by a word.
+sp_after_ptr_block_caret        = ignore   # ignore/add/remove/force
+
+# Add or remove space after pointer star '*', if followed by a qualifier.
+sp_after_ptr_star_qualifier     = add   # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by a func proto/def.
+sp_after_ptr_star_func          = add    # ignore/add/remove/force
+
+# Add or remove space after a pointer star '*', if followed by an open paren (function types).
+sp_ptr_star_paren               = add   # ignore/add/remove/force
+
+# Add or remove space before a pointer star '*', if followed by a func proto/def.
+sp_before_ptr_star_func         = remove    # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&'.
+sp_before_byref                 = remove    # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&' that isn't followed by a variable name.
+# If set to 'ignore', sp_before_byref is used instead.
+sp_before_unnamed_byref         = remove   # ignore/add/remove/force
+
+# Add or remove space after reference sign '&', if followed by a word.
+sp_after_byref                  = add    # ignore/add/remove/force
+
+# Add or remove space after a reference sign '&', if followed by a func proto/def.
+sp_after_byref_func             = add    # ignore/add/remove/force
+
+# Add or remove space before a reference sign '&', if followed by a func proto/def.
+sp_before_byref_func            = remove    # ignore/add/remove/force
+
+# Add or remove space between type and word. Default=Force.
+sp_after_type                   = ignore    # ignore/add/remove/force
+
+# Add or remove space between 'decltype(...)' and word.
+sp_after_decltype               = ignore   # ignore/add/remove/force
+
+# Add or remove space before the paren in the D constructs 'template Foo(' and 'class Foo('.
+sp_before_template_paren        = ignore   # ignore/add/remove/force
+
+# Add or remove space in 'template <' vs 'template<'.
+# If set to ignore, sp_before_angle is used.
+sp_template_angle               = ignore   # ignore/add/remove/force
+
+# Add or remove space before '<>'.
+sp_before_angle                 = remove   # ignore/add/remove/force
+
+# Add or remove space inside '<' and '>'.
+sp_inside_angle                 = remove   # ignore/add/remove/force
+
+# Add or remove space between '<>' and ':'.
+sp_angle_colon                  = ignore   # ignore/add/remove/force
+
+# Add or remove space after '<>'.
+sp_after_angle                  = remove   # ignore/add/remove/force
+
+# Add or remove space between '<>' and '(' as found in 'new List<byte>(foo);'.
+sp_angle_paren                  = remove   # ignore/add/remove/force
+
+# Add or remove space between '<>' and '()' as found in 'new List<byte>();'.
+sp_angle_paren_empty            = remove   # ignore/add/remove/force
+
+# Add or remove space between '<>' and a word as in 'List<byte> m;' or 'template <typename T> static ...'.
+sp_angle_word                   = force    # ignore/add/remove/force
+
+# Add or remove space between '>' and '>' in '>>' (template stuff). Default=Add.
+sp_angle_shift                  = remove   # ignore/add/remove/force
+
+# Permit removal of the space between '>>' in 'foo<bar<int> >' (C++11 only). Default=False.
+# sp_angle_shift cannot remove the space without this option.
+sp_permit_cpp11_shift           = true     # false/true
+
+# Add or remove space before '(' of 'if', 'for', 'switch', 'while', etc.
+sp_before_sparen                = force    # ignore/add/remove/force
+
+# Add or remove space inside if-condition '(' and ')'.
+sp_inside_sparen                = remove   # ignore/add/remove/force
+
+# Add or remove space before if-condition ')'. Overrides sp_inside_sparen.
+sp_inside_sparen_close          = ignore   # ignore/add/remove/force
+
+# Add or remove space after if-condition '('. Overrides sp_inside_sparen.
+sp_inside_sparen_open           = ignore   # ignore/add/remove/force
+
+# Add or remove space after ')' of 'if', 'for', 'switch', and 'while', etc.
+sp_after_sparen                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of 'if', 'for', 'switch', and 'while', etc.
+sp_sparen_brace                 = force    # ignore/add/remove/force
+
+# Add or remove space between 'invariant' and '(' in the D language.
+sp_invariant_paren              = ignore   # ignore/add/remove/force
+
+# Add or remove space after the ')' in 'invariant (C) c' in the D language.
+sp_after_invariant_paren        = ignore   # ignore/add/remove/force
+
+# Add or remove space before empty statement ';' on 'if', 'for' and 'while'.
+sp_special_semi                 = ignore   # ignore/add/remove/force
+
+# Add or remove space before ';'. Default=Remove.
+sp_before_semi                  = remove   # ignore/add/remove/force
+
+# Add or remove space before ';' in non-empty 'for' statements.
+sp_before_semi_for              = ignore   # ignore/add/remove/force
+
+# Add or remove space before a semicolon of an empty part of a for statement.
+sp_before_semi_for_empty        = ignore   # ignore/add/remove/force
+
+# Add or remove space after ';', except when followed by a comment. Default=Add.
+sp_after_semi                   = ignore   # ignore/add/remove/force
+
+# Add or remove space after ';' in non-empty 'for' statements. Default=Force.
+sp_after_semi_for               = force    # ignore/add/remove/force
+
+# Add or remove space after the final semicolon of an empty part of a for statement: for ( ; ; <here> ).
+sp_after_semi_for_empty         = force    # ignore/add/remove/force
+
+# Add or remove space before '[' (except '[]').
+sp_before_square                = remove   # ignore/add/remove/force
+
+# Add or remove space before structured bindings. Only for C++17.
+sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force
+
+# Add or remove space before '[]'.
+sp_before_squares               = remove   # ignore/add/remove/force
+
+# Add or remove space inside a non-empty '[' and ']'.
+sp_inside_square                = remove   # ignore/add/remove/force
+
+# Add or remove space inside a non-empty OC boxed array '@[' and ']'.
+# If set to ignore, sp_inside_square is used.
+sp_inside_square_oc_array       = ignore   # ignore/add/remove/force
+
+# Add or remove space after ',', 'a,b' vs 'a, b'.
+sp_after_comma                  = force    # ignore/add/remove/force
+
+# Add or remove space before ','. Default=Remove.
+sp_before_comma                 = remove   # ignore/add/remove/force
+
+# Add or remove space between ',' and ']' in multidimensional array type 'int[,,]'. Only for C#.
+sp_after_mdatype_commas         = ignore   # ignore/add/remove/force
+
+# Add or remove space between '[' and ',' in multidimensional array type 'int[,,]'. Only for C#.
+sp_before_mdatype_commas        = ignore   # ignore/add/remove/force
+
+# Add or remove space between ',' in multidimensional array type 'int[,,]'. Only for C#.
+sp_between_mdatype_commas       = ignore   # ignore/add/remove/force
+
+# Add or remove space between an open paren and comma: '(,' vs '( ,'. Default=Force.
+sp_paren_comma                  = force    # ignore/add/remove/force
+
+# Add or remove space before the variadic '...' when preceded by a non-punctuator.
+sp_before_ellipsis              = remove   # ignore/add/remove/force
+
+# Add or remove space between a type and '...'.
+sp_type_ellipsis                = remove   # ignore/add/remove/force
+
+# Add or remove space between ')' and '...'.
+sp_paren_ellipsis               = remove   # ignore/add/remove/force
+
+# Add or remove space after class ':'.
+sp_after_class_colon            = add    # ignore/add/remove/force
+
+# Add or remove space before class ':'.
+sp_before_class_colon           = add    # ignore/add/remove/force
+
+# Add or remove space after class constructor ':'.
+sp_after_constr_colon           = ignore   # ignore/add/remove/force
+
+# Add or remove space before class constructor ':'.
+sp_before_constr_colon          = ignore   # ignore/add/remove/force
+
+# Add or remove space before case ':'. Default=Remove.
+sp_before_case_colon            = remove   # ignore/add/remove/force
+
+# Add or remove space between 'operator' and operator sign.
+sp_after_operator               = remove   # ignore/add/remove/force
+
+# Add or remove space between the operator symbol and the open paren, as in 'operator ++('.
+sp_after_operator_sym           = remove   # ignore/add/remove/force
+
+# Overrides sp_after_operator_sym when the operator has no arguments, as in 'operator *()'.
+sp_after_operator_sym_empty     = remove   # ignore/add/remove/force
+
+# Add or remove space after C/D cast, i.e. 'cast(int)a' vs 'cast(int) a' or '(int)a' vs '(int) a'.
+sp_after_cast                   = ignore   # ignore/add/remove/force
+
+# Add or remove spaces inside cast parens.
+sp_inside_paren_cast            = remove   # ignore/add/remove/force
+
+# Add or remove space between the type and open paren in a C++ cast, i.e. 'int(exp)' vs 'int (exp)'.
+sp_cpp_cast_paren               = remove   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof' and '('.
+sp_sizeof_paren                 = remove   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof' and '...'.
+sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'sizeof...' and '('.
+sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'decltype' and '('.
+sp_decltype_paren               = ignore   # ignore/add/remove/force
+
+# Add or remove space after the tag keyword (Pawn).
+sp_after_tag                    = ignore   # ignore/add/remove/force
+
+# Add or remove space inside enum '{' and '}'.
+sp_inside_braces_enum           = ignore   # ignore/add/remove/force
+
+# Add or remove space inside struct/union '{' and '}'.
+sp_inside_braces_struct         = ignore   # ignore/add/remove/force
+
+# Add or remove space inside OC boxed dictionary @'{' and '}'
+sp_inside_braces_oc_dict        = ignore   # ignore/add/remove/force
+
+# Add or remove space after open brace in an unnamed temporary direct-list-initialization.
+sp_after_type_brace_init_lst_open = ignore   # ignore/add/remove/force
+
+# Add or remove space before close brace in an unnamed temporary direct-list-initialization.
+sp_before_type_brace_init_lst_close = ignore   # ignore/add/remove/force
+
+# Add or remove space inside an unnamed temporary direct-list-initialization.
+sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '{' and '}'.
+sp_inside_braces                = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '{}'.
+sp_inside_braces_empty          = remove   # ignore/add/remove/force
+
+# Add or remove space between return type and function name
+# A minimum of 1 is forced except for pointer return types.
+sp_type_func                    = ignore   # ignore/add/remove/force
+
+# Add or remove space between type and open brace of an unnamed temporary direct-list-initialization.
+sp_type_brace_init_lst          = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function declaration.
+sp_func_proto_paren             = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function declaration without parameters.
+sp_func_proto_paren_empty       = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function definition.
+sp_func_def_paren               = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function definition without parameters.
+sp_func_def_paren_empty         = remove   # ignore/add/remove/force
+
+# Add or remove space inside empty function '()'.
+sp_inside_fparens               = remove   # ignore/add/remove/force
+
+# Add or remove space inside function '(' and ')'.
+sp_inside_fparen                = remove   # ignore/add/remove/force
+
+# Add or remove space inside the first parens in the function type: 'void (*x)(...)'.
+sp_inside_tparen                = ignore   # ignore/add/remove/force
+
+# Add or remove between the parens in the function type: 'void (*x)(...)'.
+sp_after_tparen_close           = ignore   # ignore/add/remove/force
+
+# Add or remove space between ']' and '(' when part of a function call.
+sp_square_fparen                = remove   # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of function.
+sp_fparen_brace                 = force    # ignore/add/remove/force
+
+# Add or remove space between ')' and '{' of function call in object initialization. Overrides sp_fparen_brace.
+sp_fparen_brace_initializer     = force   # ignore/add/remove/force
+
+# Java: Add or remove space between ')' and '{{' of double brace initializer.
+sp_fparen_dbrace                = ignore   # ignore/add/remove/force
+
+# Add or remove space between function name and '(' on function calls.
+sp_func_call_paren              = remove   # ignore/add/remove/force
+
+# Add or remove space between function name and '()' on function calls without parameters.
+# If set to 'ignore' (the default), sp_func_call_paren is used.
+sp_func_call_paren_empty        = ignore   # ignore/add/remove/force
+
+# Add or remove space between the user function name and '(' on function calls
+# You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+sp_func_call_user_paren         = ignore   # ignore/add/remove/force
+
+# Add or remove space inside user function '(' and ')'
+# You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+sp_func_call_user_inside_fparen = ignore   # ignore/add/remove/force
+
+# Add or remove space between nested parens with user functions: '((' vs ') )'You need to set a keyword to be a user function, like this: 'set func_call_user _' in the config file.
+sp_func_call_user_paren_paren   = ignore   # ignore/add/remove/force
+
+# Add or remove space between a constructor/destructor and the open paren.
+sp_func_class_paren             = remove   # ignore/add/remove/force
+
+# Add or remove space between a constructor without parameters or destructor and '()'.
+sp_func_class_paren_empty       = remove   # ignore/add/remove/force
+
+# Add or remove space between 'return' and '('.
+sp_return_paren                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'return' and '{'.
+sp_return_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between '__attribute__' and '('.
+sp_attribute_paren              = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'defined' and '(' in '#if defined (FOO)'.
+sp_defined_paren                = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and '(' in 'throw (something)'.
+sp_throw_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'throw' and anything other than '(' as in '@throw [...];'.
+sp_after_throw                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '(' in 'catch (something) { }'
+# If set to ignore, sp_before_sparen is used.
+sp_catch_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between '@catch' and '(' in '@catch (something) { }'
+# If set to ignore, sp_catch_paren is used.
+sp_oc_catch_paren               = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'version' and '(' in 'version (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_version_paren                = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'scope' and '(' in 'scope (something) { }' (D language)
+# If set to ignore, sp_before_sparen is used.
+sp_scope_paren                  = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'super' and '(' in 'super (something)'. Default=Remove.
+sp_super_paren                  = remove   # ignore/add/remove/force
+
+# Add or remove space between 'this' and '(' in 'this (something)'. Default=Remove.
+sp_this_paren                   = remove   # ignore/add/remove/force
+
+# Add or remove space between macro and value.
+sp_macro                        = ignore   # ignore/add/remove/force
+
+# Add or remove space between macro function ')' and value.
+sp_macro_func                   = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'else' and '{' if on the same line.
+sp_else_brace                   = force    # ignore/add/remove/force
+
+# Add or remove space between '}' and 'else' if on the same line.
+sp_brace_else                   = force    # ignore/add/remove/force
+
+# Add or remove space between '}' and the name of a typedef on the same line.
+sp_brace_typedef                = force    # ignore/add/remove/force
+
+# Add or remove space between 'catch' and '{' if on the same line.
+sp_catch_brace                  = force    # ignore/add/remove/force
+
+# Add or remove space between '@catch' and '{' if on the same line.
+# If set to ignore, sp_catch_brace is used.
+sp_oc_catch_brace               = ignore   # ignore/add/remove/force
+
+# Add or remove space between '}' and 'catch' if on the same line.
+sp_brace_catch                  = force    # ignore/add/remove/force
+
+# Add or remove space between '}' and '@catch' if on the same line.
+# If set to ignore, sp_brace_catch is used.
+sp_oc_brace_catch               = ignore   # ignore/add/remove/force
+
+# Add or remove space between 'finally' and '{' if on the same line.
+sp_finally_brace                = force    # ignore/add/remove/force
+
+# Add or remove space between '}' and 'finally' if on the same line.
+sp_brace_finally                = force    # ignore/add/remove/force
+
+# Add or remove space between 'try' and '{' if on the same line.
+sp_try_brace                    = force    # ignore/add/remove/force
+
+# Add or remove space between get/set and '{' if on the same line.
+sp_getset_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove space between a variable and '{' for C++ uniform initialization. Default=Add.
+sp_word_brace                   = add      # ignore/add/remove/force
+
+# Add or remove space between a variable and '{' for a namespace. Default=Add.
+sp_word_brace_ns                = add      # ignore/add/remove/force
+
+# Add or remove space before the '::' operator.
+sp_before_dc                    = remove   # ignore/add/remove/force
+
+# Add or remove space after the '::' operator.
+sp_after_dc                     = remove   # ignore/add/remove/force
+
+# Add or remove around the D named array initializer ':' operator.
+sp_d_array_colon                = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '!' (not) operator. Default=Remove.
+sp_not                          = remove   # ignore/add/remove/force
+
+# Add or remove space after the '~' (invert) operator. Default=Remove.
+sp_inv                          = remove   # ignore/add/remove/force
+
+# Add or remove space after the '&' (address-of) operator. Default=Remove
+# This does not affect the spacing after a '&' that is part of a type.
+sp_addr                         = ignore   # ignore/add/remove/force
+
+# Add or remove space around the '.' or '->' operators. Default=Remove.
+sp_member                       = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '*' (dereference) operator. Default=Remove
+# This does not affect the spacing after a '*' that is part of a type.
+sp_deref                        = remove   # ignore/add/remove/force
+
+# Add or remove space after '+' or '-', as in 'x = -5' or 'y = +7'. Default=Remove.
+sp_sign                         = ignore   # ignore/add/remove/force
+
+# Add or remove space before or after '++' and '--', as in '(--x)' or 'y++;'. Default=Remove.
+sp_incdec                       = ignore   # ignore/add/remove/force
+
+# Add or remove space before a backslash-newline at the end of a line. Default=Add.
+sp_before_nl_cont               = ignore    # ignore/add/remove/force
+
+# Add or remove space after the scope '+' or '-', as in '-(void) foo;' or '+(int) bar;'.
+sp_after_oc_scope               = ignore   # ignore/add/remove/force
+
+# Add or remove space after the colon in message specs
+# '-(int) f:(int) x;' vs '-(int) f: (int) x;'.
+sp_after_oc_colon               = ignore   # ignore/add/remove/force
+
+# Add or remove space before the colon in message specs
+# '-(int) f: (int) x;' vs '-(int) f : (int) x;'.
+sp_before_oc_colon              = ignore   # ignore/add/remove/force
+
+# Add or remove space after the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'.
+sp_after_oc_dict_colon          = ignore   # ignore/add/remove/force
+
+# Add or remove space before the colon in immutable dictionary expression
+# 'NSDictionary *test = @{@"foo" :@"bar"};'.
+sp_before_oc_dict_colon         = ignore   # ignore/add/remove/force
+
+# Add or remove space after the colon in message specs
+# '[object setValue:1];' vs '[object setValue: 1];'.
+sp_after_send_oc_colon          = ignore   # ignore/add/remove/force
+
+# Add or remove space before the colon in message specs
+# '[object setValue:1];' vs '[object setValue :1];'.
+sp_before_send_oc_colon         = ignore   # ignore/add/remove/force
+
+# Add or remove space after the (type) in message specs
+# '-(int)f: (int) x;' vs '-(int)f: (int)x;'.
+sp_after_oc_type                = ignore   # ignore/add/remove/force
+
+# Add or remove space after the first (type) in message specs
+# '-(int) f:(int)x;' vs '-(int)f:(int)x;'.
+sp_after_oc_return_type         = ignore   # ignore/add/remove/force
+
+# Add or remove space between '@selector' and '('
+# '@selector(msgName)' vs '@selector (msgName)'
+# Also applies to @protocol() constructs.
+sp_after_oc_at_sel              = ignore   # ignore/add/remove/force
+
+# Add or remove space between '@selector(x)' and the following word
+# '@selector(foo) a:' vs '@selector(foo)a:'.
+sp_after_oc_at_sel_parens       = ignore   # ignore/add/remove/force
+
+# Add or remove space inside '@selector' parens
+# '@selector(foo)' vs '@selector( foo )'
+# Also applies to @protocol() constructs.
+sp_inside_oc_at_sel_parens      = ignore   # ignore/add/remove/force
+
+# Add or remove space before a block pointer caret
+# '^int (int arg){...}' vs. ' ^int (int arg){...}'.
+sp_before_oc_block_caret        = ignore   # ignore/add/remove/force
+
+# Add or remove space after a block pointer caret
+# '^int (int arg){...}' vs. '^ int (int arg){...}'.
+sp_after_oc_block_caret         = ignore   # ignore/add/remove/force
+
+# Add or remove space between the receiver and selector in a message.
+# '[receiver selector ...]'.
+sp_after_oc_msg_receiver        = ignore   # ignore/add/remove/force
+
+# Add or remove space after @property.
+sp_after_oc_property            = ignore   # ignore/add/remove/force
+
+# Add or remove space between '@synchronized' and the parenthesis
+# '@synchronized(foo)' vs '@synchronized (foo)'.
+sp_after_oc_synchronized        = ignore   # ignore/add/remove/force
+
+# Add or remove space around the ':' in 'b ? t : f'.
+sp_cond_colon                   = add    # ignore/add/remove/force
+
+# Add or remove space before the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_before            = ignore   # ignore/add/remove/force
+
+# Add or remove space after the ':' in 'b ? t : f'. Overrides sp_cond_colon.
+sp_cond_colon_after             = ignore   # ignore/add/remove/force
+
+# Add or remove space around the '?' in 'b ? t : f'.
+sp_cond_question                = add    # ignore/add/remove/force
+
+# Add or remove space before the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_before         = ignore   # ignore/add/remove/force
+
+# Add or remove space after the '?' in 'b ? t : f'. Overrides sp_cond_question.
+sp_cond_question_after          = ignore   # ignore/add/remove/force
+
+# In the abbreviated ternary form (a ?: b), add/remove space between ? and :.'. Overrides all other sp_cond_* options.
+sp_cond_ternary_short           = ignore   # ignore/add/remove/force
+
+# Fix the spacing between 'case' and the label. Only 'ignore' and 'force' make sense here.
+sp_case_label                   = force    # ignore/add/remove/force
+
+# Control the space around the D '..' operator.
+sp_range                        = ignore   # ignore/add/remove/force
+
+# Control the spacing after ':' in 'for (TYPE VAR : EXPR)'. Only JAVA.
+sp_after_for_colon              = ignore   # ignore/add/remove/force
+
+# Control the spacing before ':' in 'for (TYPE VAR : EXPR)'. Only JAVA.
+sp_before_for_colon             = ignore   # ignore/add/remove/force
+
+# Control the spacing in 'extern (C)' (D).
+sp_extern_paren                 = ignore   # ignore/add/remove/force
+
+# Control the space after the opening of a C++ comment '// A' vs '//A'.
+sp_cmt_cpp_start                = ignore   # ignore/add/remove/force
+
+# True: If space is added with sp_cmt_cpp_start, do it after doxygen sequences like '///', '///<', '//!' and '//!<'.
+sp_cmt_cpp_doxygen              = false    # false/true
+
+# True: If space is added with sp_cmt_cpp_start, do it after Qt translator or meta-data comments like '//:', '//=', and '//~'.
+sp_cmt_cpp_qttr                 = false    # false/true
+
+# Controls the spaces between #else or #endif and a trailing comment.
+sp_endif_cmt                    = add   # ignore/add/remove/force
+
+# Controls the spaces after 'new', 'delete' and 'delete[]'.
+sp_after_new                    = force    # ignore/add/remove/force
+
+# Controls the spaces between new and '(' in 'new()'.
+sp_between_new_paren            = ignore   # ignore/add/remove/force
+
+# Controls the spaces between ')' and 'type' in 'new(foo) BAR'.
+sp_after_newop_paren            = ignore   # ignore/add/remove/force
+
+# Controls the spaces inside paren of the new operator: 'new(foo) BAR'.
+sp_inside_newop_paren           = ignore   # ignore/add/remove/force
+
+# Controls the space after open paren of the new operator: 'new(foo) BAR'.
+# Overrides sp_inside_newop_paren.
+sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force
+
+# Controls the space before close paren of the new operator: 'new(foo) BAR'.
+# Overrides sp_inside_newop_paren.
+sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force
+
+# Controls the spaces before a trailing or embedded comment.
+sp_before_tr_emb_cmt            = add   # ignore/add/remove/force
+
+# Number of spaces before a trailing or embedded comment.
+sp_num_before_tr_emb_cmt        = 1        # unsigned number
+
+# Control space between a Java annotation and the open paren.
+sp_annotation_paren             = ignore   # ignore/add/remove/force
+
+# If True, vbrace tokens are dropped to the previous token and skipped.
+sp_skip_vbrace_tokens           = false    # false/true
+
+# Controls the space after 'noexcept'.
+sp_after_noexcept               = ignore   # ignore/add/remove/force
+
+# If True, a <TAB> is inserted after #define.
+force_tab_after_define          = false    # false/true
+
+#
+# Indenting
+#
+
+# The number of columns to indent per level.
+# Usually 2, 3, 4, or 8. Default=8.
+indent_columns                  = 2        # unsigned number
+
+# The continuation indent. If non-zero, this overrides the indent of '(' and '=' continuation indents.
+# For FreeBSD, this is set to 4. Negative value is absolute and not increased for each '(' level.
+indent_continue                 = 2        # number
+
+# The continuation indent, only for class header line(s). If non-zero, this
+# overrides the indent of 'class' continuation indents.
+indent_continue_class_head      = 0        # unsigned number
+
+# Indent empty lines - lines which contain only spaces before newline character
+indent_single_newlines          = false    # false/true
+
+# The continuation indent for func_*_param if they are true.
+# If non-zero, this overrides the indent.
+indent_param                    = 0        # unsigned number
+
+# How to use tabs when indenting code
+# 0=spaces only
+# 1=indent with tabs to brace level, align with spaces (default)
+# 2=indent and align with tabs, using spaces when not on a tabstop
+indent_with_tabs                = 0        # unsigned number
+
+# Comments that are not a brace level are indented with tabs on a tabstop.
+# Requires indent_with_tabs=2. If false, will use spaces.
+indent_cmt_with_tabs            = false    # false/true
+
+# Whether to indent strings broken by '\' so that they line up.
+indent_align_string             = false    # false/true
+
+# The number of spaces to indent multi-line XML strings.
+# Requires indent_align_string=True.
+indent_xml_string               = 0        # unsigned number
+
+# Spaces to indent '{' from level.
+indent_brace                    = 0        # unsigned number
+
+# Whether braces are indented to the body level.
+indent_braces                   = false    # false/true
+
+# Disabled indenting function braces if indent_braces is True.
+indent_braces_no_func           = false    # false/true
+
+# Disabled indenting class braces if indent_braces is True.
+indent_braces_no_class          = false    # false/true
+
+# Disabled indenting struct braces if indent_braces is True.
+indent_braces_no_struct         = false    # false/true
+
+# Indent based on the size of the brace parent, i.e. 'if' => 3 spaces, 'for' => 4 spaces, etc.
+indent_brace_parent             = false    # false/true
+
+# Indent based on the paren open instead of the brace open in '({\n', default is to indent by brace.
+indent_paren_open_brace         = true    # false/true
+
+# indent a C# delegate by another level, default is to not indent by another level.
+indent_cs_delegate_brace        = false    # false/true
+
+# indent a C# delegate(To hanndle delegates with no brace) by another level. default: false
+indent_cs_delegate_body         = false    # false/true
+
+# Whether the 'namespace' body is indented.
+indent_namespace                = false    # false/true
+
+# Only indent one namespace and no sub-namespaces.
+# Requires indent_namespace=True.
+indent_namespace_single_indent  = false    # false/true
+
+# The number of spaces to indent a namespace block.
+indent_namespace_level          = 0        # unsigned number
+
+# If the body of the namespace is longer than this number, it won't be indented.
+# Requires indent_namespace=True. Default=0 (no limit)
+indent_namespace_limit          = 0        # unsigned number
+
+# Whether the 'extern "C"' body is indented.
+indent_extern                   = false    # false/true
+
+# Whether the 'class' body is indented.
+indent_class                    = true     # false/true
+
+# Whether to indent the stuff after a leading base class colon.
+indent_class_colon              = false    # false/true
+
+# Indent based on a class colon instead of the stuff after the colon.
+# Requires indent_class_colon=True. Default=False.
+indent_class_on_colon           = false    # false/true
+
+# Whether to indent the stuff after a leading class initializer colon.
+indent_constr_colon             = true     # false/true
+
+# Virtual indent from the ':' for member initializers. Default=2.
+indent_ctor_init_leading        = 2        # unsigned number
+
+# Additional indent for constructor initializer list.
+# Negative values decrease indent down to the first column. Default=0.
+indent_ctor_init                = -2       # number
+
+# False=treat 'else\nif' as 'else if' for indenting purposes
+# True=indent the 'if' one level.
+indent_else_if                  = false    # false/true
+
+# Amount to indent variable declarations after a open brace. neg=relative, pos=absolute.
+indent_var_def_blk              = 0        # number
+
+# Indent continued variable declarations instead of aligning.
+indent_var_def_cont             = false    # false/true
+
+# Indent continued shift expressions ('<<' and '>>') instead of aligning.
+# Turn align_left_shift off when enabling this.
+indent_shift                    = true    # false/true
+
+# True:  force indentation of function definition to start in column 1
+# False: use the default behavior.
+indent_func_def_force_col1      = false    # false/true
+
+# True:  indent continued function call parameters one indent level
+# False: align parameters under the open paren.
+indent_func_call_param          = false     # false/true
+
+# Same as indent_func_call_param, but for function defs.
+indent_func_def_param           = false    # false/true
+
+# Same as indent_func_call_param, but for function protos.
+indent_func_proto_param         = false    # false/true
+
+# Same as indent_func_call_param, but for class declarations.
+indent_func_class_param         = false    # false/true
+
+# Same as indent_func_call_param, but for class variable constructors.
+indent_func_ctor_var_param      = false    # false/true
+
+# Same as indent_func_call_param, but for templates.
+indent_template_param           = false    # false/true
+
+# Double the indent for indent_func_xxx_param options.
+# Use both values of the options indent_columns and indent_param.
+indent_func_param_double        = false    # false/true
+
+# Indentation column for standalone 'const' function decl/proto qualifier.
+indent_func_const               = 0        # unsigned number
+
+# Indentation column for standalone 'throw' function decl/proto qualifier.
+indent_func_throw               = 0        # unsigned number
+
+# The number of spaces to indent a continued '->' or '.'
+# Usually set to 0, 1, or indent_columns.
+indent_member                   = 0        # unsigned number
+
+# setting to true will indent lines broken at '.' or '->' by a single indent
+# UO_indent_member option will not be effective if this is set to true.
+indent_member_single            = false    # false/true
+
+# Spaces to indent single line ('//') comments on lines before code.
+indent_sing_line_comments       = 0        # unsigned number
+
+# If set, will indent trailing single line ('//') comments relative
+# to the code instead of trying to keep the same absolute column.
+indent_relative_single_line_comments = true    # false/true
+
+# Spaces to indent 'case' from 'switch'
+# Usually 0 or indent_columns.
+indent_switch_case              = 2        # unsigned number
+
+# Whether to indent preprocessor statements inside of switch statements.
+indent_switch_pp                = true     # false/true
+
+# Spaces to shift the 'case' line, without affecting any other lines
+# Usually 0.
+indent_case_shift               = 0        # unsigned number
+
+# Spaces to indent '{' from 'case'.
+# By default, the brace will appear under the 'c' in case.
+# Usually set to 0 or indent_columns.
+# negative value are OK.
+indent_case_brace               = 0        # number
+
+# Whether to indent comments found in first column.
+indent_col1_comment             = false    # false/true
+
+# How to indent goto labels
+#   >0: absolute column where 1 is the leftmost column
+#  <=0: subtract from brace indent
+# Default=1
+indent_label                    = 1        # number
+
+# Same as indent_label, but for access specifiers that are followed by a colon. Default=1
+indent_access_spec              = -2        # number
+
+# Indent the code after an access specifier by one level.
+# If set, this option forces 'indent_access_spec=0'.
+indent_access_spec_body         = false    # false/true
+
+# If an open paren is followed by a newline, indent the next line so that it lines up after the open paren (not recommended).
+indent_paren_nl                 = false    # false/true
+
+# Controls the indent of a close paren after a newline.
+# 0: Indent to body level
+# 1: Align under the open paren
+# 2: Indent to the brace level
+indent_paren_close              = 2        # unsigned number
+
+# Controls the indent of the open paren of a function definition, if on it's own line.If True, indents the open paren
+indent_paren_after_func_def     = false    # false/true
+
+# Controls the indent of the open paren of a function declaration, if on it's own line.If True, indents the open paren
+indent_paren_after_func_decl    = false    # false/true
+
+# Controls the indent of the open paren of a function call, if on it's own line.If True, indents the open paren
+indent_paren_after_func_call    = false    # false/true
+
+# Controls the indent of a comma when inside a paren.If True, aligns under the open paren.
+indent_comma_paren              = false    # false/true
+
+# Controls the indent of a BOOL operator when inside a paren.If True, aligns under the open paren.
+indent_bool_paren               = false    # false/true
+
+# Controls the indent of a semicolon when inside a for paren.If True, aligns under the open for paren.
+indent_semicolon_for_paren      = false    # false/true
+
+# If 'indent_bool_paren' is True, controls the indent of the first expression. If True, aligns the first expression to the following ones.
+indent_first_bool_expr          = false    # false/true
+
+# If 'indent_semicolon_for_paren' is True, controls the indent of the first expression. If True, aligns the first expression to the following ones.
+indent_first_for_expr           = false    # false/true
+
+# If an open square is followed by a newline, indent the next line so that it lines up after the open square (not recommended).
+indent_square_nl                = false    # false/true
+
+# Don't change the relative indent of ESQL/C 'EXEC SQL' bodies.
+indent_preserve_sql             = false    # false/true
+
+# Align continued statements at the '='. Default=True
+# If False or the '=' is followed by a newline, the next line is indent one tab.
+indent_align_assign             = false    # false/true
+
+# Align continued statements at the '('. Default=True
+# If FALSE or the '(' is not followed by a newline, the next line indent is one tab.
+indent_align_paren              = true     # false/true
+
+# Indent OC blocks at brace level instead of usual rules.
+indent_oc_block                 = false    # false/true
+
+# Indent OC blocks in a message relative to the parameter name.
+# 0=use indent_oc_block rules, 1+=spaces to indent
+indent_oc_block_msg             = 0        # unsigned number
+
+# Minimum indent for subsequent parameters
+indent_oc_msg_colon             = 0        # unsigned number
+
+# If True, prioritize aligning with initial colon (and stripping spaces from lines, if necessary).
+# Default=True.
+indent_oc_msg_prioritize_first_colon = true     # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented the way that Xcode does by default (from keyword if the parameter is on its own line; otherwise, from the previous indentation level).
+indent_oc_block_msg_xcode_style = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg keyword.
+indent_oc_block_msg_from_keyword = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is relative to a msg colon.
+indent_oc_block_msg_from_colon  = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the block caret is.
+indent_oc_block_msg_from_caret  = false    # false/true
+
+# If indent_oc_block_msg and this option are on, blocks will be indented from where the brace is.
+indent_oc_block_msg_from_brace  = false    # false/true
+
+# When indenting after virtual brace open and newline add further spaces to reach this min. indent.
+indent_min_vbrace_open          = 0        # unsigned number
+
+# True: When identing after virtual brace open and newline add further spaces after regular indent to reach next tabstop.
+indent_vbrace_open_on_tabstop   = false    # false/true
+
+# If True, a brace followed by another token (not a newline) will indent all contained lines to match the token.Default=True.
+indent_token_after_brace        = false    # false/true
+
+# If True, cpp lambda body will be indentedDefault=False.
+indent_cpp_lambda_body          = true     # false/true
+
+# indent (or not) an using block if no braces are used. Only for C#.Default=True.
+indent_using_block              = true     # false/true
+
+# indent the continuation of ternary operator.
+# 0: (Default) off
+# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 2: When the `:` is a continuation, indent it under `?`
+indent_ternary_operator         = 0        # unsigned number
+
+# If true, the indentation of the chunks after a `return new` sequence will be set at return indentation column.
+indent_off_after_return_new     = false    # false/true
+
+# If true, the tokens after return are indented with regular single indentation.By default (false) the indentation is after the return token.
+indent_single_after_return      = true    # false/true
+
+# If true, ignore indent and align for asm blocks as they have their own indentation.
+indent_ignore_asm_block         = false    # false/true
+
+#
+# Newline adding and removing options
+#
+
+# Whether to collapse empty blocks between '{' and '}'.
+nl_collapse_empty_body          = false    # false/true
+
+# Don't split one-line braced assignments - 'foo_t f = { 1, 2 };'.
+nl_assign_leave_one_liners      = true     # false/true
+
+# Don't split one-line braced statements inside a class xx { } body.
+nl_class_leave_one_liners       = true     # false/true
+
+# Don't split one-line enums: 'enum foo { BAR = 15 };'
+nl_enum_leave_one_liners        = true     # false/true
+
+# Don't split one-line get or set functions.
+nl_getset_leave_one_liners      = false     # false/true
+
+# Don't split one-line get or set functions.
+nl_cs_property_leave_one_liners = false    # false/true
+
+# Don't split one-line function definitions - 'int foo() { return 0; }'.
+nl_func_leave_one_liners        = false     # false/true
+
+# Don't split one-line C++11 lambdas - '[]() { return 0; }'.
+nl_cpp_lambda_leave_one_liners  = true     # false/true
+
+# Don't split one-line if/else statements - 'if(a) b++;'.
+nl_if_leave_one_liners          = false     # false/true
+
+# Don't split one-line while statements - 'while(a) b++;'.
+nl_while_leave_one_liners       = false     # false/true
+
+# Don't split one-line OC messages.
+nl_oc_msg_leave_one_liner       = false    # false/true
+
+# (OC) Add or remove newline between method declaration and '{'.
+nl_oc_mdef_brace                = ignore   # ignore/add/remove/force
+
+# Add or remove newline between Objective-C block signature and '{'.
+nl_oc_block_brace               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between @interface and '{'.
+nl_oc_interface_brace           = ignore   # ignore/add/remove/force
+
+# Add or remove newline between @implementation and '{'.
+nl_oc_implementation_brace      = ignore   # ignore/add/remove/force
+
+# Add or remove newlines at the start of the file.
+nl_start_of_file                = remove   # ignore/add/remove/force
+
+# The number of newlines at the start of the file (only used if nl_start_of_file is 'add' or 'force'.
+nl_start_of_file_min            = 0        # unsigned number
+
+# Add or remove newline at the end of the file.
+nl_end_of_file                  = ignore    # ignore/add/remove/force
+
+# The number of newlines at the end of the file (only used if nl_end_of_file is 'add' or 'force').
+nl_end_of_file_min              = 1        # unsigned number
+
+# Add or remove newline between '=' and '{'.
+nl_assign_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '=' and '[' (D only).
+nl_assign_square                = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '[]' and '{'.
+nl_tsquare_brace                = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '= [' (D only). Will also affect the newline before the ']'.
+nl_after_square_assign          = ignore   # ignore/add/remove/force
+
+# The number of blank lines after a block of variable definitions at the top of a function body
+# 0 = No change (default).
+nl_func_var_def_blk             = 0        # unsigned number
+
+# The number of newlines before a block of typedefs
+# 0 = No change (default)
+# is overridden by the option 'nl_after_access_spec'.
+nl_typedef_blk_start            = 0        # unsigned number
+
+# The number of newlines after a block of typedefs
+# 0 = No change (default).
+nl_typedef_blk_end              = 0        # unsigned number
+
+# The maximum consecutive newlines within a block of typedefs
+# 0 = No change (default).
+nl_typedef_blk_in               = 0        # unsigned number
+
+# The number of newlines before a block of variable definitions not at the top of a function body
+# 0 = No change (default)
+# is overridden by the option 'nl_after_access_spec'.
+nl_var_def_blk_start            = 0        # unsigned number
+
+# The number of newlines after a block of variable definitions not at the top of a function body
+# 0 = No change (default).
+nl_var_def_blk_end              = 0        # unsigned number
+
+# The maximum consecutive newlines within a block of variable definitions
+# 0 = No change (default).
+nl_var_def_blk_in               = 0        # unsigned number
+
+# Add or remove newline between a function call's ')' and '{', as in:
+# list_for_each(item, &list) { }.
+nl_fcall_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'enum' and '{'.
+nl_enum_brace                   = add    # ignore/add/remove/force
+
+# Add or remove newline between 'enum' and 'class'.
+nl_enum_class                   = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'enum class' and the identifier.
+nl_enum_class_identifier        = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'enum class' type and ':'.
+nl_enum_identifier_colon        = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'enum class identifier :' and 'type' and/or 'type'.
+nl_enum_colon_type              = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'struct and '{'.
+nl_struct_brace                 = force    # ignore/add/remove/force
+
+# Add or remove newline between 'union' and '{'.
+nl_union_brace                  = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'if' and '{'.
+nl_if_brace                     = add   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'else'.
+nl_brace_else                   = add   # ignore/add/remove/force
+
+# Add or remove newline between 'else if' and '{'
+# If set to ignore, nl_if_brace is used instead.
+nl_elseif_brace                 = add   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and '{'.
+nl_else_brace                   = add   # ignore/add/remove/force
+
+# Add or remove newline between 'else' and 'if'.
+nl_else_if                      = remove   # ignore/add/remove/force
+
+# Add or remove newline before 'if'/'else if' closing parenthesis.
+nl_before_if_closing_paren      = remove   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'finally'.
+nl_brace_finally                = add   # ignore/add/remove/force
+
+# Add or remove newline between 'finally' and '{'.
+nl_finally_brace                = add   # ignore/add/remove/force
+
+# Add or remove newline between 'try' and '{'.
+nl_try_brace                    = add   # ignore/add/remove/force
+
+# Add or remove newline between get/set and '{'.
+nl_getset_brace                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'for' and '{'.
+nl_for_brace                    = add   # ignore/add/remove/force
+
+# Add or remove newline between 'catch' and '{'.
+nl_catch_brace                  = add   # ignore/add/remove/force
+
+# Add or remove newline between '@catch' and '{'.
+# If set to ignore, nl_catch_brace is used.
+nl_oc_catch_brace               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'catch'.
+nl_brace_catch                  = add   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'catch'.
+# If set to ignore, nl_brace_catch is used.
+nl_oc_brace_catch               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ']'.
+nl_brace_square                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '}' and ')' in a function invocation.
+nl_brace_fparen                 = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'while' and '{'.
+nl_while_brace                  = add   # ignore/add/remove/force
+
+# Add or remove newline between 'scope (x)' and '{' (D).
+nl_scope_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'unittest' and '{' (D).
+nl_unittest_brace               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'version (x)' and '{' (D).
+nl_version_brace                = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'using' and '{'.
+nl_using_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between two open or close braces.
+# Due to general newline/brace handling, REMOVE may not work.
+nl_brace_brace                  = ignore   # ignore/add/remove/force
+
+# Add or remove newline between 'do' and '{'.
+nl_do_brace                     = add   # ignore/add/remove/force
+
+# Add or remove newline between '}' and 'while' of 'do' statement.
+nl_brace_while                  = remove   # ignore/add/remove/force
+
+# Add or remove newline between 'switch' and '{'.
+nl_switch_brace                 = add   # ignore/add/remove/force
+
+# Add or remove newline between 'synchronized' and '{'.
+nl_synchronized_brace           = remove   # ignore/add/remove/force
+
+# Add a newline between ')' and '{' if the ')' is on a different line than the if/for/etc.
+# Overrides nl_for_brace, nl_if_brace, nl_switch_brace, nl_while_switch and nl_catch_brace.
+nl_multi_line_cond              = true     # false/true
+
+# Force a newline in a define after the macro name for multi-line defines.
+nl_multi_line_define            = false    # false/true
+
+# Whether to put a newline before 'case' statement, not after the first 'case'.
+nl_before_case                  = false    # false/true
+
+# Add or remove newline between ')' and 'throw'.
+nl_before_throw                 = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after 'case' statement.
+nl_after_case                   = false    # false/true
+
+# Add or remove a newline between a case ':' and '{'. Overrides nl_after_case.
+nl_case_colon_brace             = ignore   # ignore/add/remove/force
+
+# Newline between namespace and {.
+nl_namespace_brace              = remove    # ignore/add/remove/force
+
+# Add or remove newline between 'template<>' and whatever follows.
+nl_template_class               = ignore    # ignore/add/remove/force
+
+# Add or remove newline between 'class' and '{'.
+nl_class_brace                  = force    # ignore/add/remove/force
+
+# Add or remove newline before/after each ',' in the base class list,
+#   (tied to pos_class_comma).
+nl_class_init_args              = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in the constructor member initialization.
+# Related to nl_constr_colon, pos_constr_colon and pos_constr_comma.
+nl_constr_init_args             = ignore   # ignore/add/remove/force
+
+# Add or remove newline before first element, after comma, and after last element in enum.
+nl_enum_own_lines               = add   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a function definition.
+nl_func_type_name               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name inside a class {}
+# Uses nl_func_type_name or nl_func_proto_type_name if set to ignore.
+nl_func_type_name_class         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between class specification and '::' in 'void A::f() { }'
+# Only appears in separate member implementation (does not appear with in-line implmementation).
+nl_func_class_scope             = remove   # ignore/add/remove/force
+
+# Add or remove newline between function scope and name
+# Controls the newline after '::' in 'void A::f() { }'.
+nl_func_scope_name              = remove   # ignore/add/remove/force
+
+# Add or remove newline between return type and function name in a prototype.
+nl_func_proto_type_name         = ignore   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the declaration.
+nl_func_paren                   = remove   # ignore/add/remove/force
+
+# Overrides nl_func_paren for functions with no parameters.
+nl_func_paren_empty             = remove   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the definition.
+nl_func_def_paren               = remove   # ignore/add/remove/force
+
+# Overrides nl_func_def_paren for functions with no parameters.
+nl_func_def_paren_empty         = remove   # ignore/add/remove/force
+
+# Add or remove newline between a function name and the opening '(' in the call
+nl_func_call_paren              = remove   # ignore/add/remove/force
+
+# Overrides nl_func_call_paren for functions with no parameters.
+nl_func_call_paren_empty        = remove   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function declaration.
+nl_func_decl_start              = ignore   # ignore/add/remove/force
+
+# Add or remove newline after '(' in a function definition.
+nl_func_def_start               = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_decl_start when there is only one parameter.
+nl_func_decl_start_single       = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_start when there is only one parameter.
+nl_func_def_start_single        = ignore   # ignore/add/remove/force
+
+# Whether to add newline after '(' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_start_multi_line   = false     # false/true
+
+# Whether to add newline after '(' in a function definition if '(' and ')' are in different lines.
+nl_func_def_start_multi_line    = false     # false/true
+
+# Add or remove newline after each ',' in a function declaration.
+nl_func_decl_args               = ignore   # ignore/add/remove/force
+
+# Add or remove newline after each ',' in a function definition.
+nl_func_def_args                = ignore   # ignore/add/remove/force
+
+# Whether to add newline after each ',' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_args_multi_line    = false    # false/true
+
+# Whether to add newline after each ',' in a function definition if '(' and ')' are in different lines.
+nl_func_def_args_multi_line     = false    # false/true
+
+# Add or remove newline before the ')' in a function declaration.
+nl_func_decl_end                = ignore   # ignore/add/remove/force
+
+# Add or remove newline before the ')' in a function definition.
+nl_func_def_end                 = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_decl_end when there is only one parameter.
+nl_func_decl_end_single         = ignore   # ignore/add/remove/force
+
+# Overrides nl_func_def_end when there is only one parameter.
+nl_func_def_end_single          = ignore   # ignore/add/remove/force
+
+# Whether to add newline before ')' in a function declaration if '(' and ')' are in different lines.
+nl_func_decl_end_multi_line     = false    # false/true
+
+# Whether to add newline before ')' in a function definition if '(' and ')' are in different lines.
+nl_func_def_end_multi_line      = false    # false/true
+
+# Add or remove newline between '()' in a function declaration.
+nl_func_decl_empty              = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function definition.
+nl_func_def_empty               = ignore   # ignore/add/remove/force
+
+# Add or remove newline between '()' in a function call.
+nl_func_call_empty              = ignore   # ignore/add/remove/force
+
+# Whether to add newline after '(' in a function call if '(' and ')' are in different lines.
+nl_func_call_start_multi_line   = false    # false/true
+
+# Whether to add newline after each ',' in a function call if '(' and ')' are in different lines.
+nl_func_call_args_multi_line    = false    # false/true
+
+# Whether to add newline before ')' in a function call if '(' and ')' are in different lines.
+nl_func_call_end_multi_line     = false    # false/true
+
+# Whether to put each OC message parameter on a separate line
+# See nl_oc_msg_leave_one_liner.
+nl_oc_msg_args                  = false    # false/true
+
+# Add or remove newline between function signature and '{'.
+nl_fdef_brace                   = force    # ignore/add/remove/force
+
+# Add or remove newline between C++11 lambda signature and '{'.
+nl_cpp_ldef_brace               = add   # ignore/add/remove/force
+
+# Add or remove a newline between the return keyword and return expression.
+nl_return_expr                  = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after semicolons, except in 'for' statements.
+nl_after_semicolon              = false    # false/true
+
+# Java: Control the newline between the ')' and '{{' of the double brace initializer.
+nl_paren_dbrace_open            = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after the type in an unnamed temporary direct-list-initialization.
+nl_type_brace_init_lst          = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after open brace in an unnamed temporary direct-list-initialization.
+nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force
+
+# Whether to put a newline before close brace in an unnamed temporary direct-list-initialization.
+nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force
+
+# Whether to put a newline after brace open.
+# This also adds a newline before the matching brace close.
+nl_after_brace_open             = false    # false/true
+
+# If nl_after_brace_open and nl_after_brace_open_cmt are True, a newline is
+# placed between the open brace and a trailing single-line comment.
+nl_after_brace_open_cmt         = false    # false/true
+
+# Whether to put a newline after a virtual brace open with a non-empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open            = false    # false/true
+
+# Whether to put a newline after a virtual brace open with an empty body.
+# These occur in un-braced if/while/do/for statement bodies.
+nl_after_vbrace_open_empty      = false    # false/true
+
+# Whether to put a newline after a brace close.
+# Does not apply if followed by a necessary ';'.
+nl_after_brace_close            = false    # false/true
+
+# Whether to put a newline after a virtual brace close.
+# Would add a newline before return in: 'if (foo) a++; return;'.
+nl_after_vbrace_close           = true     # false/true
+
+# Control the newline between the close brace and 'b' in: 'struct { int a; } b;'
+# Affects enums, unions and structures. If set to ignore, uses nl_after_brace_close.
+nl_brace_struct_var             = ignore   # ignore/add/remove/force
+
+# Whether to alter newlines in '#define' macros.
+nl_define_macro                 = false    # false/true
+
+# Whether to alter newlines between consecutive paren closes,
+# The number of closing paren in a line will depend on respective open paren lines
+nl_squeeze_paren_close          = false    # false/true
+
+# Whether to remove blanks after '#ifxx' and '#elxx', or before '#elxx' and '#endif'. Does not affect top-level #ifdefs.
+nl_squeeze_ifdef                = false    # false/true
+
+# Makes the nl_squeeze_ifdef option affect the top-level #ifdefs as well.
+nl_squeeze_ifdef_top_level      = false    # false/true
+
+# Add or remove blank line before 'if'.
+nl_before_if                    = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'if' statement.
+# Add/Force work only if the next token is not a closing brace.
+nl_after_if                     = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'for'.
+nl_before_for                   = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'for' statement.
+nl_after_for                    = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'while'.
+nl_before_while                 = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'while' statement.
+nl_after_while                  = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'switch'.
+nl_before_switch                = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'switch' statement.
+nl_after_switch                 = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'synchronized'.
+nl_before_synchronized          = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'synchronized' statement.
+nl_after_synchronized           = ignore   # ignore/add/remove/force
+
+# Add or remove blank line before 'do'.
+nl_before_do                    = ignore   # ignore/add/remove/force
+
+# Add or remove blank line after 'do/while' statement.
+nl_after_do                     = ignore   # ignore/add/remove/force
+
+# Whether to double-space commented-entries in struct/union/enum.
+nl_ds_struct_enum_cmt           = false    # false/true
+
+# force nl before } of a struct/union/enum
+# (lower priority than 'eat_blanks_before_close_brace').
+nl_ds_struct_enum_close_brace   = false    # false/true
+
+# Add or remove blank line before 'func_class_def'.
+nl_before_func_class_def        = 0        # unsigned number
+
+# Add or remove blank line before 'func_class_proto'.
+nl_before_func_class_proto      = 0        # unsigned number
+
+# Add or remove a newline before/after a class colon,
+#   (tied to pos_class_colon).
+nl_class_colon                  = ignore   # ignore/add/remove/force
+
+# Add or remove a newline around a class constructor colon.
+# Related to nl_constr_init_args, pos_constr_colon and pos_constr_comma.
+nl_constr_colon                 = force    # ignore/add/remove/force
+
+# If true turns two liner namespace to one liner,else will make then four liners
+nl_namespace_two_to_one_liner   = false    # false/true
+
+# Change simple unbraced if statements into a one-liner
+# 'if(b)\n i++;' => 'if(b) i++;'.
+nl_create_if_one_liner          = false    # false/true
+
+# Change simple unbraced for statements into a one-liner
+# 'for (i=0;i<5;i++)\n foo(i);' => 'for (i=0;i<5;i++) foo(i);'.
+nl_create_for_one_liner         = false    # false/true
+
+# Change simple unbraced while statements into a one-liner
+# 'while (i<5)\n foo(i++);' => 'while (i<5) foo(i++);'.
+nl_create_while_one_liner       = false    # false/true
+
+# Change simple 4,3,2 liner function def statements into a one-liner
+nl_create_func_def_one_liner    = false    # false/true
+
+#  Change a one-liner if statement into simple unbraced if
+# 'if(b) i++;' => 'if(b)\n i++;'.
+nl_split_if_one_liner           = false    # false/true
+
+# Change a one-liner for statement into simple unbraced for
+# 'for (i=0;<5;i++) foo(i);' => 'for (i=0;<5;i++)\n foo(i);'.
+nl_split_for_one_liner          = false    # false/true
+
+# Change a one-liner while statement into simple unbraced while
+# 'while (i<5) foo(i++);' => 'while (i<5)\n foo(i++);'.
+nl_split_while_one_liner        = false    # false/true
+
+#
+# Blank line options
+#
+
+# The maximum consecutive newlines (3 = 2 blank lines).
+nl_max                          = 3        # unsigned number
+
+# The maximum consecutive newlines in function.
+nl_max_blank_in_func            = 0        # unsigned number
+
+# The number of newlines after a function prototype, if followed by another function prototype.
+nl_after_func_proto             = 0        # unsigned number
+
+# The number of newlines after a function prototype, if not followed by another function prototype.
+nl_after_func_proto_group       = 0        # unsigned number
+
+# The number of newlines after a function class prototype, if followed by another function class prototype.
+nl_after_func_class_proto       = 0        # unsigned number
+
+# The number of newlines after a function class prototype, if not followed by another function class prototype.
+nl_after_func_class_proto_group = 0        # unsigned number
+
+# Whether one-line method definitions inside a class body should be treated
+# as if they were prototypes for the purposes of adding newlines.
+#
+# Requires nl_class_leave_one_liners=true. Overrides nl_before_func_body_def
+# and nl_before_func_class_def for one-liners.
+nl_class_leave_one_liner_groups = false    # true/false
+
+# The number of newlines before a multi-line function def body.
+nl_before_func_body_def         = 0        # unsigned number
+
+# The number of newlines before a multi-line function prototype body.
+nl_before_func_body_proto       = 0        # unsigned number
+
+# The number of newlines after '}' of a multi-line function body.
+nl_after_func_body              = 0        # unsigned number
+
+# The number of newlines after '}' of a multi-line function body in a class declaration.
+nl_after_func_body_class        = 0        # unsigned number
+
+# The number of newlines after '}' of a single line function body.
+nl_after_func_body_one_liner    = 0        # unsigned number
+
+# The minimum number of newlines before a multi-line comment.
+# Doesn't apply if after a brace open or another multi-line comment.
+nl_before_block_comment         = 0        # unsigned number
+
+# The minimum number of newlines before a single-line C comment.
+# Doesn't apply if after a brace open or other single-line C comments.
+nl_before_c_comment             = 0        # unsigned number
+
+# The minimum number of newlines before a CPP comment.
+# Doesn't apply if after a brace open or other CPP comments.
+nl_before_cpp_comment           = 0        # unsigned number
+
+# Whether to force a newline after a multi-line comment.
+nl_after_multiline_comment      = false    # false/true
+
+# Whether to force a newline after a label's colon.
+nl_after_label_colon            = false    # false/true
+
+# The number of newlines after '}' or ';' of a struct/enum/union definition.
+nl_after_struct                 = 0        # unsigned number
+
+# The number of newlines before a class definition.
+nl_before_class                 = 0        # unsigned number
+
+# The number of newlines after '}' or ';' of a class definition.
+nl_after_class                  = 0        # unsigned number
+
+# The number of newlines before a 'private:', 'public:', 'protected:', 'signals:', or 'slots:' label.
+# Will not change the newline count if after a brace open.
+# 0 = No change.
+nl_before_access_spec           = 0        # unsigned number
+
+# The number of newlines after a 'private:', 'public:', 'protected:', 'signals:' or 'slots:' label.
+# 0 = No change.
+# Overrides 'nl_typedef_blk_start' and 'nl_var_def_blk_start'.
+nl_after_access_spec            = 0        # unsigned number
+
+# The number of newlines between a function def and the function comment.
+# 0 = No change.
+nl_comment_func_def             = 0        # unsigned number
+
+# The number of newlines after a try-catch-finally block that isn't followed by a brace close.
+# 0 = No change.
+nl_after_try_catch_finally      = 0        # unsigned number
+
+# The number of newlines before and after a property, indexer or event decl.
+# 0 = No change.
+nl_around_cs_property           = 0        # unsigned number
+
+# The number of newlines between the get/set/add/remove handlers in C#.
+# 0 = No change.
+nl_between_get_set              = 0        # unsigned number
+
+# Add or remove newline between C# property and the '{'.
+nl_property_brace               = ignore   # ignore/add/remove/force
+
+# The number of newlines after '{' of a namespace. This also adds newlines
+# before the matching '}'.
+#
+# 0 = Apply eat_blanks_after_open_brace or eat_blanks_before_close_brace if
+#     applicable, otherwise no change.
+#
+# Overrides eat_blanks_after_open_brace and eat_blanks_before_close_brace.
+nl_inside_namespace             = 0        # unsigned number
+
+# Whether to remove blank lines after '{'.
+eat_blanks_after_open_brace     = false    # false/true
+
+# Whether to remove blank lines before '}'.
+eat_blanks_before_close_brace   = false    # false/true
+
+# How aggressively to remove extra newlines not in preproc.
+# 0: No change
+# 1: Remove most newlines not handled by other config
+# 2: Remove all newlines and reformat completely by config
+nl_remove_extra_newlines        = 0        # unsigned number
+
+# Whether to put a blank line before 'return' statements, unless after an open brace.
+nl_before_return                = false    # false/true
+
+# Whether to put a blank line after 'return' statements, unless followed by a close brace.
+nl_after_return                 = false    # false/true
+
+# Whether to put a newline after a Java annotation statement.
+# Only affects annotations that are after a newline.
+nl_after_annotation             = ignore   # ignore/add/remove/force
+
+# Controls the newline between two annotations.
+nl_between_annotation           = ignore   # ignore/add/remove/force
+
+#
+# Positioning options
+#
+
+# The position of arithmetic operators in wrapped expressions.
+pos_arith                       = ignore    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of assignment in wrapped expressions.
+# Do not affect '=' followed by '{'.
+pos_assign                      = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of boolean operators in wrapped expressions.
+pos_bool                        = ignore    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of comparison operators in wrapped expressions.
+pos_compare                     = ignore    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of conditional (b ? t : f) operators in wrapped expressions.
+pos_conditional                 = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in wrapped expressions.
+pos_comma                       = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in enum entries.
+pos_enum_comma                  = ignore   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in the base class list if there are more than one line,
+#   (tied to nl_class_init_args).
+pos_class_comma                 = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of the comma in the constructor initialization list.
+# Related to nl_constr_colon, nl_constr_init_args and pos_constr_colon.
+pos_constr_comma                = trail    # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of trailing/leading class colon, between class and base class list
+#   (tied to nl_class_colon).
+pos_class_colon                 = lead_force   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+# The position of colons between constructor and member initialization,
+# (tied to nl_constr_colon).
+# Related to nl_constr_colon, nl_constr_init_args and pos_constr_comma.
+pos_constr_colon                = lead_break   # ignore/join/lead/lead_break/lead_force/trail/trail_break/trail_force
+
+#
+# Line Splitting options
+#
+
+# Try to limit code width to N number of columns
+code_width                      = 80      # unsigned number
+
+# Whether to fully split long 'for' statements at semi-colons.
+ls_for_split_full               = false    # false/true
+
+# Whether to fully split long function protos/calls at commas.
+ls_func_split_full              = false    # false/true
+
+# Whether to split lines as close to code_width as possible and ignore some groupings.
+ls_code_width                   = false    # false/true
+
+#
+# Code alignment (not left column spaces/tabs)
+#
+
+# Whether to keep non-indenting tabs.
+align_keep_tabs                 = false    # false/true
+
+# Whether to use tabs for aligning.
+align_with_tabs                 = false    # false/true
+
+# Whether to bump out to the next tab when aligning.
+align_on_tabstop                = false    # false/true
+
+# Whether to right-align numbers.
+align_number_right              = false    # false/true
+
+# Whether to keep whitespace not required for alignment.
+align_keep_extra_space          = false    # false/true
+
+# Align variable definitions in prototypes and functions.
+align_func_params               = false    # false/true
+
+# The span for aligning parameter definitions in function on parameter name (0=don't align).
+align_func_params_span          = 0        # unsigned number
+
+# The threshold for aligning function parameter definitions (0=no limit).
+align_func_params_thresh        = 0        # unsigned number
+
+# The gap for aligning function parameter definitions.
+align_func_params_gap           = 0        # unsigned number
+
+# Align parameters in single-line functions that have the same name.
+# The function names must already be aligned with each other.
+align_same_func_call_params     = false    # false/true
+
+# The span for aligning function-call parameters for single line functions.
+#  0 = Don't align (default).
+align_same_func_call_params_span = 0       # unsigned number
+
+# The threshold for aligning function-call parameters for single line
+# functions.
+#  0 = No limit (default).
+align_same_func_call_params_thresh = 0     # unsigned number
+
+# The span for aligning variable definitions (0=don't align)
+align_var_def_span              = 0        # unsigned number
+
+# How to align the star in variable definitions.
+#  0=Part of the type     'void *   foo;'
+#  1=Part of the variable 'void     *foo;'
+#  2=Dangling             'void    *foo;'
+align_var_def_star_style        = 0        # unsigned number
+
+# How to align the '&' in variable definitions.
+#  0=Part of the type
+#  1=Part of the variable
+#  2=Dangling
+align_var_def_amp_style         = 0        # unsigned number
+
+# The threshold for aligning variable definitions (0=no limit)
+align_var_def_thresh            = 0        # unsigned number
+
+# The gap for aligning variable definitions.
+align_var_def_gap               = 0        # unsigned number
+
+# Whether to align the colon in struct bit fields.
+align_var_def_colon             = false    # false/true
+
+# align variable defs gap for bit colons.
+align_var_def_colon_gap         = 0        # unsigned number
+
+# Whether to align any attribute after the variable name.
+align_var_def_attribute         = false    # false/true
+
+# Whether to align inline struct/enum/union variable definitions.
+align_var_def_inline            = false    # false/true
+
+# The span for aligning on '=' in assignments (0=don't align)
+align_assign_span               = 0        # unsigned number
+
+# The threshold for aligning on '=' in assignments (0=no limit)
+align_assign_thresh             = 0        # unsigned number
+
+# How to apply align_assign_span to function declaration "assignments", i.e.
+# 'virtual void foo() = 0' or '~foo() = {default|delete}'.
+#  0: Align with other assignments (default)
+#  1: Align with each other, ignoring regular assignments
+#  2: Don't align
+align_assign_decl_func          = 0        # unsigned number
+
+# The span for aligning on '=' in enums (0=don't align)
+align_enum_equ_span             = 0        # unsigned number
+
+# The threshold for aligning on '=' in enums (0=no limit)
+align_enum_equ_thresh           = 0        # unsigned number
+
+# The span for aligning class (0=don't align)
+align_var_class_span            = 0        # unsigned number
+
+# The threshold for aligning class member definitions (0=no limit).
+align_var_class_thresh          = 0        # unsigned number
+
+# The gap for aligning class member definitions.
+align_var_class_gap             = 0        # unsigned number
+
+# The span for aligning struct/union (0=don't align)
+align_var_struct_span           = 0        # unsigned number
+
+# The threshold for aligning struct/union member definitions (0=no limit)
+align_var_struct_thresh         = 0        # unsigned number
+
+# The gap for aligning struct/union member definitions.
+align_var_struct_gap            = 0        # unsigned number
+
+# The span for aligning struct initializer values (0=don't align)
+align_struct_init_span          = 0        # unsigned number
+
+# The minimum space between the type and the synonym of a typedef.
+align_typedef_gap               = 0        # unsigned number
+
+# The span for aligning single-line typedefs (0=don't align).
+align_typedef_span              = 0        # unsigned number
+
+# How to align typedef'd functions with other typedefs
+# 0: Don't mix them at all
+# 1: align the open paren with the types
+# 2: align the function type name with the other type names
+align_typedef_func              = 0        # unsigned number
+
+# Controls the positioning of the '*' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '*'
+# 1: The '*' is part of type name: typedef int  *pint;
+# 2: The '*' is part of the type, but dangling: typedef int *pint;
+align_typedef_star_style        = 0        # unsigned number
+
+# Controls the positioning of the '&' in typedefs. Just try it.
+# 0: Align on typedef type, ignore '&'
+# 1: The '&' is part of type name: typedef int  &pint;
+# 2: The '&' is part of the type, but dangling: typedef int &pint;
+align_typedef_amp_style         = 0        # unsigned number
+
+# The span for aligning comments that end lines (0=don't align)
+align_right_cmt_span            = 0        # unsigned number
+
+# If aligning comments, mix with comments after '}' and #endif with less than 3 spaces before the comment.
+align_right_cmt_mix             = false    # false/true
+
+# Whether to only align trailing comments that are at the same brace level.
+align_right_cmt_same_level      = false    # true/false
+
+# If a trailing comment is more than this number of columns away from the text it follows,
+# it will qualify for being aligned. This has to be > 0 to do anything.
+align_right_cmt_gap             = 0        # unsigned number
+
+# Align trailing comment at or beyond column N; 'pulls in' comments as a bonus side effect (0=ignore)
+align_right_cmt_at_col          = 0        # unsigned number
+
+# The span for aligning function prototypes (0=don't align).
+align_func_proto_span           = 0        # unsigned number
+
+# Minimum gap between the return type and the function name.
+align_func_proto_gap            = 0        # unsigned number
+
+# Align function protos on the 'operator' keyword instead of what follows.
+align_on_operator               = false    # false/true
+
+# Whether to mix aligning prototype and variable declarations.
+# If True, align_var_def_XXX options are used instead of align_func_proto_XXX options.
+align_mix_var_proto             = false    # false/true
+
+# Align single-line functions with function prototypes, uses align_func_proto_span.
+align_single_line_func          = false    # false/true
+
+# Aligning the open brace of single-line functions.
+# Requires align_single_line_func=True, uses align_func_proto_span.
+align_single_line_brace         = false    # false/true
+
+# Gap for align_single_line_brace.
+align_single_line_brace_gap     = 0        # unsigned number
+
+# The span for aligning ObjC msg spec (0=don't align)
+align_oc_msg_spec_span          = 0        # unsigned number
+
+# Whether to align macros wrapped with a backslash and a newline.
+# This will not work right if the macro contains a multi-line comment.
+align_nl_cont                   = false    # false/true
+
+# # Align macro functions and variables together.
+align_pp_define_together        = false    # false/true
+
+# The minimum space between label and value of a preprocessor define.
+align_pp_define_gap             = 0        # unsigned number
+
+# The span for aligning on '#define' bodies (0=don't align, other=number of lines including comments between blocks)
+align_pp_define_span            = 0        # unsigned number
+
+# Align lines that start with '<<' with previous '<<'. Default=True.
+align_left_shift                = false     # false/true
+
+# Align text after asm volatile () colons.
+align_asm_colon                 = false    # false/true
+
+# Span for aligning parameters in an Obj-C message call on the ':' (0=don't align)
+align_oc_msg_colon_span         = 0        # unsigned number
+
+# If True, always align with the first parameter, even if it is too short.
+align_oc_msg_colon_first        = false    # false/true
+
+# Aligning parameters in an Obj-C '+' or '-' declaration on the ':'.
+align_oc_decl_colon             = false    # false/true
+
+#
+# Comment modifications
+#
+
+# Try to wrap comments at cmt_width columns
+cmt_width                       = 0        # unsigned number
+
+# Set the comment reflow mode (Default=0)
+# 0: no reflowing (apart from the line wrapping due to cmt_width)
+# 1: no touching at all
+# 2: full reflow
+cmt_reflow_mode                 = 0        # unsigned number
+
+# Whether to convert all tabs to spaces in comments. Default is to leave tabs inside comments alone, unless used for indenting.
+cmt_convert_tab_to_spaces       = false    # false/true
+
+# If False, disable all multi-line comment changes, including cmt_width. keyword substitution and leading chars.
+# Default=True.
+cmt_indent_multi                = false    # false/true
+
+# Whether to group c-comments that look like they are in a block.
+cmt_c_group                     = false    # false/true
+
+# Whether to put an empty '/*' on the first line of the combined c-comment.
+cmt_c_nl_start                  = false    # false/true
+
+# Whether to put a newline before the closing '*/' of the combined c-comment.
+cmt_c_nl_end                    = false    # false/true
+
+# Whether to group cpp-comments that look like they are in a block.
+cmt_cpp_group                   = false    # false/true
+
+# Whether to put an empty '/*' on the first line of the combined cpp-comment.
+cmt_cpp_nl_start                = false    # false/true
+
+# Whether to put a newline before the closing '*/' of the combined cpp-comment.
+cmt_cpp_nl_end                  = false    # false/true
+
+# Whether to change cpp-comments into c-comments.
+cmt_cpp_to_c                    = false    # false/true
+
+# Whether to put a star on subsequent comment lines.
+cmt_star_cont                   = false    # false/true
+
+# The number of spaces to insert at the start of subsequent comment lines.
+cmt_sp_before_star_cont         = 0        # unsigned number
+
+# The number of spaces to insert after the star on subsequent comment lines.
+cmt_sp_after_star_cont          = 0        # number
+
+# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
+# the comment are the same length. Default=True.
+cmt_multi_check_last            = true     # false/true
+
+# For multi-line comments with a '*' lead, remove leading spaces if the first and last lines of
+# the comment are the same length AND if the length is bigger as the first_len minimum. Default=4
+cmt_multi_first_len_minimum     = 4        # unsigned number
+
+# The filename that contains text to insert at the head of a file if the file doesn't start with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_header          = ""         # string
+
+# The filename that contains text to insert at the end of a file if the file doesn't end with a C/C++ comment.
+# Will substitute $(filename) with the current file's name.
+cmt_insert_file_footer          = ""         # string
+
+# The filename that contains text to insert before a function implementation if the function isn't preceded with a C/C++ comment.
+# Will substitute $(function) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+# Will also substitute $(fclass) with the class name: void CFoo::Bar() { ... }.
+cmt_insert_func_header          = ""         # string
+
+# The filename that contains text to insert before a class if the class isn't preceded with a C/C++ comment.
+# Will substitute $(class) with the class name.
+cmt_insert_class_header         = ""         # string
+
+# The filename that contains text to insert before a Obj-C message specification if the method isn't preceded with a C/C++ comment.
+# Will substitute $(message) with the function name and $(javaparam) with the javadoc @param and @return stuff.
+cmt_insert_oc_msg_header        = ""         # string
+
+# If a preprocessor is encountered when stepping backwards from a function name, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_oc_msg_header, cmt_insert_func_header and cmt_insert_class_header.
+cmt_insert_before_preproc       = false    # false/true
+
+# If a function is declared inline to a class definition, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_func_header.
+cmt_insert_before_inlines       = false     # false/true
+
+# If the function is a constructor/destructor, then
+# this option decides whether the comment should be inserted.
+# Affects cmt_insert_func_header.
+cmt_insert_before_ctor_dtor     = false    # false/true
+
+#
+# Code modifying options (non-whitespace)
+#
+
+# Add or remove braces on single-line 'do' statement.
+mod_full_brace_do               = ignore    # ignore/add/remove/force
+
+# Add or remove braces on single-line 'for' statement.
+mod_full_brace_for              = ignore    # ignore/add/remove/force
+
+# Add or remove braces on single-line function definitions. (Pawn).
+mod_full_brace_function         = add    # ignore/add/remove/force
+
+# Add or remove braces on single-line 'if' statement. Will not remove the braces if they contain an 'else'.
+mod_full_brace_if               = ignore    # ignore/add/remove/force
+
+# Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
+# If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
+mod_full_brace_if_chain         = false    # false/true
+
+# Make all if/elseif/else statements with at least one 'else' or 'else if' fully braced.
+# If mod_full_brace_if_chain is used together with this option, all if-else chains will get braces,
+# and simple 'if' statements will lose them (if possible).
+mod_full_brace_if_chain_only    = false    # false/true
+
+# Don't remove braces around statements that span N newlines
+mod_full_brace_nl               = 0        # unsigned number
+
+# Blocks removal of braces if the parenthesis of if/for/while/.. span multiple lines.
+mod_full_brace_nl_block_rem_mlcond = false    # false/true
+
+# Add or remove braces on single-line 'while' statement.
+mod_full_brace_while            = ignore    # ignore/add/remove/force
+
+# Add or remove braces on single-line 'using ()' statement.
+mod_full_brace_using            = add    # ignore/add/remove/force
+
+# Add or remove unnecessary paren on 'return' statement.
+mod_paren_on_return             = remove   # ignore/add/remove/force
+
+# Whether to change optional semicolons to real semicolons.
+mod_pawn_semicolon              = true     # false/true
+
+# Add parens on 'while' and 'if' statement around bools.
+mod_full_paren_if_bool          = false    # false/true
+
+# Whether to remove superfluous semicolons.
+mod_remove_extra_semicolon      = true     # false/true
+
+# If a function body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_function_closebrace_comment = 0        # unsigned number
+
+# If a namespace body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_namespace_closebrace_comment = 0        # unsigned number
+
+# If a class body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_class_closebrace_comment = 0        # unsigned number
+
+# If a switch body exceeds the specified number of newlines and doesn't have a comment after
+# the close brace, a comment will be added.
+mod_add_long_switch_closebrace_comment = 0        # unsigned number
+
+# If an #ifdef body exceeds the specified number of newlines and doesn't have a comment after
+# the #endif, a comment will be added.
+mod_add_long_ifdef_endif_comment = 0        # unsigned number
+
+# If an #ifdef or #else body exceeds the specified number of newlines and doesn't have a comment after
+# the #else, a comment will be added.
+mod_add_long_ifdef_else_comment = 0        # unsigned number
+
+# If True, will sort consecutive single-line 'import' statements [Java, D].
+mod_sort_import                 = false    # false/true
+
+# If True, will sort consecutive single-line 'using' statements [C#].
+mod_sort_using                  = false    # false/true
+
+# If True, will sort consecutive single-line '#include' statements [C/C++] and '#import' statements [Obj-C]
+# This is generally a bad idea, as it may break your code.
+mod_sort_include                = false    # false/true
+
+# If True, it will move a 'break' that appears after a fully braced 'case' before the close brace.
+mod_move_case_break             = false    # false/true
+
+# Will add or remove the braces around a fully braced case statement.
+# Will only remove the braces if there are no variable declarations in the block.
+mod_case_brace                  = ignore   # ignore/add/remove/force
+
+# If True, it will remove a void 'return;' that appears as the last statement in a function.
+mod_remove_empty_return         = false     # false/true
+
+# Add or remove the comma after the last value of an enumeration.
+mod_enum_last_comma             = ignore   # ignore/add/remove/force
+
+# If True, it will organize the properties (Obj-C).
+mod_sort_oc_properties          = false    # false/true
+
+# Determines weight of class property modifier (Obj-C).
+mod_sort_oc_property_class_weight = 0        # number
+
+# Determines weight of atomic, nonatomic (Obj-C).
+mod_sort_oc_property_thread_safe_weight = 0        # number
+
+# Determines weight of readwrite (Obj-C).
+mod_sort_oc_property_readwrite_weight = 0        # number
+
+# Determines weight of reference type (retain, copy, assign, weak, strong) (Obj-C).
+mod_sort_oc_property_reference_weight = 0        # number
+
+# Determines weight of getter type (getter=) (Obj-C).
+mod_sort_oc_property_getter_weight = 0        # number
+
+# Determines weight of setter type (setter=) (Obj-C).
+mod_sort_oc_property_setter_weight = 0        # number
+
+# Determines weight of nullability type (nullable, nonnull, null_unspecified, null_resettable) (Obj-C).
+mod_sort_oc_property_nullability_weight = 0        # number
+
+#
+# Preprocessor options
+#
+
+# Control indent of preprocessors inside #if blocks at brace level 0 (file-level).
+pp_indent                       = ignore   # ignore/add/remove/force
+
+# Whether to indent #if/#else/#endif at the brace level (True) or from column 1 (False).
+pp_indent_at_level              = false    # false/true
+
+# Specifies the number of columns to indent preprocessors per level at brace level 0 (file-level).
+# If pp_indent_at_level=False, specifies the number of columns to indent preprocessors per level at brace level > 0 (function-level).
+# Default=1.
+pp_indent_count                 = 2        # unsigned number
+
+# Add or remove space after # based on pp_level of #if blocks.
+pp_space                        = ignore   # ignore/add/remove/force
+
+# Sets the number of spaces added with pp_space.
+pp_space_count                  = 0        # unsigned number
+
+# The indent for #region and #endregion in C# and '#pragma region' in C/C++.
+pp_indent_region                = 0        # number
+
+# Whether to indent the code between #region and #endregion.
+pp_region_indent_code           = false    # false/true
+
+# If pp_indent_at_level=True, sets the indent for #if, #else and #endif when not at file-level.
+# 0:  indent preprocessors using output_tab_size.
+# >0: column at which all preprocessors will be indented.
+pp_indent_if                    = 0        # number
+
+# Control whether to indent the code between #if, #else and #endif.
+pp_if_indent_code               = false    # false/true
+
+# Whether to indent '#define' at the brace level (True) or from column 1 (false).
+pp_define_at_level              = false    # false/true
+
+# Whether to ignore the '#define' body while formatting.
+pp_ignore_define_body           = false    # false/true
+
+# Whether to indent case statements between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the case statements directly inside of.
+pp_indent_case                  = true     # false/true
+
+# Whether to indent whole function definitions between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the function definition is directly inside of.
+pp_indent_func_def              = true     # false/true
+
+# Whether to indent extern C blocks between #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the extern block is directly inside of.
+pp_indent_extern                = true     # false/true
+
+# Whether to indent braces directly inside #if, #else, and #endif.
+# Only applies to the indent of the preprocesser that the braces are directly inside of.
+pp_indent_brace                 = true     # false/true
+
+#
+# Sort includes options
+#
+
+# The regex for include category with priority 0.
+include_category_0              = ""         # string
+
+# The regex for include category with priority 1.
+include_category_1              = ""         # string
+
+# The regex for include category with priority 2.
+include_category_2              = ""         # string
+
+#
+# Use or Do not Use options
+#
+
+# True:  indent_func_call_param will be used (default)
+# False: indent_func_call_param will NOT be used.
+use_indent_func_call_param      = true     # false/true
+
+# The value of the indentation for a continuation line is calculate differently if the statement is:
+#   a declaration: your case with QString fileName ...
+#   an assignment: your case with pSettings = new QSettings( ...
+# At the second case the indentation value might be used twice:
+#   at the assignment
+#   at the function call (if present)
+# To prevent the double use of the indentation value, use this option with the value 'True'.
+# True:  indent_continue will be used only once
+# False: indent_continue will be used every time (default).
+use_indent_continue_only_once   = false    # false/true
+
+# the value might be used twice:
+#   at the assignment
+#   at the opening brace
+# To prevent the double use of the indentation value, use this option with the value 'True'.
+# True:  indentation will be used only once
+# False: indentation will be used every time (default).
+indent_cpp_lambda_only_once     = false    # false/true
+
+# SIGNAL/SLOT Qt macros have special formatting options. See options_for_QT.cpp for details.
+# Default=True.
+use_options_overriding_for_qt_macros = true     # false/true
+
+#
+# Warn levels - 1: error, 2: warning (default), 3: note
+#
+
+# Warning is given if doing tab-to-\t replacement and we have found one in a C# verbatim string literal.
+warn_level_tabs_found_in_verbatim_string_literals = 2        # unsigned number
+
+# Meaning of the settings:
+#   Ignore - do not do any changes
+#   Add    - makes sure there is 1 or more space/brace/newline/etc
+#   Force  - makes sure there is exactly 1 space/brace/newline/etc,
+#            behaves like Add in some contexts
+#   Remove - removes space/brace/newline/etc
+#
+#
+# - Token(s) can be treated as specific type(s) with the 'set' option:
+#     `set tokenType tokenString [tokenString...]`
+#
+#     Example:
+#       `set BOOL __AND__ __OR__`
+#
+#     tokenTypes are defined in src/token_enum.h, use them without the
+#     'CT_' prefix: 'CT_BOOL' -> 'BOOL'
+#
+#
+# - Token(s) can be treated as type(s) with the 'type' option.
+#     `type tokenString [tokenString...]`
+#
+#     Example:
+#       `type int c_uint_8 Rectangle`
+#
+#     This can also be achieved with `set TYPE int c_uint_8 Rectangle`
+#
+#
+# To embed whitespace in tokenStrings use the '\' escape character, or quote
+# the tokenStrings. These quotes are supported: "'`
+#
+#
+# - Support for the auto detection of languages through the file ending can be
+#   added using the 'file_ext' command.
+#     `file_ext langType langString [langString..]`
+#
+#     Example:
+#       `file_ext CPP .ch .cxx .cpp.in`
+#
+#     langTypes are defined in uncrusify_types.h in the lang_flag_e enum, use
+#     them without the 'LANG_' prefix: 'LANG_CPP' -> 'CPP'
+#
+#
+# - Custom macro-based indentation can be set up using 'macro-open',
+#   'macro-else' and 'macro-close'.
+#     `(macro-open | macro-else | macro-close) tokenString`
+#
+#     Example:
+#       `macro-open  BEGIN_TEMPLATE_MESSAGE_MAP`
+#       `macro-open  BEGIN_MESSAGE_MAP`
+#       `macro-close END_MESSAGE_MAP`
+#
+#
+# option(s) with 'not default' value: 0
+#
+
+

--- a/rmf_utils/test/format/rmf_code_style.cfg
+++ b/rmf_utils/test/format/rmf_code_style.cfg
@@ -1916,7 +1916,7 @@ align_pp_define_gap             = 0        # unsigned number
 align_pp_define_span            = 0        # unsigned number
 
 # Align lines that start with '<<' with previous '<<'. Default=True.
-align_left_shift                = false     # false/true
+align_left_shift                = true     # false/true
 
 # Align text after asm volatile () colons.
 align_asm_colon                 = false    # false/true


### PR DESCRIPTION
This PR introduces the `rmf_uncurstify` linter and applies the same on
- `rmf_traffic`
- `rmf_traffic_ros2`
- `rmf_fleet_adapter` 

packages based on the rules specified in `rmf_utils/test/format/rmf_code_style.cfg`

Once the packages are built, running
```colcon test --packages-select rmf_traffic rmf_traffic_ros2 rmf_fleet_adapter```
will run the cmake-integrated `rmf_uncristify` linter on the packages.

To see details of the test results
```cat log/latest_test/<pkg_name>/stdout_stderr.log```