### PR TITLE
Account for map name

### DIFF
--- a/rmf_fleet_adapter/src/full_control/MoveAction.cpp
+++ b/rmf_fleet_adapter/src/full_control/MoveAction.cpp
@@ -129,13 +129,14 @@ public:
 
     const auto& planner = _node->get_planner();
 
-    Eigen::Vector3d pose =
-    {_context->location.x, _context->location.y, _context->location.yaw};
+    const auto& p = _context->location;
+    const Eigen::Vector3d pose = {p.x, p.y, p.yaw};
+    const std::string& map_name = _context->location.level_name;
 
     // TODO: further parameterize waypoint and lane merging distance
     const auto plan_starts =
       rmf_traffic::agv::compute_plan_starts(
-      planner.get_configuration().graph(), pose, start_time, 0.1, 1.0,
+      planner.get_configuration().graph(), map_name, pose, start_time, 0.1, 1.0,
       1e-8);
 
     if (plan_starts.empty())
@@ -346,12 +347,15 @@ public:
     });
 
     const auto& planner = _node->get_planner();
-    Eigen::Vector3d pose =
-      {_context->location.x, _context->location.y, _context->location.yaw};
+
+    const auto& p = _context->location;
+    const std::string& map_name = _context->location.level_name;
+    const Eigen::Vector3d pose = {p.x, p.y, p.yaw};
 
     const auto plan_starts =
       rmf_traffic::agv::compute_plan_starts(
-      planner.get_configuration().graph(), pose, start_time, 0.1, 1.0, 1e-8);
+      planner.get_configuration().graph(), map_name, pose,
+          start_time, 0.1, 1.0, 1e-8);
 
     rmf_traffic::agv::SimpleNegotiator negotiator(
           plan_starts,
@@ -1249,8 +1253,10 @@ public:
 
     const auto& planner = _node->get_planner();
 
-    Eigen::Vector3d pose =
-    {_context->location.x, _context->location.y, _context->location.yaw};
+    const auto& p = _context->location;
+    const Eigen::Vector3d pose = {p.x, p.y, p.yaw};
+    const std::string& map_name = _context->location.level_name;
+
     const auto start_time =
       rmf_traffic_ros2::convert(_node->get_clock()->now()) +
       std::chrono::nanoseconds(0);
@@ -1258,8 +1264,8 @@ public:
     // TODO: further parameterize waypoint and lane merging distance
     const auto plan_starts =
       rmf_traffic::agv::compute_plan_starts(
-      planner.get_configuration().graph(), pose, start_time, 0.1, 1.0,
-      1e-8);
+      planner.get_configuration().graph(), map_name, pose,
+      start_time, 0.1, 1.0, 1e-8);
 
     if (plan_starts.empty())
     {

--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -613,6 +613,7 @@ private:
 ///   1e-8 meters.
 std::vector<Plan::Start> compute_plan_starts(
   const rmf_traffic::agv::Graph& graph,
+  const std::string& map_name,
   const Eigen::Vector3d pose,
   const rmf_traffic::Time start_time,
   const double max_merge_waypoint_distance = 0.1,

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -709,6 +709,7 @@ Plan::Plan()
 //==============================================================================
 std::vector<Plan::Start> compute_plan_starts(
   const rmf_traffic::agv::Graph& graph,
+  const std::string& map_name,
   const Eigen::Vector3d pose,
   const rmf_traffic::Time start_time,
   const double max_merge_waypoint_distance,
@@ -722,6 +723,9 @@ std::vector<Plan::Start> compute_plan_starts(
   for (std::size_t i = 0; i < graph.num_waypoints(); ++i)
   {
     const auto& wp = graph.get_waypoint(i);
+    if (wp.get_map_name() != map_name)
+      continue;
+
     const Eigen::Vector2d wp_location = wp.get_location();
 
     if ( (p_location - wp_location).norm() < max_merge_waypoint_distance)
@@ -738,10 +742,16 @@ std::vector<Plan::Start> compute_plan_starts(
   for (std::size_t i = 0; i < graph.num_lanes(); ++i)
   {
     const auto& lane = graph.get_lane(i);
-    const Eigen::Vector2d p0 =
-      graph.get_waypoint(lane.entry().waypoint_index()).get_location();
-    const Eigen::Vector2d p1 =
-      graph.get_waypoint(lane.exit().waypoint_index()).get_location();
+    const auto& wp0 = graph.get_waypoint(lane.entry().waypoint_index());
+    if (wp0.get_map_name() != map_name)
+      continue;
+
+    const auto& wp1 = graph.get_waypoint(lane.exit().waypoint_index());
+    if (wp1.get_map_name() != map_name)
+      continue;
+
+    const Eigen::Vector2d p0 = wp0.get_location();
+    const Eigen::Vector2d p1 = wp1.get_location();
 
     const double lane_length = (p1 - p0).norm();
 

--- a/rmf_traffic/test/unit/agv/test_Negotiation_edgecases.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiation_edgecases.cpp
@@ -232,15 +232,15 @@ SCENARIO("Test difficult 3-way scenarios")
     const auto time = std::chrono::steady_clock::now();
 
     auto a0_starts = rmf_traffic::agv::compute_plan_starts(
-      graph_a, {14.006982, -15.530105, -3.137865}, time);
+      graph_a, test_map_name, {14.006982, -15.530105, -3.137865}, time);
     auto a0_goal = rmf_traffic::agv::Plan::Goal(1);
 
     auto b1_starts = rmf_traffic::agv::compute_plan_starts(
-          graph_b, {11.892134, -15.398828, 2.631314}, time);
+          graph_b, test_map_name, {11.892134, -15.398828, 2.631314}, time);
     auto b1_goal = rmf_traffic::agv::Plan::Goal(11);
 
     auto b2_starts = rmf_traffic::agv::compute_plan_starts(
-          graph_b, {13.057442, -15.363754, -3.128299}, time);
+          graph_b, test_map_name, {13.057442, -15.363754, -3.128299}, time);
     auto b2_goal = rmf_traffic::agv::Plan::Goal(13);
 
     NegotiationRoom::Intentions intentions;

--- a/rmf_traffic/test/unit/agv/test_compute_plan_starts.cpp
+++ b/rmf_traffic/test/unit/agv/test_compute_plan_starts.cpp
@@ -49,7 +49,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {0, 0, 0};
 
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -79,7 +81,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1 + 1e-8, 0.1, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -94,7 +98,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1 - 1e-8, 0.1, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -109,7 +115,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1, 0.1 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -124,7 +132,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1, 0.1 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -154,7 +164,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1 + 0.1 - 1e-8, 0.1, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -169,7 +181,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1 - 0.1 + 1e-8, 0.1, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -184,7 +198,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1, 0.1 + 0.1 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -199,7 +215,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0.1, 0.1 - 0.1 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -237,7 +255,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {0.05, 0.05, 0};
 
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -272,7 +292,9 @@ SCENARIO("Test computing Starts from coordinates")
       Eigen::Vector3d robot_loc = {
         0 - max_waypoint_merging_distance - 1e-8, 0, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -292,7 +314,7 @@ SCENARIO("Test computing Starts from coordinates")
         0 - slightly_larger_radius_x_y, 0 + slightly_larger_radius_x_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
         rmf_traffic::agv::compute_plan_starts(
-        graph, robot_loc, initial_time,
+        graph, test_map_name, robot_loc, initial_time,
         max_waypoint_merging_distance,
         max_lane_merging_distance,
         min_lane_length);
@@ -306,7 +328,9 @@ SCENARIO("Test computing Starts from coordinates")
       Eigen::Vector3d robot_loc = {
         0 - slightly_larger_radius_x_y, 0 - slightly_larger_radius_x_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -324,7 +348,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0 - 1e-8, 0 + very_near_to_border_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -339,7 +365,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0 - 1e-8, 0 - very_near_to_border_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -371,7 +399,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0 - max_lane_merging_distance + 1e-8, 0, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -392,7 +422,9 @@ SCENARIO("Test computing Starts from coordinates")
         0 + slightly_smaller_than_border_x_y,
         0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -411,7 +443,7 @@ SCENARIO("Test computing Starts from coordinates")
         0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
         rmf_traffic::agv::compute_plan_starts(
-        graph, robot_loc, initial_time,
+        graph, test_map_name, robot_loc, initial_time,
         max_waypoint_merging_distance,
         max_lane_merging_distance,
         min_lane_length);
@@ -427,7 +459,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {0 - 1e-8, 0 + very_near_to_border_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -443,7 +477,7 @@ SCENARIO("Test computing Starts from coordinates")
       Eigen::Vector3d robot_loc = {0 - 1e-8, 0 - very_near_to_border_y, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
         rmf_traffic::agv::compute_plan_starts(
-        graph, robot_loc, initial_time,
+        graph, test_map_name, robot_loc, initial_time,
         max_waypoint_merging_distance,
         max_lane_merging_distance,
         min_lane_length);
@@ -469,7 +503,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {5.5, 5.5, 0};
 
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -498,7 +534,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {5.5, 5.5, 0};
 
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -542,7 +580,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -559,7 +599,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -575,7 +617,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 + max_lane_merging_distance - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -591,7 +635,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 - max_lane_merging_distance + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -622,7 +668,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -653,7 +701,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -684,7 +734,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 + 1.0 - 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -715,7 +767,9 @@ SCENARIO("Test computing Starts from coordinates")
     {
       Eigen::Vector3d robot_loc = {5, 0 - 1.0 + 1e-8, 0};
       std::vector<rmf_traffic::agv::Plan::Start> start_set =
-        rmf_traffic::agv::compute_plan_starts(graph,
+        rmf_traffic::agv::compute_plan_starts(
+          graph,
+          test_map_name,
           robot_loc,
           initial_time,
           max_waypoint_merging_distance,
@@ -763,7 +817,9 @@ SCENARIO("Test computing Starts from coordinates")
       0 + max_lane_merging_distance - 1e-8,
       0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -811,7 +867,9 @@ SCENARIO("Test computing Starts from coordinates")
       0 + max_lane_merging_distance - 1e-8,
       0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -862,7 +920,9 @@ SCENARIO("Test computing Starts from coordinates")
       0 + max_lane_merging_distance - 1e-8,
       0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -910,7 +970,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc =
     {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -954,7 +1016,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc =
     {0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -992,7 +1056,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {
       0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -1038,7 +1104,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {
       0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc, initial_time,
         max_waypoint_merging_distance,
         max_lane_merging_distance,
@@ -1081,7 +1149,9 @@ SCENARIO("Test computing Starts from coordinates")
     Eigen::Vector3d robot_loc = {
       0 + max_waypoint_merging_distance + 1e-8, 0, 0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,
@@ -1124,7 +1194,9 @@ SCENARIO("Test computing Starts from coordinates")
 
     Eigen::Vector3d robot_loc = {1 + 1e-8, 1 + 1e-8, 0.0};
     std::vector<rmf_traffic::agv::Plan::Start> start_set =
-      rmf_traffic::agv::compute_plan_starts(graph,
+      rmf_traffic::agv::compute_plan_starts(
+        graph,
+        test_map_name,
         robot_loc,
         initial_time,
         max_waypoint_merging_distance,


### PR DESCRIPTION
The function to compute valid planer start conditions was not accounting for the name of the map that the vehicle was on. This is a problem for multi-floor scenarios.