### PR TITLE
Fix CHANGELOG renderings

### DIFF
--- a/rmf_fleet_adapter/CHANGELOG.rst
+++ b/rmf_fleet_adapter/CHANGELOG.rst
@@ -8,14 +8,14 @@ Forthcoming
 1.0.0 (2020-06-23)
 ------------------
 * Provides `rmf_fleet_adapter` library
-  * The `rmf_fleet_adapter::agv` component can be used to develop a custom "Full Control" fleet adapter
-  * `rmf_fleet_adapter/StandardNames.hpp` specifies topic names that are used for RMF integration
+    * The `rmf_fleet_adapter::agv` component can be used to develop a custom "Full Control" fleet adapter
+    * `rmf_fleet_adapter/StandardNames.hpp` specifies topic names that are used for RMF integration
 * Provides a prototype `read_only` fleet adapter implementation
-  * This will be deprecated in the future in favor of a C++ API
-  * To use this fleet adapter, you must implement a "read-only fleet driver" to talk to the fleet adapter using `rmf_fleet_msgs`
+    * This will be deprecated in the future in favor of a C++ API
+    * To use this fleet adapter, you must implement a "read-only fleet driver" to talk to the fleet adapter using `rmf_fleet_msgs`
 * Provides a deprecated `full_control` fleet adapter implementation
-  * This is made to be backwards compatible with "full-control fleet drivers" that were developed in the early stages of RMF
-  * New users should prefer to implement their own fleet adapter using the `rmf_fleet_adapter::agv` API
+    * This is made to be backwards compatible with "full-control fleet drivers" that were developed in the early stages of RMF
+    * New users should prefer to implement their own fleet adapter using the `rmf_fleet_adapter::agv` API
 * Uses rxcpp to make the fleet adapters reactive and multi-threaded
 * Has a known memory leak issue which will be resolved in a later release
 * Contributors: Aaron Chong, Charayaphan Nakorn Boon Han, Marco A. Gutiérrez, Grey, Yadu, Yadunund, koonpeng, methylDragon

--- a/rmf_fleet_adapter/README.md
+++ b/rmf_fleet_adapter/README.md
@@ -1,7 +1,3 @@
 # rmf\_fleet\_adapter package
 
 This package contains the various fleet adapter nodes for different levels of control. Using specific messages from `rmf_fleet_msgs`, it communicates with proprietary fleet drivers and managers through ROS2.
-
-## Note,
-
-* The current implementation is mainly a migration of `proto_fleet_adapter` from the `rmf_traffic_ros2` package.

--- a/rmf_traffic/CHANGELOG.rst
+++ b/rmf_traffic/CHANGELOG.rst
@@ -8,26 +8,26 @@ Forthcoming
 1.0.0 (2020-06-23)
 ------------------
 * Provides core `rmf_traffic` utilities
-  * `Trajectory` - Describe a motion through 2D space
-  * `Route` - Describe a path that a robot will follow
-  * `Motion` - Convert a discrete `Trajectory` into a continuous function
+    * `Trajectory` - Describe a motion through 2D space
+    * `Route` - Describe a path that a robot will follow
+    * `Motion` - Convert a discrete `Trajectory` into a continuous function
 * Provides `rmf_traffic::schedule` utilities for managing traffic schedules
-  * `Database` - Object for managing a schedule database
-  * `Viewer` - Interface for viewing a schedule database
-  * `Writer` - Interface for writing to a schedule database
-  * `Mirror` - Object for mirroring a schedule database across a distributed system
-  * `Snapshot` - Object that captures a snapshot of a database
-  * `Participant` - Object that manages participation in a schedule
-  * `ParticipantDescription` - Object that describes a participant
-  * `Query` - Object that describes a schedule query
-  * `Negotiation` - Object that manages a traffic negotiation
-  * `Negotiator` - Interface used to respond to negotiation events
-  * `StubbornNegotiator` - An implementation of a `Negotiator` that refuses to deviate from its path
+    * `Database` - Object for managing a schedule database
+    * `Viewer` - Interface for viewing a schedule database
+    * `Writer` - Interface for writing to a schedule database
+    * `Mirror` - Object for mirroring a schedule database across a distributed system
+    * `Snapshot` - Object that captures a snapshot of a database
+    * `Participant` - Object that manages participation in a schedule
+    * `ParticipantDescription` - Object that describes a participant
+    * `Query` - Object that describes a schedule query
+    * `Negotiation` - Object that manages a traffic negotiation
+    * `Negotiator` - Interface used to respond to negotiation events
+    * `StubbornNegotiator` - An implementation of a `Negotiator` that refuses to deviate from its path
 * Provides `rmf_traffic::agv` utilities to help AGV fleets integrate with the schedule
-  * `Graph` - Describe the route graph that an AGV is allowed to use
-  * `VehicleTraits` - Describe the kinematic properties of an AGV
-  * `Interpolate` - Interpolate the trajectory of an AGV based on its traits
-  * `RouteValidator` - Interface for determining whether a route is free of conflicts
-  * `Planner` - Object that can generate plans for an AGV that comply with the schedule or that suit a negotiation
-  * `SimpleNegotiator` - An implementation of a `schedule::Negotiator` that can negotiate for an AGV
+    * `Graph` - Describe the route graph that an AGV is allowed to use
+    * `VehicleTraits` - Describe the kinematic properties of an AGV
+    * `Interpolate` - Interpolate the trajectory of an AGV based on its traits
+    * `RouteValidator` - Interface for determining whether a route is free of conflicts
+    * `Planner` - Object that can generate plans for an AGV that comply with the schedule or that suit a negotiation
+    * `SimpleNegotiator` - An implementation of a `schedule::Negotiator` that can negotiate for an AGV
 * Contributors: Aaron Chong, Boon Han, Charayaphan Nakorn Boon Han, Grey, Luca Della Vedova, Marco A. Gutiérrez, Morgan Quigley, Yadu, Yadunund, koonpeng

--- a/rmf_traffic_ros2/CHANGELOG.rst
+++ b/rmf_traffic_ros2/CHANGELOG.rst
@@ -8,10 +8,10 @@ Forthcoming
 1.0.0 (2020-06-23)
 ------------------
 * Provides `rmf_traffic_ros2` library which offers utilities to wrap `rmf_traffic` into `ros2` APIs
-  * `rmf_traffic_ros2::convert(T)` functions convert between `rmf_traffic` API data structures and `rmf_traffic_msgs` message structures
-  * `rmf_traffic_ros2::schedule` utilities help to connect `rmf_traffic` objects across distributed ROS2 systems
-    * `MirrorManager` - Object that maintains a `rmf_traffic::schedule::Mirror` across ROS2 connections
-    * `Writer` - Factory for `rmf_traffic::schedule::Participant` objects that can talk to a database across ROS2 connections
-    * `Negotiation` - Object that manages a set of traffic negotiations across ROS2 connections
+    * `rmf_traffic_ros2::convert(T)` functions convert between `rmf_traffic` API data structures and `rmf_traffic_msgs` message structures
+    * `rmf_traffic_ros2::schedule` utilities help to connect `rmf_traffic` objects across distributed ROS2 systems
+        * `MirrorManager` - Object that maintains a `rmf_traffic::schedule::Mirror` across ROS2 connections
+        * `Writer` - Factory for `rmf_traffic::schedule::Participant` objects that can talk to a database across ROS2 connections
+        * `Negotiation` - Object that manages a set of traffic negotiations across ROS2 connections
 * `rmf_traffic_schedule` - a ROS2 node that manages a traffic schedule service and judges the outcomes of traffic negotiations
 * Contributors: Aaron Chong, Grey, Marco A. Gutiérrez, Morgan Quigley, Yadu, Yadunund, koonpeng

--- a/rmf_utils/CHANGELOG.rst
+++ b/rmf_utils/CHANGELOG.rst
@@ -8,8 +8,8 @@ Forthcoming
 1.0.0 (2020-06-23)
 ------------------
 * Basic utilities for use in the `rmf_core` packages
-  * `impl_ptr` - A smart pointer that helps implement a PIMPL-pattern
-  * `clone_ptr` - A smart pointer with cloning semantics (copying the pointer instance will clone the underlying object)
-  * `optional` - A stopgap measure to get the features of `std::optional` before C++17 is available
-  * `Modular` - A class for comparing integral version numbers that may wrap around due to integer overflow
+    * `impl_ptr` - A smart pointer that helps implement a PIMPL-pattern
+    * `clone_ptr` - A smart pointer with cloning semantics (copying the pointer instance will clone the underlying object)
+    * `optional` - A stopgap measure to get the features of `std::optional` before C++17 is available
+    * `Modular` - A class for comparing integral version numbers that may wrap around due to integer overflow
 * Contributors: Grey, Luca Della Vedova, Marco A. Gutiérrez, Michael X. Grey, Morgan Quigley, Yadu, Yadunund


### PR DESCRIPTION
The CHANGELOGs were being rendered incorrectly because the nested list syntax requires 4-space indents instead of 2-space.

It seems that something strange is still happening, because parent bullet points are getting bolded and italicized for some reason. I tried switching the asterisks to dashes, but that didn't seem to change the effect.