### PR TITLE
Change deprecated macro to its replacement

### DIFF
--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -22,7 +22,7 @@ target_include_directories(rmf_utils
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-ament_export_interfaces(rmf_utils HAS_LIBRARY_TARGET)
+ament_export_targets(rmf_utils HAS_LIBRARY_TARGET)
 
 install(
   DIRECTORY include/


### PR DESCRIPTION
See the release notes here:
https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/#ament-export-interfaces-replaced-by-ament-export-targets