### PR TITLE
Remove deprecated node-name parameters from launch files

### DIFF
--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -26,7 +26,6 @@
   <node pkg="rmf_fleet_adapter"
         exec="$(var control_type)"
         name="$(var fleet_name)_fleet_adapter"
-        node-name="$(var fleet_name)_fleet_adapter"
         output="both">
 
     <param name="fleet_name" value="$(var fleet_name)"/>

--- a/rmf_fleet_adapter/launch/robot_state_aggregator.launch.xml
+++ b/rmf_fleet_adapter/launch/robot_state_aggregator.launch.xml
@@ -9,7 +9,6 @@
   <node pkg="rmf_fleet_adapter"
         exec="robot_state_aggregator"
         name="$(var fleet_name)_state_aggregator"
-        node-name="$(var fleet_name)_state_aggregator"
         output="both">
 
     <param name="robot_prefix" value="$(var robot_prefix)"/>


### PR DESCRIPTION
The `node-name` parameter in XML-format launch files has been deprecated and removed in Foxy. Moreover, using both `node-name` and `name` is an error. This PR removes the deprecated `node-name` parameter, leaving the `name` parameter.

These changes are backwards-compatible with Eloquent.