### PR TITLE
Fix compiler warnings

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/tasks/Delivery.cpp
@@ -35,8 +35,6 @@ std::shared_ptr<Task> make_delivery(
   const auto pickup_wp =
       graph.find_waypoint(request.pickup_place_name)->index();
 
-  const auto& node = context->node();
-
   Task::PendingPhases phases;
   phases.push_back(
         phases::GoToPlace::make(context, std::move(pickup_start), pickup_wp));

--- a/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Database.cpp
@@ -400,7 +400,7 @@ rmf_utils::optional<Writer::Input> Database::Debug::get_itinerary(
   for (const RouteId route : state.active_routes)
     itinerary.push_back({route, state.storage.at(route).entry->route});
 
-  return std::move(itinerary);
+  return itinerary;
 }
 
 //==============================================================================
@@ -1034,7 +1034,7 @@ rmf_utils::optional<Itinerary> Database::get_itinerary(
   for (const RouteId route : state.active_routes)
     itinerary.push_back(state.storage.at(route).entry->route);
 
-  return std::move(itinerary);
+  return itinerary;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Mirror.cpp
@@ -258,7 +258,7 @@ rmf_utils::optional<Itinerary> Mirror::get_itinerary(
   for (const auto& s : state.storage)
     itinerary.push_back(s.second.entry->route);
 
-  return std::move(itinerary);
+  return itinerary;
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/Rectifier.cpp
@@ -133,7 +133,7 @@ DatabaseRectificationRequesterFactory::make(
     _pimpl->_database, std::move(rectifier), participant_id);
 
   _pimpl->_handles.push_back(requester->_handle);
-  return std::move(requester);
+  return requester;
 }
 
 //==============================================================================

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -90,7 +90,7 @@ public:
     // because the Database should never double-assign a ParticipantId
     stub_map[participant_id] = requester->stub;
 
-    return std::move(requester);
+    return requester;
   }
 
   void check_inconsistencies(const InconsistencyMsg& msg)


### PR DESCRIPTION
This PR:

- removes a few of `std::move` usages that are redundant and preventing RVO, because they are turning a local variable into an rvalue reference.
- removes an unused variable in `rmf_fleet_adaptor/tasks/Delivery.cpp`