### PR TITLE
Fix deprecated api usage

### DIFF
--- a/rmf_fleet_adapter/rmf_rxcpp/include/rmf_rxcpp/Transport.hpp
+++ b/rmf_fleet_adapter/rmf_rxcpp/include/rmf_rxcpp/Transport.hpp
@@ -105,10 +105,10 @@ private:
   bool _node_added = false;
   std::condition_variable _spin_cv;
 
-  static rclcpp::executor::ExecutorArgs _make_exec_args(
+  static rclcpp::ExecutorOptions _make_exec_args(
       const rclcpp::NodeOptions& options)
   {
-    rclcpp::executor::ExecutorArgs exec_args;
+    rclcpp::ExecutorOptions exec_args;
     exec_args.context = options.context();
     return exec_args;
   }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -145,7 +145,7 @@ public:
       const rclcpp::NodeOptions& node_options,
       rmf_utils::optional<rmf_traffic::Duration> discovery_timeout)
   {
-    if (!rclcpp::is_initialized(node_options.context()))
+    if (!rclcpp::ok(node_options.context()))
     {
       throw std::runtime_error(
             "rclcpp must be initialized before creating an Adapter! "


### PR DESCRIPTION
Remove usage of APIs that have been deprecated in Foxy, using their new replacements instead. 