### PR TITLE
Improve conflict detection for vehicles that start close to each other

### DIFF
--- a/rmf_fleet_adapter/CHANGELOG.rst
+++ b/rmf_fleet_adapter/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package rmf_fleet_adapter
 Forthcoming
 -----------
 
-1.0.1 (2020-07-XX)
+1.0.1 (2020-07-20)
 ------------------
 * Interrupt dangling negotiation planning efforts to reduce memory usage: [#130](https://github.com/osrf/rmf_core/pull/130/)
 * Trim the amount of system memory that is committed to a fleet adapter after each task: [#130](https://github.com/osrf/rmf_core/pull/130/)

--- a/rmf_traffic/CHANGELOG.rst
+++ b/rmf_traffic/CHANGELOG.rst
@@ -5,7 +5,11 @@ Changelog for package rmf_traffic
 Forthcoming
 -----------
 
-1.0.1 (2020-07-XX)
+1.0.2 (2020-07-27)
+------------------
+* Improved definition of "traffic conflict" for vechiles that start too close: [#136](https://github.com/osrf/rmf_core/pull/136)
+
+1.0.1 (2020-07-20)
 ------------------
 * Allow users to specify a callback for interrupting a planner: [#130](https://github.com/osrf/rmf_core/pull/130/)
 * Allow a Negotiation Table Viewer to know when its Table is defunct: [#130](https://github.com/osrf/rmf_core/pull/130/)

--- a/rmf_traffic/src/rmf_traffic/DetectConflict.cpp
+++ b/rmf_traffic/src/rmf_traffic/DetectConflict.cpp
@@ -278,21 +278,6 @@ BoundingBox adjust_bounding_box(
 }
 
 //==============================================================================
-BoundingBox get_bounding_footprint(
-  const rmf_traffic::Spline& spline,
-  const Profile::Implementation& profile)
-{
-  if (profile.footprint)
-  {
-    return adjust_bounding_box(
-      get_bounding_box(spline),
-      profile.footprint->get_characteristic_length());
-  }
-
-  return void_box();
-}
-
-//==============================================================================
 BoundingProfile get_bounding_profile(
   const rmf_traffic::Spline& spline,
   const Profile::Implementation& profile)
@@ -641,7 +626,7 @@ rmf_utils::optional<rmf_traffic::Time> detect_approach(
 
     const DistanceDifferential D(*spline_a, *spline_b);
 
-    if (D.initially_negative_derivative())
+    if (D.initially_approaching())
     {
       const auto time = D.start_time();
       if (!output_conflicts)

--- a/rmf_traffic/src/rmf_traffic/DetectConflict.cpp
+++ b/rmf_traffic/src/rmf_traffic/DetectConflict.cpp
@@ -459,15 +459,6 @@ bool close_start(
   // it a conflict for them to be in each other's vicinities. This gives robots
   // an opportunity to back away from each other without it being considered a
   // schedule conflict.
-
-  if (profile_a.footprint == profile_a.vicinity
-    && profile_b.footprint == profile_b.vicinity)
-  {
-    // If there is no difference between the footprint and vicinity for either
-    // vehicle, then there is no such thing as a "close start".
-    return false;
-  }
-
   Spline spline_a(a_it);
   Spline spline_b(b_it);
   const auto start_time =

--- a/rmf_traffic/src/rmf_traffic/Spline.hpp
+++ b/rmf_traffic/src/rmf_traffic/Spline.hpp
@@ -92,7 +92,7 @@ public:
       const Spline& spline_a,
       const Spline& spline_b);
 
-  bool initially_negative_derivative() const;
+  bool initially_approaching() const;
 
   /// Calculate the times within the relevant window when an "approach" is
   /// occuring. This means that the vehicles are getting closer together than

--- a/rmf_traffic/src/rmf_traffic/Spline.hpp
+++ b/rmf_traffic/src/rmf_traffic/Spline.hpp
@@ -28,6 +28,7 @@
 
 namespace rmf_traffic {
 
+//==============================================================================
 /// A utility class to convert Trajectories into piecewise-splines.
 ///
 /// \warning For now this class is only meant for internal use; it is not part
@@ -77,6 +78,32 @@ public:
 private:
 
   Parameters params;
+
+};
+
+//==============================================================================
+/// This class helps compute the differentials of the distance between two
+/// splines.
+class DistanceDifferential
+{
+public:
+
+  DistanceDifferential(
+      const Spline& spline_a,
+      const Spline& spline_b);
+
+  bool initially_negative_derivative() const;
+
+  /// Calculate the times within the relevant window when an "approach" is
+  /// occuring. This means that the vehicles are getting closer together than
+  /// they should.
+  std::vector<Time> approach_times() const;
+
+  Time start_time() const;
+  Time finish_time() const;
+
+private:
+  Spline::Parameters _params;
 
 };
 

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -731,10 +731,10 @@ SCENARIO("A Single Lane")
           }
         });
 
-      THEN("No Proposal is found")
+      THEN("A proposal is found")
       {
         auto proposal = NegotiationRoom(database, intentions).solve();
-        REQUIRE_FALSE(proposal);
+        REQUIRE(proposal);
       }
     }
 

--- a/rmf_traffic/test/unit/agv/test_Negotiator.cpp
+++ b/rmf_traffic/test/unit/agv/test_Negotiator.cpp
@@ -433,8 +433,6 @@ SCENARIO("Multi-participant negotiation")
 
   auto proposal = NegotiationRoom(database, intentions, 4.0)/*.print()*/.solve();
   REQUIRE(proposal);
-
-  //print_proposal(*proposal);
 }
 
 // Helper Definitions

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -88,7 +88,7 @@ void print_trajectory_info(
   {
     int waypoint_count = 1;
     const auto& t = r.trajectory();
-    std::cout << "Trajectory [" << trajectory_count << "] in " << r.map() 
+    std::cout << "Trajectory [" << trajectory_count << "] in " << r.map()
               << " with " << t.size() << " waypoints\n";
     for (auto it = t.begin(); it != t.end(); it++)
     {
@@ -2593,4 +2593,115 @@ SCENARIO("Multilevel Planning")
     CHECK(count_events(*plan) == 2);
     CHECK(has_event(ExpectEvent::LiftDoorOpen, *plan));
   }
+}
+
+SCENARIO("Close start", "[close_start]")
+{
+  using namespace std::chrono_literals;
+
+  auto database = std::make_shared<rmf_traffic::schedule::Database>();
+
+  rmf_traffic::Profile profile{
+    rmf_traffic::geometry::make_final_convex<
+      rmf_traffic::geometry::Circle>(0.1),
+    rmf_traffic::geometry::make_final_convex<
+      rmf_traffic::geometry::Circle>(1.0)
+  };
+
+  auto p1 = rmf_traffic::schedule::make_participant(
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 1",
+      "test_Negotiator",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
+
+  auto p2 = rmf_traffic::schedule::make_participant(
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 2",
+      "test_Negotiator",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
+
+  const std::string test_map_name = "test_map";
+  rmf_traffic::agv::Graph graph;
+  graph.add_waypoint(test_map_name, { 0.0, -5.0}); // 0
+  graph.add_waypoint(test_map_name, {-5.0, 0.0}); // 1
+  graph.add_waypoint(test_map_name, { 0.0, 0.0}); // 2
+  graph.add_waypoint(test_map_name, { 5.0,  0.0}); // 3
+  graph.add_waypoint(test_map_name, { 0.0, 5.0}); // 4
+  graph.add_waypoint(test_map_name, { 5.0, 5.0}); // 5
+
+  /*
+   *         4-----5
+   *         |     |
+   *         |     |
+   *   1-----2-----3
+   *         |
+   *         |
+   *         0
+   */
+
+  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
+    {
+      graph.add_lane(w0, w1);
+      graph.add_lane(w1, w0);
+    };
+
+  add_bidir_lane(0, 2);
+  add_bidir_lane(1, 2);
+  add_bidir_lane(3, 2);
+  add_bidir_lane(3, 5);
+  add_bidir_lane(4, 2);
+  add_bidir_lane(4, 5);
+
+  const rmf_traffic::agv::VehicleTraits traits{
+    {0.7, 0.3},
+    {1.0, 0.45},
+    profile
+  };
+
+  const auto time = std::chrono::steady_clock::now();
+
+  rmf_traffic::agv::Planner::Configuration configuration{graph, traits};
+
+  rmf_traffic::Trajectory t_obs;
+  t_obs.insert(time, {-0.5, 0.0, 0.0}, {0.0, 0.0, 0.0});
+  t_obs.insert(time + 10min, {-0.5, 0.0, 0.0}, {0.0, 0.0, 0.0});
+  p2.set({{test_map_name, t_obs}});
+
+  rmf_traffic::agv::Planner planner{
+    configuration,
+    rmf_traffic::agv::Plan::Options{
+      rmf_traffic::agv::ScheduleRouteValidator::make(
+            database, p1.id(), p1.description().profile())
+    }
+  };
+
+  const auto result =
+      planner.plan(
+        {
+          rmf_traffic::agv::Plan::Start(time, 2, 0, Eigen::Vector2d{0.5, 0.0}),
+          rmf_traffic::agv::Plan::Start(time, 3, 0, Eigen::Vector2d{0.5, 0.0})
+        }, 4);
+
+  REQUIRE(result);
+
+  CHECK(result->get_itinerary().back().trajectory().back().time()
+        < time + 10min);
+
+  std::unordered_set<std::size_t> visited_wps;
+  for (const auto& wp : result->get_waypoints())
+  {
+    if (wp.graph_index())
+      visited_wps.insert(*wp.graph_index());
+  }
+
+  CHECK(visited_wps.size() == 3);
+  CHECK(visited_wps.count(3));
+  CHECK(visited_wps.count(5));
+  CHECK(visited_wps.count(4));
 }

--- a/rmf_traffic/test/unit/test_Conflict.cpp
+++ b/rmf_traffic/test/unit/test_Conflict.cpp
@@ -55,11 +55,10 @@ SCENARIO("DetectConflict unit tests")
       t2.insert(time, pos, vel);
       t2.insert(time + 10s, pos, vel);
 
-      THEN("The between function reports the details of conflict")
+      THEN("The robots are not approaching each other, so it is not a conflict")
       {
         const auto conflicts = get_conflicts(profile, t1, profile, t2);
-
-        CHECK(conflicts.size() == 1);
+        CHECK(conflicts.empty());
 
         std::vector<ConflictDataParams> expected_conflicts;
         expected_conflicts.push_back({
@@ -84,10 +83,10 @@ SCENARIO("DetectConflict unit tests")
       t2.insert(time, Eigen::Vector3d(dx, dx, dx), vel);
       t2.insert(time + 10s, Eigen::Vector3d(dx, dx, dx), vel);
 
-      THEN("The between function reports the details of conflict")
+      THEN("The robots are not approaching each other, so it is not a conflict")
       {
         const auto conflicts = get_conflicts(profile, t1, profile, t2);
-        CHECK(conflicts.size() == 1);
+        CHECK(conflicts.empty());
 
         std::vector<ConflictDataParams> expected_conflicts;
         expected_conflicts.push_back({

--- a/rmf_traffic/test/unit/test_Profile.cpp
+++ b/rmf_traffic/test/unit/test_Profile.cpp
@@ -125,7 +125,7 @@ SCENARIO("Testing Construction")
   }
 }
 
-SCENARIO("Testing conflicts", "[conflicts]")
+SCENARIO("Testing conflicts", "[close_start]")
 {
   using Trajecotry = rmf_traffic::Trajectory;
 

--- a/rmf_traffic/test/unit/test_Profile.cpp
+++ b/rmf_traffic/test/unit/test_Profile.cpp
@@ -125,7 +125,7 @@ SCENARIO("Testing Construction")
   }
 }
 
-SCENARIO("Testing conflicts")
+SCENARIO("Testing conflicts", "[conflicts]")
 {
   using Trajecotry = rmf_traffic::Trajectory;
 
@@ -193,40 +193,90 @@ SCENARIO("Testing conflicts")
         t2));
   }
 
-  GIVEN("Overlapping footprints and vicinities")
-  {
-    Trajecotry t1;
-    t1.insert(start_time, {0, 0, 0}, {0, 0, 0});
-    t1.insert(start_time + 10s, {10, 0, 0}, {0, 0, 0});
-
-    Trajecotry t2;
-    t2.insert(start_time, {0, 2, 0}, {0, 0, 0});
-    t2.insert(start_time + 10s, {10, 2, 0}, {0, 0, 0});
-
-    CHECK(rmf_traffic::DetectConflict::between(
-        {circle_1, circle_2},
-        t1,
-        {circle_1, circle_2},
-        t2));
-  }
-
   GIVEN("Footprint overlaps with vicinity from the start")
   {
     Trajecotry t1;
     t1.insert(start_time, {0, 0, 0}, {0, 0, 0});
-    t1.insert(start_time + 10s, {0, 0, 0}, {0, 0, 0});
 
     Trajecotry t2;
     t2.insert(start_time, {2.8, 0, 0}, {0, 0, 0});
-    t2.insert(start_time + 10s, {2.8, 0, 0}, {0, 0, 0});
 
-    // A conflict only exists if the footprint entered the vicinity after the
-    // start of the trajectory
-    CHECK_FALSE(rmf_traffic::DetectConflict::between(
-        {circle_1, circle_2},
-        t1,
-        {circle_1},
-        t2));
+    const rmf_traffic::Profile profile{circle_1, circle_2};
+
+    // When a robot starts in another's vicinity, a conflict only happens if the
+    // robots move closer to each other.
+
+    WHEN("Vehicles sit still")
+    {
+      t1.insert(start_time + 10s, {0, 0, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {2.8, 0, 0}, {0, 0, 0});
+      CHECK_FALSE(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
+
+    WHEN("Vehicles move in parallel")
+    {
+      t1.insert(start_time + 10s, {0, 10, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {2.8, 10, 0}, {0, 0, 0});
+      CHECK_FALSE(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
+
+    WHEN("One vehicle moves away")
+    {
+      t1.insert(start_time + 10s, {0, 0, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {10, 0, 0}, {0, 0, 0});
+      CHECK_FALSE(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
+
+    WHEN("Vehicles move apart slightly")
+    {
+      t1.insert(start_time + 10s, {0, 10, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {3, 10, 0}, {0, 0, 0});
+      CHECK_FALSE(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
+
+    WHEN("Vehicles move apart orthogonally")
+    {
+      t1.insert(start_time + 10s, {0, 10, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {10, 0, 0}, {0, 0, 0});
+      CHECK_FALSE(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
+
+    WHEN("Vehicles move apart in opposite shearing directions")
+    {
+      t1.insert(start_time + 10s, {0, 10, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {2.8, -10, 0}, {0, 0, 0});
+      CHECK_FALSE(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
+
+    WHEN("Vehicles move directly apart from each other")
+    {
+      t1.insert(start_time + 10s, {-10, 0, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {10, 0, 0}, {0, 0, 0});
+      CHECK_FALSE(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
+
+    WHEN("Vehicles move directly across each other")
+    {
+      t1.insert(start_time + 10s, {10, 0, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {-10, 0, 0}, {0, 0, 0});
+      CHECK(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
+
+    WHEN("Vehicles move a little closer")
+    {
+      t1.insert(start_time + 10s, {0, 10, 0}, {0, 0, 0});
+      t2.insert(start_time + 10s, {2.79, 10, 0}, {0, 0, 0});
+      CHECK(rmf_traffic::DetectConflict::between(
+          profile, t1, profile, t2));
+    }
   }
 
   GIVEN("Footprint overlaps with vicinity and then leaves")


### PR DESCRIPTION
When two vehicles start too close to each other, we need to tweak the definition of what is considered a conflict. Ordinarily a conflict would happen any time the footprint of one robot enters the vicinity of another. However, if a footprint of one is already inside the vicinity of another (which can happen due to latency, localization errors, etc), then it would be impossible to resolve the conflict since there would be no choice for either vehicle that would be considered conflict-free.

Therefore, when vehicles start in close proximity, we need to use a different definition of what constitutes a conflict. With this PR, when two itineraries start in close proximity, it will only be a conflict if either:
1. The derivative of the distance between the two itineraries is ever negative while they are still in close proximity, or
2. They re-invade each other's proximity after exiting.

This change should help to fix deadlocks properly in close-encounter situations.