### PR TITLE
Feature/remove ros2 dep

### DIFF
--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5.0)
 
-project(rmf_traffic)
+project(rmf_traffic VERSION 1.0.2)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
@@ -37,7 +37,6 @@ add_library(rmf_traffic SHARED
 find_package(ament_cmake_catch2 QUIET)
 find_package(rmf_cmake_uncrustify QUIET)
 if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
-
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
 
   ament_add_catch2(
@@ -81,7 +80,7 @@ target_include_directories(rmf_traffic
 
 install(
   DIRECTORY include/rmf_traffic
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  DESTINATION include
 )
 
 install(
@@ -98,26 +97,23 @@ install(
 )
 
 # Create cmake config files
-# See doc: https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#example-generating-package-files
 include(CMakePackageConfigHelpers)
-configure_package_config_file(
-  ${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_traffic-config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config.cmake
-  INSTALL_DESTINATION lib/cmake/rmf_traffic
-  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-config-version.cmake"
+  COMPATIBILITY ExactVersion
 )
-# write_basic_package_version_file(
-#   ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config-version.cmake
-#   VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion
-# )
-
+configure_package_config_file(
+  "${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_traffic-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-config.cmake"
+  INSTALL_DESTINATION "lib/cmake/rmf_traffic"
+)
 install(
   FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config.cmake
-    # ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config-version.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-config-version.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-config.cmake"
   DESTINATION lib/cmake/rmf_traffic
 )
 export(
   EXPORT rmf_traffic-targets
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-targets.cmake
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-targets.cmake
 )

--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -4,8 +4,6 @@ project(rmf_traffic)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
-find_package(ament_cmake REQUIRED)
-
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -26,7 +24,6 @@ include(FindPkgConfig)
 pkg_check_modules(PC_FCL REQUIRED fcl)
 pkg_check_modules(PC_CCD REQUIRED ccd)
 
-find_package(ament_cmake REQUIRED)
 find_package(rmf_utils REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Threads)
@@ -37,8 +34,9 @@ add_library(rmf_traffic SHARED
   ${core_lib_srcs}
 )
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_catch2 REQUIRED)
+find_package(ament_cmake_catch2 QUIET)
+find_package(rmf_cmake_uncrustify QUIET)
+if(BUILD_TESTING AND ament_cmake_catch2_FOUND AND rmf_cmake_uncrustify_FOUND)
 
   file(GLOB_RECURSE unit_test_srcs "test/*.cpp")
 
@@ -56,7 +54,6 @@ if(BUILD_TESTING)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/>
   )
 
-  find_package(rmf_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file NAMES "share/format/rmf_code_style.cfg")
 
   rmf_uncrustify(
@@ -68,7 +65,7 @@ endif()
 
 target_link_libraries(rmf_traffic
   PUBLIC
-    rmf_utils::rmf_utils
+    ${rmf_utils_LIBRARIES}
   PRIVATE
     ${PC_FCL_LIBRARIES}
     ${PC_CCD_LIBRARIES}
@@ -78,23 +75,49 @@ target_include_directories(rmf_traffic
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    ${rmf_utils_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
 )
 
-ament_export_interfaces(rmf_traffic HAS_LIBRARY_TARGET)
-ament_export_dependencies(rmf_utils)
-
 install(
-  DIRECTORY include/
+  DIRECTORY include/rmf_traffic
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install(
   TARGETS rmf_traffic
-  EXPORT  rmf_traffic
+  EXPORT  rmf_traffic-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-ament_package()
+install(
+  EXPORT rmf_traffic-targets
+  DESTINATION lib/cmake/rmf_traffic
+)
+
+# Create cmake config files
+# See doc: https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#example-generating-package-files
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_traffic-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config.cmake
+  INSTALL_DESTINATION lib/cmake/rmf_traffic
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+# write_basic_package_version_file(
+#   ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config-version.cmake
+#   VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion
+# )
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config.cmake
+    # ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config-version.cmake
+  DESTINATION lib/cmake/rmf_traffic
+)
+export(
+  EXPORT rmf_traffic-targets
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-targets.cmake
+)

--- a/rmf_traffic/CMakeLists.txt
+++ b/rmf_traffic/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 
 target_link_libraries(rmf_traffic
   PUBLIC
-    ${rmf_utils_LIBRARIES}
+    rmf_utils::rmf_utils
   PRIVATE
     ${PC_FCL_LIBRARIES}
     ${PC_CCD_LIBRARIES}
@@ -74,13 +74,25 @@ target_include_directories(rmf_traffic
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${rmf_utils_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
 )
 
-install(
-  DIRECTORY include/rmf_traffic
-  DESTINATION include
+# Create cmake config files
+include(CMakePackageConfigHelpers)
+
+set(INSTALL_CONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/rmf_traffic/cmake")
+set(PACKAGE_CONFIG_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config-version.cmake")
+set(PACKAGE_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-config.cmake")
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_traffic-config.cmake.in"
+  ${PACKAGE_CONFIG_FILE}
+  INSTALL_DESTINATION ${INSTALL_CONFIG_DIR}
+)
+
+write_basic_package_version_file(
+  ${PACKAGE_CONFIG_VERSION_FILE}
+  COMPATIBILITY ExactVersion
 )
 
 install(
@@ -92,28 +104,28 @@ install(
 )
 
 install(
-  EXPORT rmf_traffic-targets
-  DESTINATION lib/cmake/rmf_traffic
+  DIRECTORY include/rmf_traffic
+  DESTINATION include
 )
 
-# Create cmake config files
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-config-version.cmake"
-  COMPATIBILITY ExactVersion
-)
-configure_package_config_file(
-  "${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_traffic-config.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-config.cmake"
-  INSTALL_DESTINATION "lib/cmake/rmf_traffic"
-)
 install(
   FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-config-version.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-config.cmake"
-  DESTINATION lib/cmake/rmf_traffic
+    ${PACKAGE_CONFIG_VERSION_FILE}
+    ${PACKAGE_CONFIG_FILE}
+  DESTINATION ${INSTALL_CONFIG_DIR}
 )
+
+install(
+  EXPORT rmf_traffic-targets
+  FILE rmf_traffic-targets.cmake
+  NAMESPACE rmf_traffic::
+  DESTINATION ${INSTALL_CONFIG_DIR}
+)
+
 export(
   EXPORT rmf_traffic-targets
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_traffic-targets.cmake
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_traffic-targets.cmake
+  NAMESPACE rmf_traffic::
 )
+
+export(PACKAGE rmf_traffic)

--- a/rmf_traffic/cmake/rmf_traffic-config.cmake.in
+++ b/rmf_traffic/cmake/rmf_traffic-config.cmake.in
@@ -1,11 +1,14 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+find_dependency(Eigen3 REQUIRED)
 find_dependency(rmf_utils REQUIRED)
 
-set(@PROJECT_NAME@_FOUND ON)
-set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
-set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
-set(@PROJECT_NAME@_LIBRARIES "@PACKAGE_LIBRARIES@")
+set(rmf_traffic_FOUND ON)
+message(STATUS "package_prefix_dir: ${PACKAGE_PREFIX_DIR}")
+
+set_and_check(rmf_traffic_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(rmf_traffic_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+set(rmf_traffic_LIBRARIES "@PACKAGE_LIBRARIES@")
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/rmf_traffic/cmake/rmf_traffic-config.cmake.in
+++ b/rmf_traffic/cmake/rmf_traffic-config.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(rmf_utils REQUIRED)
+
+set(@PROJECT_NAME@_FOUND ON)
+set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+set(@PROJECT_NAME@_LIBRARIES "@PACKAGE_LIBRARIES@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/rmf_traffic/cmake/rmf_traffic-config.cmake.in
+++ b/rmf_traffic/cmake/rmf_traffic-config.cmake.in
@@ -1,14 +1,14 @@
 @PACKAGE_INIT@
 
+get_filename_component(rmf_traffic_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
 include(CMakeFindDependencyMacro)
+
 find_dependency(Eigen3 REQUIRED)
 find_dependency(rmf_utils REQUIRED)
 
-set(rmf_traffic_FOUND ON)
-message(STATUS "package_prefix_dir: ${PACKAGE_PREFIX_DIR}")
+if(NOT TARGET rmf_traffic::rmf_traffic)
+    include("${rmf_traffic_CMAKE_DIR}/rmf_traffic-targets.cmake")
+endif()
 
-set_and_check(rmf_traffic_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
-set_and_check(rmf_traffic_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
-set(rmf_traffic_LIBRARIES "@PACKAGE_LIBRARIES@")
-
-include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+check_required_components(rmf_traffic)

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -14,8 +14,8 @@
   <build_depend>libccd-dev</build_depend>
   <build_depend>libfcl-dev</build_depend>
 
-  <!-- <test_depend>ament_cmake_catch2</test_depend> -->
-  <!-- <test_depend>rmf_cmake_uncrustify</test_depend> -->
+  <test_depend>ament_cmake_catch2</test_depend>
+  <test_depend>rmf_cmake_uncrustify</test_depend>
 
   <depend>eigen</depend>
 

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -8,20 +8,18 @@
   <license>Apache License 2.0</license>
   <author>Grey</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-
   <build_depend>rmf_utils</build_depend>
   <build_export_depend>rmf_utils</build_export_depend>
 
   <build_depend>libccd-dev</build_depend>
   <build_depend>libfcl-dev</build_depend>
 
-  <test_depend>ament_cmake_catch2</test_depend>
-  <test_depend>rmf_cmake_uncrustify</test_depend>
+  <!-- <test_depend>ament_cmake_catch2</test_depend> -->
+  <!-- <test_depend>rmf_cmake_uncrustify</test_depend> -->
 
   <depend>eigen</depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>cmake</build_type>
   </export>
 </package>

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library(rmf_traffic_ros2 SHARED ${core_lib_srcs})
 
 target_link_libraries(rmf_traffic_ros2
   PUBLIC
-    rmf_traffic::rmf_traffic
+    ${rmf_traffic_LIBRARIES}
     ${rmf_traffic_msgs_LIBRARIES}
     ${rclcpp_LIBRARIES}
 )
@@ -45,6 +45,7 @@ target_include_directories(rmf_traffic_ros2
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    ${rmf_traffic_INCLUDE_DIRS}
     ${rmf_traffic_msgs_INCLUDE_DIRS}
     ${rclcpp_INCLUDE_DIRS}
 )

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -20,10 +20,16 @@ find_package(rmf_fleet_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(rclcpp REQUIRED)
 
+if (rmf_traffic_FOUND)
+  message(STATUS "found rmf_traffic")
+  message(STATUS "rmf_traffic_LIBRARIES: ${rmf_traffic_LIBRARIES}")
+  message(STATUS "rmf_traffic_INCLUDE_DIRS: ${rmf_traffic_INCLUDE_DIRS}")
+endif()
+
 if(BUILD_TESTING)
   find_package(rmf_cmake_uncrustify REQUIRED)
   find_file(uncrustify_config_file NAMES "share/format/rmf_code_style.cfg")
-                
+
   rmf_uncrustify(
     ARGN include src examples
     CONFIG_FILE ${uncrustify_config_file}
@@ -70,7 +76,6 @@ target_link_libraries(rmf_traffic_schedule
 # TODO(MXG): Consider creating a separate downstream package for these
 add_executable(participant_node examples/participant_node.cpp)
 target_link_libraries(participant_node PUBLIC rmf_traffic_ros2)
-
 
 #===============================================================================
 install(

--- a/rmf_traffic_ros2/CMakeLists.txt
+++ b/rmf_traffic_ros2/CMakeLists.txt
@@ -42,7 +42,7 @@ add_library(rmf_traffic_ros2 SHARED ${core_lib_srcs})
 
 target_link_libraries(rmf_traffic_ros2
   PUBLIC
-    ${rmf_traffic_LIBRARIES}
+    rmf_traffic::rmf_traffic
     ${rmf_traffic_msgs_LIBRARIES}
     ${rclcpp_LIBRARIES}
 )
@@ -51,7 +51,6 @@ target_include_directories(rmf_traffic_ros2
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    ${rmf_traffic_INCLUDE_DIRS}
     ${rmf_traffic_msgs_INCLUDE_DIRS}
     ${rclcpp_INCLUDE_DIRS}
 )

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rmf_utils</depend>
   <depend>rmf_traffic</depend>
   <depend>rmf_traffic_msgs</depend>
   <depend>rmf_fleet_msgs</depend>

--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -20,47 +20,55 @@ target_include_directories(rmf_utils
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+# Create cmake config files
+include(CMakePackageConfigHelpers)
+
+set(INSTALL_CONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/rmf_utils/cmake")
+set(PACKAGE_CONFIG_VERSION_FILE "${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config-version.cmake")
+set(PACKAGE_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config.cmake")
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_utils-config.cmake.in"
+  ${PACKAGE_CONFIG_FILE}
+  INSTALL_DESTINATION ${INSTALL_CONFIG_DIR}
+)
+
+write_basic_package_version_file(
+  ${PACKAGE_CONFIG_VERSION_FILE}
+  COMPATIBILITY ExactVersion
+)
+
+install(
+  TARGETS rmf_utils
+  EXPORT rmf_utils-targets
+  DESTINATION lib
+)
+
 install(
   DIRECTORY include/rmf_utils
   DESTINATION include
 )
 
 install(
-  TARGETS rmf_utils
-  EXPORT  rmf_utils-targets
-  DESTINATION lib
+  FILES
+    ${PACKAGE_CONFIG_VERSION_FILE}
+    ${PACKAGE_CONFIG_FILE}
+  DESTINATION ${INSTALL_CONFIG_DIR}
 )
 
 install(
   EXPORT rmf_utils-targets
-  DESTINATION lib/cmake/rmf_utils
+  FILE rmf_utils-targets.cmake
+  NAMESPACE rmf_utils::
+  DESTINATION ${INSTALL_CONFIG_DIR}
 )
 
-install(
-  FILES test/format/rmf_code_style.cfg
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/format
-)
-
-add_subdirectory(test/unit)
-
-# Create cmake config files
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-config-version.cmake"
-  COMPATIBILITY ExactVersion
-)
-configure_package_config_file(
-  "${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_utils-config.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-config.cmake"
-  INSTALL_DESTINATION "lib/cmake/rmf_utils"
-)
-install(
-  FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-config-version.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-config.cmake"
-  DESTINATION lib/cmake/rmf_utils
-)
 export(
   EXPORT rmf_utils-targets
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-targets.cmake
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-targets.cmake
+  NAMESPACE rmf_utils::
 )
+
+export(PACKAGE rmf_utils)
+
+add_subdirectory(test/unit)

--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -12,8 +12,6 @@ endif()
 
 include(GNUInstallDirs)
 
-find_package(ament_cmake REQUIRED)
-
 add_library(rmf_utils INTERFACE)
 
 target_include_directories(rmf_utils
@@ -22,21 +20,20 @@ target_include_directories(rmf_utils
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-ament_export_interfaces(rmf_utils HAS_LIBRARY_TARGET)
-
 install(
   DIRECTORY include/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-foreach(module ${extra_cmake_modules})
-  list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS cmake/${module})
-endforeach()
-
-
 install(
   TARGETS rmf_utils
-  EXPORT  rmf_utils
+  EXPORT  rmf_utils-targets
+  DESTINATION lib
+)
+
+install(
+  EXPORT rmf_utils-targets
+  DESTINATION lib/cmake/rmf_utils
 )
 
 install(
@@ -46,4 +43,27 @@ install(
 
 add_subdirectory(test/unit)
 
-ament_package()
+# Create cmake config files
+# See doc: https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#example-generating-package-files
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_utils-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config.cmake
+  INSTALL_DESTINATION lib/cmake/rmf_utils
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+# write_basic_package_version_file(
+#   ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config-version.cmake
+#   VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion
+# )
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config.cmake
+    # ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config-version.cmake
+  DESTINATION lib/cmake/rmf_utils
+)
+export(
+  EXPORT rmf_utils-targets
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-targets.cmake
+)

--- a/rmf_utils/CMakeLists.txt
+++ b/rmf_utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5.0)
 
-project(rmf_utils)
+project(rmf_utils VERSION 1.0.2)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
@@ -21,8 +21,8 @@ target_include_directories(rmf_utils
 )
 
 install(
-  DIRECTORY include/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  DIRECTORY include/rmf_utils
+  DESTINATION include
 )
 
 install(
@@ -44,26 +44,23 @@ install(
 add_subdirectory(test/unit)
 
 # Create cmake config files
-# See doc: https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#example-generating-package-files
 include(CMakePackageConfigHelpers)
-configure_package_config_file(
-  ${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_utils-config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config.cmake
-  INSTALL_DESTINATION lib/cmake/rmf_utils
-  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-config-version.cmake"
+  COMPATIBILITY ExactVersion
 )
-# write_basic_package_version_file(
-#   ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config-version.cmake
-#   VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion
-# )
-
+configure_package_config_file(
+  "${CMAKE_CURRENT_LIST_DIR}/cmake/rmf_utils-config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-config.cmake"
+  INSTALL_DESTINATION "lib/cmake/rmf_utils"
+)
 install(
   FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config.cmake
-    # ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-config-version.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-config-version.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-config.cmake"
   DESTINATION lib/cmake/rmf_utils
 )
 export(
   EXPORT rmf_utils-targets
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/rmf_utils-targets.cmake
+  FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/rmf_utils-targets.cmake
 )

--- a/rmf_utils/cmake/rmf_utils-config.cmake.in
+++ b/rmf_utils/cmake/rmf_utils-config.cmake.in
@@ -1,10 +1,11 @@
 @PACKAGE_INIT@
 
+get_filename_component(rmf_utils_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+
 include(CMakeFindDependencyMacro)
 
-set(rmf_utils_FOUND ON)
-set_and_check(rmf_utils_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
-set_and_check(rmf_utils_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
-set(rmf_utils_LIBRARIES "@PACKAGE_LIBRARIES@")
+if(NOT TARGET rmf_utils::rmf_utils)
+  include("${rmf_utils_CMAKE_DIR}/rmf_utils-targets.cmake")
+endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/rmf_utils-targets.cmake")
+check_required_components(rmf_utils)

--- a/rmf_utils/cmake/rmf_utils-config.cmake.in
+++ b/rmf_utils/cmake/rmf_utils-config.cmake.in
@@ -2,9 +2,9 @@
 
 include(CMakeFindDependencyMacro)
 
-set(@PROJECT_NAME@_FOUND ON)
-set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
-set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
-set(@PROJECT_NAME@_LIBRARIES "@PACKAGE_LIBRARIES@")
+set(rmf_utils_FOUND ON)
+set_and_check(rmf_utils_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(rmf_utils_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+set(rmf_utils_LIBRARIES "@PACKAGE_LIBRARIES@")
 
-include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/rmf_utils-targets.cmake")

--- a/rmf_utils/cmake/rmf_utils-config.cmake.in
+++ b/rmf_utils/cmake/rmf_utils-config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+set(@PROJECT_NAME@_FOUND ON)
+set_and_check(@PROJECT_NAME@_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(@PROJECT_NAME@_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
+set(@PROJECT_NAME@_LIBRARIES "@PACKAGE_LIBRARIES@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")

--- a/rmf_utils/package.xml
+++ b/rmf_utils/package.xml
@@ -8,9 +8,7 @@
   <license>Apache License 2.0</license>
   <author>Grey</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
* removes ROS 2 dependencies from `rmf_utils` and `rmf_traffic`
* only when `BUILD_TESTING` is called will it try to find `ament_cmake_catch2` and `rmf_cmake_uncrustify`

This should allow us to distribute `rmf_utils` and `rmf_traffic` binaries to be used on non-ROS-2 systems