### PR TITLE
Traffic Light API

### DIFF
--- a/ament_cmake_catch2/package.xml
+++ b/ament_cmake_catch2/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>ament_cmake_catch2</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>Allows integrating catch2 tests in the ament buildsystem with CMake</description>
   <maintainer email="luca@osrfoundation.org">Luca Della Vedova</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_cmake_uncrustify/package.xml
+++ b/rmf_cmake_uncrustify/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rmf_cmake_uncrustify</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>
     ament_cmake_uncrustify with support for parsing a config file.
     </description>

--- a/rmf_dispenser_msgs/package.xml
+++ b/rmf_dispenser_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_dispenser_msgs</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>A package containing messages used to interface to dispenser workcells</description>
   <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_door_msgs/package.xml
+++ b/rmf_door_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_door_msgs</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>Messages used to interface to doors</description>
   <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_fleet_adapter/CHANGELOG.rst
+++ b/rmf_fleet_adapter/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog for package rmf_fleet_adapter
 Forthcoming
 -----------
 
+1.1.0 (2020-09-XX)
+------------------
+* Traffic Light API: [#147](https://github.com/osrf/rmf_core/pull/147)
+
 1.0.2 (2020-07-27)
 ------------------
 * Always respond to negotiations: [#138](https://github.com/osrf/rmf_core/pull/138)

--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -87,6 +87,7 @@ if (BUILD_TESTING)
   ament_add_catch2(
     rmf_fleet_adapter_test
       test/main.cpp
+      test/adapters/test_TrafficLight.cpp
       test/phases/MockAdapterFixture.cpp
       test/phases/DoorOpenTest.cpp
       test/phases/DoorCloseTest.cpp

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Adapter.hpp
@@ -18,6 +18,7 @@
 #define RMF_FLEET_ADAPTER__AGV__ADAPTER_HPP
 
 #include <rmf_fleet_adapter/agv/FleetUpdateHandle.hpp>
+#include <rmf_fleet_adapter/agv/TrafficLight.hpp>
 
 #include <rmf_traffic/agv/VehicleTraits.hpp>
 #include <rmf_traffic/agv/Graph.hpp>
@@ -97,6 +98,19 @@ public:
       const std::string& fleet_name,
       rmf_traffic::agv::VehicleTraits traits,
       rmf_traffic::agv::Graph navigation_graph);
+
+  /// Create a traffic light to help manage robots that can only support pause
+  /// and resume commands.
+  ///
+  /// \param[in] fleet_name
+  ///   The name of the fleet
+  void add_traffic_light(
+      std::shared_ptr<TrafficLight::CommandHandle> command,
+      const std::string& fleet_name,
+      const std::string& robot_name,
+      rmf_traffic::agv::VehicleTraits traits,
+      rmf_traffic::Profile profile,
+      std::function<void(TrafficLight::UpdateHandlePtr handle)> handle_cb);
 
   /// Get the rclcpp::Node that this adapter will be using for communication.
   std::shared_ptr<rclcpp::Node> node();

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotCommandHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotCommandHandle.hpp
@@ -59,9 +59,10 @@ public:
   ///   other vehicles.
   ///
   /// \param[in] next_arrival_estimator
-  ///   Give an estimate for how long the robot will take to reach the path
-  ///   element of the specified index. You should still be calling
-  ///   RobotUpdateHandle::update_position() even as you call this function.
+  ///   Use this callback to give estimates for how long the robot will take to
+  ///   reach the path element of the specified index. You should still be
+  ///   calling RobotUpdateHandle::update_position() even as you call this
+  ///   function.
   ///
   /// \param[in] path_finished_callback
   ///   Trigger this callback when the robot is done following the new path.

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -123,7 +123,13 @@ public:
     ///   but UpdateHandle::add_delay(~) should be called whenever that happens.
     virtual void receive_path_timing(
         std::size_t version,
-        const std::vector<rmf_traffic::Time>& timing);
+        const std::vector<rmf_traffic::Time>& timing) = 0;
+
+    /// This function will be called when deadlock has occurred due to an
+    /// unresolvable conflict. Human intervention may be required at this point,
+    /// because the RMF traffic negotiation system does not have a high enough
+    /// level of control over the conflicting participants to resolve it.
+    virtual void deadlock() = 0;
 
   };
 

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -96,22 +96,29 @@ public:
     ///   version number does not match the latest path that you submitted, then
     ///   simply ignore and discard the timing information.
     ///
-    /// \param[in] timing
+    /// \param[in] departure_timing
     ///   This is a vector of the earliest times that the vehicle is allowed to
     ///   leave a given waypoint. The entries of this vector have a 1:1 mapping
     ///   with the entries of the path vector that was submitted earlier. Each
     ///   entry represents the earliest time that a robot is allowed to move
     ///   past its corresponding waypoint. If the robot arrives at the waypoint
     ///   before the given time, then the robot is obligated to pause until the
-    ///   given time arrives. The robot is allowed to arrive at a waypoint late,
-    ///   but UpdateHandle::add_delay(~) should be called whenever that happens.
+    ///   given time arrives.
+    ///
+    ///   \warning Sometimes a vehicle may need to pause after it has already
+    ///   departed one of its waypoints but before it reaches the next one. This
+    ///   will be conveyed by increasing the departure time of the last waypoint
+    ///   that it left. If the departure timing of the last waypoint that the
+    ///   robot departed from is increased to a value greater than the current
+    ///   clock time, then the robot is obligated to stop in place (wherever it
+    ///   happens to be) until the time is reached.
     ///
     /// \param[in] progress_updater
     ///   Use this callback to update the traffic light on how the robot has
     ///   progressed along the path.
     virtual void receive_path_timing(
         std::size_t version,
-        const std::vector<rclcpp::Time>& timing,
+        const std::vector<rclcpp::Time>& departure_timing,
         ProgressCallback progress_updater) = 0;
 
     /// This function will be called when deadlock has occurred due to an

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <vector>
 
+#include <rclcpp/time.hpp>
+
 #include <rmf_utils/impl_ptr.hpp>
 
 namespace rmf_fleet_adapter {
@@ -111,7 +113,7 @@ public:
     ///   wait at that point).
     virtual void receive_path_timing(
         std::size_t version,
-        const std::vector<rmf_traffic::Time>& timing,
+        const std::vector<rclcpp::Time>& timing,
         ArrivalEstimator arrival_estimator) = 0;
 
     /// This function will be called when deadlock has occurred due to an

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -55,22 +55,18 @@ public:
     ///
     /// \param[in] new_path
     ///   Submit a new path that the robot intends to follow.
-    std::size_t update_path(
-        const std::vector<Waypoint>& new_path);
+    std::size_t update_path(const std::vector<Waypoint>& new_path);
 
     /// Call this function if the robot has been delayed along its path.
     ///
-    /// \param[in] version
-    ///   The version number of the path that has been delayed. This must be
-    ///   equal to the return value provided by the update_path(~) function.
+    /// \note This should generally not be given a negative value, because you
+    /// are obligated to have the robot pause any time it is getting ahead of
+    /// its scheduled itinerary.
     ///
     /// \param[in] delay
-    ///   The severity of the delay. This should generally not be negative,
-    ///   because you are obligated to have the robot pause any time it is
-    ///   getting ahead of its scheduled itinerary.
-    void add_delay(
-        std::size_t version,
-        rmf_traffic::Duration delay);
+    ///   The severity of the delay.
+    ///
+    void add_delay(rmf_traffic::Duration delay);
 
     class Implementation;
   private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -18,10 +18,12 @@
 #ifndef RMF_FLEET_ADAPTER__AGV__TRAFFICLIGHT_HPP
 #define RMF_FLEET_ADAPTER__AGV__TRAFFICLIGHT_HPP
 
-#include <memory>
-#include <Eigen/Geometry>
+#include <rmf_fleet_adapter/agv/Waypoint.hpp>
 
-#include <rmf_traffic/Time.hpp>
+#include <memory>
+#include <vector>
+
+#include <rmf_utils/impl_ptr.hpp>
 
 namespace rmf_fleet_adapter {
 namespace agv {
@@ -36,29 +38,6 @@ public:
   class UpdateHandle
   {
   public:
-
-    struct Waypoint
-    {
-      /// The name of the reference map that the position is on.
-      std::string map_name;
-
-      /// A position along the robot's path where it will (or can) have zero
-      /// instantaneous velocity. This will usually be a point where the robot
-      /// needs to turn, or a point that comes before an intersection, so the
-      /// robot can come to a stop and allow other vehicles to pass.
-      Eigen::Vector3d position;
-
-      /// A delay that the robot is expected to experience once it arrives at
-      /// this waypoint. Usually this will be caused by the robots needing to
-      /// wait for doors to open or lifts to arrive.
-      rmf_traffic::Duration mandatory_delay = std::chrono::nanoseconds(0);
-
-      /// Whether or not the robot can wait at this point. If passthrough is
-      /// true, then the planner will assume that it cannot ask the robot to
-      /// wait here. If passthrough is false, the planner may request that the
-      /// robot wait here to avoid a conflict with other traffic participants.
-      bool passthrough = false;
-    };
 
     /// Update the traffic light with a new path for your robot.
     ///
@@ -92,6 +71,10 @@ public:
     void add_delay(
         std::size_t version,
         rmf_traffic::Duration delay);
+
+    class Implementation;
+  private:
+    rmf_utils::unique_impl_ptr<Implementation> _pimpl;
   };
 
   using UpdateHandlePtr = std::shared_ptr<UpdateHandle>;

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -120,6 +120,7 @@ public:
     /// level of control over the conflicting participants to resolve it.
     virtual void deadlock() = 0;
 
+    virtual ~CommandHandle() = default;
   };
 
   using CommandHandlePtr = std::shared_ptr<CommandHandle>;

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -77,13 +77,13 @@ public:
     /// progress of the vehicle.
     ///
     /// \param[in] path_index
-    ///   The index whose arrival estimate is being reported.
+    ///   The index of the path element that the robot is currently moving
+    ///   towards.
     ///
-    /// \param[in] remaining_time
-    ///   An estimate of how much longer the robot will take to arrive at
-    ///   `path_index`.
-    using ArrivalEstimator =
-        std::function<void(std::size_t path_index, Duration remaining_time)>;
+    /// \param[in] location
+    ///   The current (x, y, yaw) location of the robot.
+    using ProgressCallback =
+        std::function<void(std::size_t path_index, Eigen::Vector3d location)>;
 
     /// Receive the required timing for a path that has been submitted.
     ///
@@ -106,15 +106,13 @@ public:
     ///   given time arrives. The robot is allowed to arrive at a waypoint late,
     ///   but UpdateHandle::add_delay(~) should be called whenever that happens.
     ///
-    /// \param[in] arrival_estimator
-    ///   Use this callback to give estimates for how long the robot will take
-    ///   to reach the path element of the specified index (give how long until
-    ///   the robot will arrive, regardless of how long the robot is supposed to
-    ///   wait at that point).
+    /// \param[in] progress_updater
+    ///   Use this callback to update the traffic light on how the robot has
+    ///   progressed along the path.
     virtual void receive_path_timing(
         std::size_t version,
         const std::vector<rclcpp::Time>& timing,
-        ArrivalEstimator arrival_estimator) = 0;
+        ProgressCallback progress_updater) = 0;
 
     /// This function will be called when deadlock has occurred due to an
     /// unresolvable conflict. Human intervention may be required at this point,

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -103,6 +103,10 @@ public:
 
     /// Receive the required timing for a path that has been submitted.
     ///
+    /// This function may get called multiple times for the same path version,
+    /// because the timing information may need to change as the traffic
+    /// schedule gets updated and conflicts occur.
+    ///
     /// \param[in] version
     ///   The version number of the path whose timing is being provided. If this
     ///   version number does not match the latest path that you submitted, then

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_FLEET_ADAPTER__AGV__TRAFFICLIGHT_HPP
+#define RMF_FLEET_ADAPTER__AGV__TRAFFICLIGHT_HPP
+
+#include <memory>
+#include <Eigen/Geometry>
+
+#include <rmf_traffic/Time.hpp>
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+//==============================================================================
+class TrafficLight
+{
+public:
+
+  /// A class for updating a traffic light manager about the intentions and
+  /// state of its robot.
+  class UpdateHandle
+  {
+  public:
+
+    struct Waypoint
+    {
+      /// The name of the reference map that the position is on.
+      std::string map_name;
+
+      /// A position along the robot's path where it will (or can) have zero
+      /// instantaneous velocity. This will usually be a point where the robot
+      /// needs to turn, or a point that comes before an intersection, so the
+      /// robot can come to a stop and allow other vehicles to pass.
+      Eigen::Vector3d position;
+
+      /// A delay that the robot is expected to experience once it arrives at
+      /// this waypoint. Usually this will be caused by the robots needing to
+      /// wait for doors to open or lifts to arrive.
+      rmf_traffic::Duration mandatory_delay = std::chrono::nanoseconds(0);
+
+      /// Whether or not the robot can wait at this point. If passthrough is
+      /// true, then the planner will assume that it cannot ask the robot to
+      /// wait here. If passthrough is false, the planner may request that the
+      /// robot wait here to avoid a conflict with other traffic participants.
+      bool passthrough = false;
+    };
+
+    /// Update the traffic light with a new path for your robot.
+    ///
+    /// The traffic light manager is an async system, which means responses for
+    /// this update will come at a later time. Due to race conditions, it's
+    /// possible to get responses for old path updates that you no longer care
+    /// about because you are operating off of a new path now. Save the return
+    /// value of this function, and ignore all calls to
+    /// CommandHandle::receive_path_timing(~) whose version number is different
+    /// from the return value of your latest call to update_path(~).
+    ///
+    /// This function should be called any time the robot changes its path, and
+    /// it may also be a good idea to call it if significant delays or
+    /// interruptions have accumulated.
+    ///
+    /// \param[in] new_path
+    ///   Submit a new path that the robot intends to follow.
+    std::size_t update_path(
+        const std::vector<Waypoint>& new_path);
+
+    /// Call this function if the robot has been delayed along its path.
+    ///
+    /// \param[in] version
+    ///   The version number of the path that has been delayed. This must be
+    ///   equal to the return value provided by the update_path(~) function.
+    ///
+    /// \param[in] delay
+    ///   The severity of the delay. This should generally not be negative,
+    ///   because you are obligated to have the robot pause any time it is
+    ///   getting ahead of its scheduled itinerary.
+    void add_delay(
+        std::size_t version,
+        rmf_traffic::Duration delay);
+  };
+
+  using UpdateHandlePtr = std::shared_ptr<UpdateHandle>;
+
+  /// Implement this class to receive traffic light commands from RMF.
+  class CommandHandle
+  {
+  public:
+
+    /// Receive the required timing for a path that has been submitted.
+    ///
+    /// \param[in] version
+    ///   The version number of the path whose timing is being provided. If this
+    ///   version number does not match the latest path that you submitted, then
+    ///   simply ignore and discard the timing information.
+    ///
+    /// \param[in] timing
+    ///   This is a vector of the earliest times that the vehicle is allowed to
+    ///   leave a given waypoint. The entries of this vector have a 1:1 mapping
+    ///   with the entries of the path vector that was submitted earlier. Each
+    ///   entry represents the earliest time that a robot is allowed to move
+    ///   past its corresponding waypoint. If the robot arrives at the waypoint
+    ///   before the given time, then the robot is obligated to pause until the
+    ///   given time arrives. The robot is allowed to arrive at a waypoint late,
+    ///   but UpdateHandle::add_delay(~) should be called whenever that happens.
+    virtual void receive_path_timing(
+        std::size_t version,
+        const std::vector<rmf_traffic::Time>& timing);
+
+  };
+
+  using CommandHandlePtr = std::shared_ptr<CommandHandle>;
+
+};
+
+} // namespace agv
+} // namespace rmf_fleet_adapter
+
+#endif // RMF_FLEET_ADAPTER__AGV__TRAFFICLIGHT_HPP

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Waypoint.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/Waypoint.hpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_FLEET_ADAPTER__AGV__WAYPOINT_HPP
+#define RMF_FLEET_ADAPTER__AGV__WAYPOINT_HPP
+
+#include <rmf_traffic/Time.hpp>
+
+#include <rmf_utils/impl_ptr.hpp>
+
+#include <Eigen/Geometry>
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+//==============================================================================
+class Waypoint
+{
+public:
+
+  /// Constructor
+  ///
+  /// \param[in] map_name
+  ///   The name of the reference map that the position is on.
+  ///
+  /// \param[in] position
+  ///   A position along the robot's path where it will (or can) have zero
+  ///   instantaneous velocity. This will usually be a point where the robot
+  ///   needs to turn, or a point that comes before an intersection, so the
+  ///   robot can come to a stop and allow other vehicles to pass. This is a 2D
+  ///   heterogeneous vector. The first two elements refer to translational
+  ///   (x,y) position while the third element is a yaw value in radians.
+  ///
+  /// \param[in] mandatory_delay
+  ///   A delay that the robot is expected to experience once it arrives at
+  ///   this waypoint. Usually this will be caused by the robots needing to
+  ///   wait for doors to open or lifts to arrive.
+  ///
+  /// \param[in] yield
+  ///   Whether or not the robot can wait at this point. If yield is false, then
+  ///   the planner will assume that it cannot ask the robot to wait here. If
+  ///   yield is true, then the planner may request that the robot wait here to
+  ///   avoid conflicts with other traffic participants.
+  Waypoint(
+      std::string map_name,
+      Eigen::Vector3d position,
+      rmf_traffic::Duration mandatory_delay = std::chrono::nanoseconds(0),
+      bool yield = true);
+
+  /// Get the map of this Waypoint.
+  const std::string& map_name() const;
+
+  /// Set the map of this Waypoint.
+  Waypoint& map_name(std::string new_map_name);
+
+  /// Get the position of this Waypoint.
+  const Eigen::Vector3d& position() const;
+
+  /// Set the position of this Waypoint.
+  Waypoint& position(Eigen::Vector3d new_position);
+
+  /// Get the mandatory delay associated with this Waypoint.
+  rmf_traffic::Duration mandatory_delay() const;
+
+  /// Set the mandatory delay associated with this Waypoint.
+  Waypoint& mandatory_delay(rmf_traffic::Duration duration);
+
+  /// Get whether the robot can yield here.
+  bool yield() const;
+
+  /// Set whether the robot can yield here.
+  Waypoint& yield(bool on);
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+} // namespace agv
+} // namespace rmf_fleet_adapter
+
+#endif // RMF_FLEET_ADAPTER__AGV__WAYPOINT_HPP

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/test/MockAdapter.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/test/MockAdapter.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include <rmf_fleet_adapter/agv/FleetUpdateHandle.hpp>
+#include <rmf_fleet_adapter/agv/TrafficLight.hpp>
 
 #include <rclcpp/node.hpp>
 
@@ -48,6 +49,13 @@ public:
       const std::string& fleet_name,
       rmf_traffic::agv::VehicleTraits traits,
       rmf_traffic::agv::Graph navigation_graph);
+
+  TrafficLight::UpdateHandlePtr add_traffic_light(
+      std::shared_ptr<TrafficLight::CommandHandle> command,
+      const std::string& fleet_name,
+      const std::string& robot_name,
+      rmf_traffic::agv::VehicleTraits traits,
+      rmf_traffic::Profile profile);
 
   /// Get the rclcpp Node for this adapter
   std::shared_ptr<rclcpp::Node> node();

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_fleet_adapter</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>Fleet Adapter package for RMF fleets.</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <maintainer email="aaron@openrobotics.org">Aaron</maintainer>

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -175,9 +175,15 @@ public:
     const auto stop_time =
         std::chrono::steady_clock::now() + *discovery_timeout;
 
-    while (rclcpp::ok() && std::chrono::steady_clock::now() < stop_time)
+    rclcpp::executor::ExecutorArgs args;
+    args.context = node_options.context();
+    rclcpp::executors::SingleThreadedExecutor executor(args);
+    executor.add_node(node);
+
+    while (rclcpp::ok(node_options.context())
+           && std::chrono::steady_clock::now() < stop_time)
     {
-      rclcpp::spin_some(node);
+      executor.spin_some();
 
       bool ready = true;
       ready &= writer->ready();

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -287,9 +287,10 @@ void Adapter::add_traffic_light(
 
   _pimpl->writer->async_make_participant(
       std::move(description),
-      [worker = _pimpl->worker,
-       command = std::move(command),
+      [command = std::move(command),
        traits = std::move(traits),
+       schedule = _pimpl->mirror_manager.snapshot_handle(),
+       worker = _pimpl->worker,
        handle_cb = std::move(handle_cb),
        negotiation = _pimpl->negotiation,
        node = _pimpl->node](
@@ -304,7 +305,9 @@ void Adapter::add_traffic_light(
           std::move(command),
           std::move(participant),
           std::move(traits),
+          std::move(schedule),
           worker,
+          node,
           *negotiation);
 
     worker.schedule(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp
@@ -308,13 +308,13 @@ void Adapter::add_traffic_light(
           std::move(schedule),
           worker,
           node,
-          *negotiation);
+          negotiation.get());
 
     worker.schedule(
           [handle_cb = std::move(handle_cb),
            update_handle = std::move(update_handle)](const auto&)
     {
-      handle_cb(update_handle);
+      handle_cb(std::move(update_handle));
     });
   });
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
@@ -875,7 +875,7 @@ TrafficLight::UpdateHandle::Implementation::make(
     std::shared_ptr<rmf_traffic::schedule::Snappable> schedule,
     rxcpp::schedulers::worker worker,
     std::shared_ptr<rclcpp::Node> node,
-    rmf_traffic_ros2::schedule::Negotiation& negotiation)
+    rmf_traffic_ros2::schedule::Negotiation* negotiation)
 {
   std::shared_ptr<UpdateHandle> handle = std::make_shared<UpdateHandle>();
   handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
@@ -886,9 +886,12 @@ TrafficLight::UpdateHandle::Implementation::make(
         std::move(worker),
         std::move(node));
 
-  handle->_pimpl->negotiation_license = negotiation.register_negotiator(
-        handle->_pimpl->data->itinerary.id(),
-        std::make_unique<Negotiator>(handle->_pimpl->data));
+  if (negotiation)
+  {
+    handle->_pimpl->negotiation_license = negotiation->register_negotiator(
+          handle->_pimpl->data->itinerary.id(),
+          std::make_unique<Negotiator>(handle->_pimpl->data));
+  }
 
   return handle;
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "internal_TrafficLight.hpp"
+
+#include <rmf_utils/Modular.hpp>
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+//==============================================================================
+void TrafficLight::UpdateHandle::Implementation::Negotiator::respond(
+    const TableViewerPtr& table_viewer,
+    const ResponderPtr& responder)
+{
+  const auto data = _data.lock();
+  if (!data || !data->planner || !data->plan)
+  {
+    // If we no longer have access to the traffic light data or there is no
+    // plan being followed, then we simply forfeit the negotiation.
+    return responder->forfeit({});
+  }
+
+  // FIXME TODO(MXG): Reply to the negotiation here.
+  assert(false);
+}
+
+//==============================================================================
+void TrafficLight::UpdateHandle::Implementation::Data::update_path(
+    const std::size_t version,
+    const std::vector<Waypoint>& new_path)
+{
+  if (rmf_utils::modular(version).less_than(processing_version))
+    return;
+
+  assert(version != processing_version);
+
+  rmf_traffic::agv::Graph graph;
+  for (const auto wp : new_path)
+  {
+    graph.add_waypoint(wp.map_name(), wp.position().block<2,1>(0,0))
+        .set_passthrough_point(!wp.yield())
+        .set_holding_point(wp.yield());
+  }
+
+//  rmf_traffic::agv::Plan::Configuration config(
+//        )
+}
+
+//==============================================================================
+std::size_t TrafficLight::UpdateHandle::update_path(
+    const std::vector<Waypoint>& new_path)
+{
+  const std::size_t version = ++_pimpl->received_version;
+  _pimpl->data->worker.schedule(
+        [version, new_path, data = _pimpl->data](const auto&)
+  {
+    data->update_path(version, new_path);
+  });
+
+  return version;
+}
+
+} // namespace agv
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
@@ -17,10 +17,435 @@
 
 #include "internal_TrafficLight.hpp"
 
+#include "../services/FindPath.hpp"
+
 #include <rmf_utils/Modular.hpp>
+
+#include <rmf_traffic_ros2/Time.hpp>
+
+#include <rmf_traffic/Motion.hpp>
 
 namespace rmf_fleet_adapter {
 namespace agv {
+
+//==============================================================================
+class TrafficLight::UpdateHandle::Implementation::Data
+    : std::enable_shared_from_this<Data>
+{
+public:
+
+  std::shared_ptr<CommandHandle> command;
+
+  rmf_traffic::schedule::Participant itinerary;
+
+  rmf_traffic::agv::VehicleTraits traits;
+
+  std::shared_ptr<rmf_traffic::schedule::Snappable> schedule;
+
+  rxcpp::schedulers::worker worker;
+
+  std::shared_ptr<rclcpp::Node> node;
+
+  std::size_t current_version = 0;
+
+  std::shared_ptr<rmf_traffic::Profile> profile;
+
+  std::vector<Waypoint> path;
+
+  rmf_utils::optional<rmf_traffic::agv::Plan> plan;
+
+  std::shared_ptr<rmf_traffic::agv::Planner> planner;
+
+  std::vector<rmf_traffic::Time> arrival_timing;
+  std::vector<rclcpp::Time> departure_timing;
+
+  std::size_t processing_version = 0;
+
+  std::shared_ptr<services::FindPath> find_path_service;
+  rxcpp::subscription find_path_subscription;
+
+  void update_path(
+      std::size_t version,
+      const std::vector<Waypoint>& new_path);
+
+  void update_timing(
+      std::size_t version,
+      std::vector<Waypoint> path_,
+      rmf_traffic::agv::Plan plan_,
+      std::shared_ptr<rmf_traffic::agv::Planner> planner_);
+
+  Data(
+      std::shared_ptr<CommandHandle> command_,
+      rmf_traffic::schedule::Participant itinerary_,
+      rmf_traffic::agv::VehicleTraits traits_,
+      std::shared_ptr<rmf_traffic::schedule::Snappable> schedule_,
+      rxcpp::schedulers::worker worker_,
+      std::shared_ptr<rclcpp::Node> node_)
+    : command(std::move(command_)),
+      itinerary(std::move(itinerary_)),
+      traits(std::move(traits_)),
+      schedule(std::move(schedule_)),
+      worker(std::move(worker_)),
+      node(std::move(node_)),
+      profile(std::make_shared<rmf_traffic::Profile>(
+                itinerary.description().profile()))
+  {
+    // Do nothing
+  }
+};
+
+//==============================================================================
+void TrafficLight::UpdateHandle::Implementation::Data::update_path(
+    const std::size_t version,
+    const std::vector<Waypoint>& new_path)
+{
+  if (rmf_utils::modular(version).less_than(processing_version))
+    return;
+
+  assert(version != processing_version);
+  processing_version = version;
+
+  const bool clear_itinerary = new_path.empty()
+      || (new_path.size() == 1
+          && new_path.front().mandatory_delay() <= std::chrono::nanoseconds(0));
+
+  const auto now = rmf_traffic_ros2::convert(node->now());
+
+  if (clear_itinerary)
+  {
+    // Clear out this robot's itinerary because it is done moving
+    RCLCPP_INFO(
+      node->get_logger(),
+      "Traffic light controlled robot [%s] owned by [%s] is being taken off "
+      "the schedule after being given a null path.",
+      itinerary.description().name().c_str(),
+      itinerary.description().owner().c_str());
+
+    plan = rmf_utils::nullopt;
+    planner = nullptr;
+    path.clear();
+    departure_timing.clear();
+    itinerary.clear();
+    return;
+  }
+  else if (new_path.size() == 1)
+  {
+    // Have the robot sit in place if it was given a single-point trajectory
+    // with a mandatory delay
+    plan = rmf_utils::nullopt;
+    planner = nullptr;
+
+    rmf_traffic::Trajectory sit;
+    sit.insert(
+      now,
+      new_path.front().position(),
+      Eigen::Vector3d::Zero());
+
+    sit.insert(
+      now + new_path.front().mandatory_delay(),
+      new_path.front().position(),
+      Eigen::Vector3d::Zero());
+
+    itinerary.set({{new_path.front().map_name(), sit}});
+  }
+
+  rmf_traffic::agv::Graph graph;
+  for (std::size_t i=0; i < new_path.size(); ++i)
+  {
+    const auto& wp = new_path[i];
+    graph.add_waypoint(wp.map_name(), wp.position().block<2,1>(0,0))
+        .set_passthrough_point(!wp.yield())
+        .set_holding_point(wp.yield());
+
+    if (i > 0)
+    {
+      const auto& last_wp = new_path[i-1];
+      rmf_traffic::agv::Graph::Lane::EventPtr event = nullptr;
+      if (last_wp.mandatory_delay() > std::chrono::nanoseconds(0))
+      {
+        // We use DoorOpen for lack of a better placeholder
+        event = rmf_traffic::agv::Graph::Lane::Event::make(
+              rmf_traffic::agv::Graph::Lane::DoorOpen(
+                "", last_wp.mandatory_delay()));
+      }
+
+      graph.add_lane(rmf_traffic::agv::Graph::Lane::Node(i-1, event), i);
+    }
+  }
+
+  auto new_planner = std::make_shared<rmf_traffic::agv::Planner>(
+        rmf_traffic::agv::Plan::Configuration(graph, traits),
+        rmf_traffic::agv::Plan::Options(nullptr));
+
+  rmf_traffic::agv::Plan::Start start{now, 0, new_path.front().position()[2]};
+
+  find_path_service = std::make_shared<services::FindPath>(
+    new_planner, rmf_traffic::agv::Plan::StartSet({std::move(start)}),
+    graph.num_waypoints()-1, schedule->snapshot(), itinerary.id(), profile);
+
+  find_path_subscription = rmf_rxcpp::make_job<services::FindPath::Result>(
+        find_path_service)
+      .observe_on(rxcpp::identity_same_worker(worker))
+      .subscribe(
+        [w = weak_from_this(), version, new_path, new_planner](
+        const services::FindPath::Result& result)
+  {
+    const auto data = w.lock();
+    if (!data)
+      return;
+
+    if (version != data->processing_version)
+    {
+      // This means the path that triggered this service is deprecated.
+      return;
+    }
+
+    if (!result)
+    {
+      RCLCPP_ERROR(
+        data->node->get_logger(),
+        "Failed to find any itinerary for submitted path #%d of robot [%s] "
+        "owned by [%s]. This is a critical bug and should be reported to the "
+        "rmf_core developers.",
+        version,
+        data->itinerary.description().name().c_str(),
+        data->itinerary.description().owner().c_str());
+
+      return;
+    }
+
+    data->current_version = version;
+
+    data->update_timing(
+      version,
+      std::move(new_path),
+      std::move(*result),
+      std::move(new_planner));
+  });
+}
+
+namespace {
+
+//==============================================================================
+rmf_utils::optional<rmf_traffic::Time> linear_interpolate_time(
+    const rmf_traffic::Trajectory::Waypoint& wp0,
+    const rmf_traffic::Trajectory::Waypoint& wp1,
+    const Eigen::Vector2d& p)
+{
+  const Eigen::Vector2d p0 = wp0.position().block<2,1>(0,0);
+  const Eigen::Vector2d p1 = wp1.position().block<2,1>(0,0);
+  if ((p1 - p0).dot(p - p0) < 0)
+    return rmf_utils::nullopt;
+
+  if ((p1 - p0).dot(p1 - p) < 0)
+    return rmf_utils::nullopt;
+
+  const double v = wp0.velocity().block<2,1>(0,0).norm();
+  assert(std::abs(v - wp1.velocity().block<2,1>(0,0).norm()) < 1e-2);
+
+  const double r = (p - p0).norm();
+  const double s = r/v;
+
+  assert(s <= rmf_traffic::time::to_seconds(wp1.time() - wp0.time()));
+  return wp0.time() + rmf_traffic::time::from_seconds(s);
+}
+
+//==============================================================================
+rmf_utils::optional<rmf_traffic::Time> parabolic_interpolate_time(
+    const rmf_traffic::Trajectory::Waypoint& wp0,
+    const rmf_traffic::Trajectory::Waypoint& wp1,
+    const Eigen::Vector2d& p)
+{
+  const Eigen::Vector2d p0 = wp0.position().block<2,1>(0,0);
+  const Eigen::Vector2d p1 = wp1.position().block<2,1>(0,0);
+  if ((p1 - p0).dot(p - p0) < 0)
+    return rmf_utils::nullopt;
+
+  if ((p1 - p0).dot(p1 - p) < 0)
+    return rmf_utils::nullopt;
+
+  const double r = (p - p0).norm();
+  const double v0 = wp0.velocity().block<2,1>(0,0).norm();
+  const double v1 = wp1.velocity().block<2,1>(0,0).norm();
+  const double dt = rmf_traffic::time::to_seconds(wp1.time() - wp0.time());
+  const double a = (v1 - v0)/dt;
+
+  const double D = v0*v0 + 2*a*r;
+
+  const double t_minus = (-v0 - std::sqrt(D))/a;
+  if (0 <= t_minus && t_minus <= dt)
+    return wp0.time() + rmf_traffic::time::from_seconds(t_minus);
+
+  const double t_plus = (-v0 + std::sqrt(D))/a;
+  if (0 <= t_plus && t_plus <= dt)
+    return wp0.time() + rmf_traffic::time::from_seconds(t_plus);
+
+  assert(false);
+  return rmf_utils::nullopt;
+}
+
+//==============================================================================
+rmf_traffic::Time interpolate_time(
+  const rmf_traffic::agv::VehicleTraits& traits,
+  const rmf_traffic::agv::Plan::Waypoint& wp0,
+  const rmf_traffic::agv::Plan::Waypoint& wp1,
+  const Eigen::Vector2d& p)
+{
+  const auto interp = rmf_traffic::agv::Interpolate::positions(
+        traits, wp0.time(), {wp0.position(), wp1.position()});
+
+  // The interpolation will either be two parabolas or it will be two parabolas
+  // with a linear component in the middle.
+  assert(interp.size() == 3 || interp.size() == 4);
+  const double r = (p - wp0.position().block<2,1>(0,0)).norm();
+  if (r < 1e-3)
+    return wp0.time();
+
+  const auto end = interp.end();
+  if (interp.size() == 3)
+  {
+    for (auto it = ++interp.begin(); it != end; ++it)
+    {
+      const auto last = --rmf_traffic::Trajectory::const_iterator(it);
+      if (const auto t = parabolic_interpolate_time(*last, *it, p))
+        return *t;
+    }
+  }
+  else if(interp.size() == 4)
+  {
+    std::size_t count = 0;
+    for (auto it = ++interp.begin(); it != end; ++it, ++count)
+    {
+      const auto last = --rmf_traffic::Trajectory::const_iterator(it);
+      if (count == 0 || count == 2)
+      {
+        if (const auto t = parabolic_interpolate_time(*last, *it, p))
+          return *t;
+      }
+      else
+      {
+        if (const auto t = linear_interpolate_time(*last, *it, p))
+          return *t;
+      }
+    }
+  }
+
+  assert(false);
+  throw std::runtime_error(
+    "[rmf_fleet_adapter::agv::TrafficLight] Failed to interpolate an "
+    "intermediary waypoint.");
+}
+} // anonymous namespace
+
+//==============================================================================
+void TrafficLight::UpdateHandle::Implementation::Data::update_timing(
+    const std::size_t version,
+    std::vector<Waypoint> path_,
+    rmf_traffic::agv::Plan plan_,
+    std::shared_ptr<rmf_traffic::agv::Planner> planner_)
+{
+  if (version != current_version)
+    return;
+
+  path = std::move(path_);
+  plan = std::move(plan_);
+  planner = std::move(planner_);
+
+  assert(!path.empty());
+
+  rclcpp::Time last_t =
+      rmf_traffic_ros2::convert(plan->get_waypoints().front().time());
+
+  const auto& waypoints = plan->get_waypoints();
+  const auto& graph = planner->get_configuration().graph();
+
+  arrival_timing.resize(path.size(), rmf_traffic_ros2::convert(last_t));
+  departure_timing.resize(path.size(), last_t);
+
+  std::size_t current_wp = 0;
+
+  for (std::size_t i=0; i < waypoints.size(); ++i)
+  {
+    const auto& wp = waypoints[i];
+
+    assert(wp.graph_index());
+    if (*wp.graph_index() != current_wp)
+    {
+      const std::size_t next_wp = *wp.graph_index();
+      for (std::size_t k=current_wp+1; k < next_wp; ++k)
+      {
+        // For any intermediate waypoints that will be passed over without
+        // stopping, we should try to calculate the time that the robot is
+        // expected to pass over it.
+        const auto p = graph.get_waypoint(k).get_location();
+        const auto t = interpolate_time(traits, waypoints[i-1], wp, p);
+        arrival_timing[k] = t;
+        departure_timing[k] = rmf_traffic_ros2::convert(t);
+      }
+
+      current_wp = *wp.graph_index();
+      arrival_timing[current_wp] = wp.time();
+    }
+
+    // This might get overriden several times since a single path waypoint might
+    // show up several times in a plan. We want to use the last time that is
+    // associated with this path waypoint.
+    departure_timing[current_wp] = rmf_traffic_ros2::convert(wp.time());
+  }
+
+  command->receive_path_timing(
+    current_version, departure_timing,
+    [w = weak_from_this(), current_version = current_version](
+        const std::size_t path_index, rmf_traffic::Duration remaining_time)
+  {
+    const auto data = w.lock();
+    if (!data)
+      return;
+
+    const rmf_traffic::Time estimated_time =
+        rmf_traffic_ros2::convert(data->node->now() + remaining_time);
+
+    data->worker.schedule(
+          [w = std::weak_ptr<Data>(data),
+           current_version,
+           path_index,
+           estimated_time](const auto&)
+    {
+      const auto data = w.lock();
+      if (!data)
+        return;
+
+      if (current_version != data->current_version)
+        return;
+
+      assert(path_index < data->arrival_timing.size());
+
+      const auto new_delay = estimated_time - data->arrival_timing[path_index];
+      const auto time_shift = new_delay - data->itinerary.delay();
+      if (time_shift > std::chrono::seconds(5))
+        data->itinerary.delay(time_shift);
+    });
+  });
+}
+
+class TrafficLight::UpdateHandle::Implementation::Negotiator
+    : public rmf_traffic::schedule::Negotiator
+{
+public:
+
+  Negotiator(std::shared_ptr<Data> data)
+    : _data(std::move(data))
+  {
+    // Do nothing
+  }
+
+  void respond(
+      const TableViewerPtr& table_viewer,
+      const ResponderPtr& responder) final;
+
+private:
+  std::weak_ptr<Data> _data;
+};
 
 //==============================================================================
 void TrafficLight::UpdateHandle::Implementation::Negotiator::respond(
@@ -39,26 +464,50 @@ void TrafficLight::UpdateHandle::Implementation::Negotiator::respond(
   assert(false);
 }
 
-//==============================================================================
-void TrafficLight::UpdateHandle::Implementation::Data::update_path(
-    const std::size_t version,
-    const std::vector<Waypoint>& new_path)
+//==============================================================================s
+TrafficLight::UpdateHandle::Implementation::Implementation(
+    std::shared_ptr<CommandHandle> command_,
+    rmf_traffic::schedule::Participant itinerary_,
+    rmf_traffic::agv::VehicleTraits traits_,
+    std::shared_ptr<rmf_traffic::schedule::Snappable> schedule_,
+    rxcpp::schedulers::worker worker_,
+    std::shared_ptr<rclcpp::Node> node_)
+  : data(std::make_shared<Data>(
+           std::move(command_),
+           std::move(itinerary_),
+           std::move(traits_),
+           std::move(schedule_),
+           std::move(worker_),
+           std::move(node_)))
 {
-  if (rmf_utils::modular(version).less_than(processing_version))
-    return;
+  // Do nothing
+}
 
-  assert(version != processing_version);
+//==============================================================================
+std::shared_ptr<TrafficLight::UpdateHandle>
+TrafficLight::UpdateHandle::Implementation::make(
+    std::shared_ptr<CommandHandle> command,
+    rmf_traffic::schedule::Participant itinerary,
+    rmf_traffic::agv::VehicleTraits traits,
+    std::shared_ptr<rmf_traffic::schedule::Snappable> schedule,
+    rxcpp::schedulers::worker worker,
+    std::shared_ptr<rclcpp::Node> node,
+    rmf_traffic_ros2::schedule::Negotiation& negotiation)
+{
+  std::shared_ptr<UpdateHandle> handle = std::make_shared<UpdateHandle>();
+  handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
+        std::move(command),
+        std::move(itinerary),
+        std::move(traits),
+        std::move(schedule),
+        std::move(worker),
+        std::move(node));
 
-  rmf_traffic::agv::Graph graph;
-  for (const auto wp : new_path)
-  {
-    graph.add_waypoint(wp.map_name(), wp.position().block<2,1>(0,0))
-        .set_passthrough_point(!wp.yield())
-        .set_holding_point(wp.yield());
-  }
+  handle->_pimpl->negotiation_license = negotiation.register_negotiator(
+        handle->_pimpl->data->itinerary.id(),
+        std::make_unique<Negotiator>(handle->_pimpl->data));
 
-//  rmf_traffic::agv::Plan::Configuration config(
-//        )
+  return handle;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Waypoint.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Waypoint.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rmf_fleet_adapter/agv/Waypoint.hpp>
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+//==============================================================================
+class Waypoint::Implementation
+{
+public:
+
+  std::string map_name;
+  Eigen::Vector3d position;
+  rmf_traffic::Duration mandatory_delay;
+  bool yield;
+
+};
+
+//==============================================================================
+Waypoint::Waypoint(
+    std::string map_name,
+    Eigen::Vector3d position,
+    rmf_traffic::Duration mandatory_delay,
+    bool yield)
+  : _pimpl(rmf_utils::make_impl<Implementation>(
+             Implementation{
+               std::move(map_name),
+               std::move(position),
+               mandatory_delay,
+               yield
+             }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+const std::string& Waypoint::map_name() const
+{
+  return _pimpl->map_name;
+}
+
+//==============================================================================
+Waypoint& Waypoint::map_name(std::string new_map_name)
+{
+  _pimpl->map_name = std::move(new_map_name);
+  return *this;
+}
+
+//==============================================================================
+const Eigen::Vector3d& Waypoint::position() const
+{
+  return _pimpl->position;
+}
+
+//==============================================================================
+Waypoint& Waypoint::position(Eigen::Vector3d new_position)
+{
+  _pimpl->position = new_position;
+  return *this;
+}
+
+//==============================================================================
+rmf_traffic::Duration Waypoint::mandatory_delay() const
+{
+  return _pimpl->mandatory_delay;
+}
+
+//==============================================================================
+Waypoint& Waypoint::mandatory_delay(rmf_traffic::Duration duration)
+{
+  _pimpl->mandatory_delay = duration;
+  return *this;
+}
+
+//==============================================================================
+bool Waypoint::yield() const
+{
+  return _pimpl->yield;
+}
+
+//==============================================================================
+Waypoint& Waypoint::yield(bool on)
+{
+  _pimpl->yield = on;
+  return *this;
+}
+
+} // namespace agv
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_TrafficLight.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_TrafficLight.hpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__AGV__INTERNAL_TRAFFICLIGHT_HPP
+#define SRC__RMF_FLEET_ADAPTER__AGV__INTERNAL_TRAFFICLIGHT_HPP
+
+#include <rmf_fleet_adapter/agv/TrafficLight.hpp>
+
+#include <rmf_traffic/agv/Planner.hpp>
+
+#include <rmf_traffic/schedule/Negotiator.hpp>
+#include <rmf_traffic/schedule/Participant.hpp>
+
+#include <rmf_traffic_ros2/schedule/Negotiation.hpp>
+
+#include <rxcpp/rx.hpp>
+
+namespace rmf_fleet_adapter {
+namespace agv {
+
+//==============================================================================
+class TrafficLight::UpdateHandle::Implementation
+{
+public:
+
+  class Data
+  {
+  public:
+
+    std::shared_ptr<CommandHandle> command;
+
+    rmf_traffic::schedule::Participant itinerary;
+
+    rmf_traffic::agv::VehicleTraits traits;
+
+    rxcpp::schedulers::worker worker;
+
+    std::size_t current_version = 0;
+
+    std::vector<Waypoint> path;
+
+    rmf_utils::optional<rmf_traffic::agv::Plan> plan;
+
+    rmf_utils::optional<rmf_traffic::agv::Planner> planner;
+
+    std::size_t processing_version = 0;
+
+    void update_path(
+        std::size_t version,
+        const std::vector<Waypoint>& new_path);
+
+    Data(
+        std::shared_ptr<CommandHandle> command_,
+        rmf_traffic::schedule::Participant itinerary_,
+        rmf_traffic::agv::VehicleTraits traits_,
+        rxcpp::schedulers::worker worker_)
+      : command(std::move(command_)),
+        itinerary(std::move(itinerary_)),
+        traits(std::move(traits_)),
+        worker(std::move(worker_))
+    {
+      // Do nothing
+    }
+  };
+
+  class Negotiator : public rmf_traffic::schedule::Negotiator
+  {
+  public:
+
+    Negotiator(std::shared_ptr<Data> data)
+      : _data(std::move(data))
+    {
+      // Do nothing
+    }
+
+    void respond(
+        const TableViewerPtr& table_viewer,
+        const ResponderPtr& responder) final;
+
+  private:
+    std::weak_ptr<Data> _data;
+  };
+
+  std::size_t received_version = 0;
+
+  std::shared_ptr<Data> data;
+
+  std::shared_ptr<void> negotiation_license;
+
+  Implementation(
+      std::shared_ptr<CommandHandle> command_,
+      rmf_traffic::schedule::Participant itinerary_,
+      rmf_traffic::agv::VehicleTraits traits_,
+      rxcpp::schedulers::worker worker_)
+    : data(std::make_shared<Data>(
+             std::move(command_),
+             std::move(itinerary_),
+             std::move(traits_),
+             std::move(worker_)))
+  {
+    // Do nothing
+  }
+
+  static std::shared_ptr<UpdateHandle> make(
+      std::shared_ptr<CommandHandle> command,
+      rmf_traffic::schedule::Participant itinerary,
+      rmf_traffic::agv::VehicleTraits traits,
+      rxcpp::schedulers::worker worker,
+      rmf_traffic_ros2::schedule::Negotiation& negotiation)
+  {
+    std::shared_ptr<UpdateHandle> handle = std::make_shared<UpdateHandle>();
+    handle->_pimpl = rmf_utils::make_unique_impl<Implementation>(
+          std::move(command),
+          std::move(itinerary),
+          std::move(traits),
+          std::move(worker));
+
+    handle->_pimpl->negotiation_license = negotiation.register_negotiator(
+          handle->_pimpl->data->itinerary.id(),
+          std::make_unique<Negotiator>(handle->_pimpl->data));
+
+    return handle;
+  }
+
+};
+
+} // namespace agv
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__AGV__INTERNAL_TRAFFICLIGHT_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_TrafficLight.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_TrafficLight.hpp
@@ -61,7 +61,7 @@ public:
       std::shared_ptr<rmf_traffic::schedule::Snappable> schedule,
       rxcpp::schedulers::worker worker,
       std::shared_ptr<rclcpp::Node> node,
-      rmf_traffic_ros2::schedule::Negotiation& negotiation);
+      rmf_traffic_ros2::schedule::Negotiation* negotiation);
 
 };
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/test/MockAdapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/test/MockAdapter.cpp
@@ -18,6 +18,7 @@
 #include <rmf_fleet_adapter/agv/test/MockAdapter.hpp>
 
 #include "../internal_FleetUpdateHandle.hpp"
+#include "../internal_TrafficLight.hpp"
 
 #include <rmf_traffic/schedule/Database.hpp>
 
@@ -75,6 +76,33 @@ std::shared_ptr<FleetUpdateHandle> MockAdapter::add_fleet(
 
   _pimpl->fleets.push_back(fleet);
   return fleet;
+}
+
+//==============================================================================
+TrafficLight::UpdateHandlePtr MockAdapter::add_traffic_light(
+    std::shared_ptr<TrafficLight::CommandHandle> command,
+    const std::string& fleet_name,
+    const std::string& robot_name,
+    rmf_traffic::agv::VehicleTraits traits,
+    rmf_traffic::Profile profile)
+{
+  rmf_traffic::schedule::ParticipantDescription description(
+      robot_name,
+      fleet_name,
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile);
+
+  auto participant = rmf_traffic::schedule::make_participant(
+        std::move(description), _pimpl->database, nullptr);
+
+  return TrafficLight::UpdateHandle::Implementation::make(
+        std::move(command),
+        std::move(participant),
+        std::move(traits),
+        _pimpl->database,
+        _pimpl->worker,
+        _pimpl->node,
+        nullptr);
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/test/MockAdapter.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/test/MockAdapter.cpp
@@ -26,6 +26,7 @@ namespace rmf_fleet_adapter {
 namespace agv {
 namespace test {
 
+//==============================================================================
 class MockAdapter::Implementation
 {
 public:
@@ -41,7 +42,7 @@ public:
       node{Node::make(worker, node_name, node_options)},
       database{std::make_shared<rmf_traffic::schedule::Database>()}
   {
-
+    // Do nothing
   }
 
   std::vector<std::shared_ptr<FleetUpdateHandle>> fleets = {};

--- a/rmf_fleet_adapter/test/adapters/test_TrafficLight.cpp
+++ b/rmf_fleet_adapter/test/adapters/test_TrafficLight.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "../mock/MockTrafficLightCommand.hpp"
+
+#include <rmf_fleet_adapter/agv/test/MockAdapter.hpp>
+
+#include <rmf_traffic/geometry/Circle.hpp>
+#include <rmf_traffic/Profile.hpp>
+#include <rmf_traffic/agv/VehicleTraits.hpp>
+
+#include <rclcpp/context.hpp>
+
+#include <rmf_utils/catch.hpp>
+
+#include "../thread_cooldown.hpp"
+
+//==============================================================================
+std::vector<rmf_fleet_adapter::agv::Waypoint> make_path(
+    const rmf_traffic::agv::Graph& graph,
+    const std::vector<std::size_t>& wp_indices,
+    const double orientation)
+{
+  std::vector<rmf_fleet_adapter::agv::Waypoint> path;
+  for (auto index : wp_indices)
+  {
+    const auto& wp = graph.get_waypoint(index);
+    Eigen::Vector3d p;
+    p[2] = orientation;
+    p.block<2,1>(0,0) = wp.get_location();
+    path.emplace_back(wp.get_map_name(), p);
+  }
+
+  return path;
+}
+
+//==============================================================================
+SCENARIO("Test timing")
+{
+  rmf_fleet_adapter_test::thread_cooldown = true;
+  using namespace std::chrono_literals;
+
+  const std::string test_map_name = "test_map";
+  rmf_traffic::agv::Graph graph;
+  graph.add_waypoint(test_map_name, {0.0, -10.0}); // 0
+  graph.add_waypoint(test_map_name, {0.0, -5.0});  // 1
+  graph.add_waypoint(test_map_name, {5.0, -5.0}).set_holding_point(true);  // 2
+  graph.add_waypoint(test_map_name, {-10.0, 0.0}); // 3
+  graph.add_waypoint(test_map_name, {-5.0, 0.0}); // 4
+  graph.add_waypoint(test_map_name, {0.0, 0.0}); // 5
+  graph.add_waypoint(test_map_name, {5.0, 0.0}); // 6
+  graph.add_waypoint(test_map_name, {10.0, 0.0}); // 7
+  graph.add_waypoint(test_map_name, {0.0, 5.0}); // 8
+  graph.add_waypoint(test_map_name, {5.0, 5.0}).set_holding_point(true); // 9
+  graph.add_waypoint(test_map_name, {0.0, 10.0}); // 10
+
+  /*
+   *                   10
+   *                   |
+   *                   |
+   *                   8------9
+   *                   |      |
+   *                   |      |
+   *     3------4------5------6------7
+   *                   |      |
+   *                   |      |
+   *                   1------2
+   *                   |
+   *                   |
+   *                   0
+   **/
+
+  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
+    {
+      graph.add_lane(w0, w1);
+      graph.add_lane(w1, w0);
+    };
+
+  add_bidir_lane(0, 1);  // 0   1
+  add_bidir_lane(1, 2);  // 2   3
+  add_bidir_lane(1, 5);  // 4   5
+  add_bidir_lane(2, 6);  // 6   7
+  add_bidir_lane(3, 4);  // 8   9
+  add_bidir_lane(4, 5);  // 10 11
+  add_bidir_lane(5, 6);  // 12 13
+  add_bidir_lane(6, 7);  // 14 15
+  add_bidir_lane(5, 8);  // 16 17
+  add_bidir_lane(6, 9);  // 18 19
+  add_bidir_lane(8, 9);  // 20 21
+  add_bidir_lane(8, 10); // 22 23
+
+  rmf_traffic::Profile profile{
+    rmf_traffic::geometry::make_final_convex<
+      rmf_traffic::geometry::Circle>(1.0)
+  };
+
+  const rmf_traffic::agv::VehicleTraits traits{
+    {0.7, 0.3},
+    {1.0, 0.45},
+    profile
+  };
+
+  auto rcl_context = std::make_shared<rclcpp::Context>();
+  rcl_context->init(0, nullptr);
+  rmf_fleet_adapter::agv::test::MockAdapter adapter(
+        "test_TrafficLight", rclcpp::NodeOptions().context(rcl_context));
+
+  auto command_0 =
+      std::make_shared<rmf_fleet_adapter_test::MockTrafficLightCommand>();
+  auto update_0 = adapter.add_traffic_light(
+        command_0, "fleet_0", "robot_0", traits, profile);
+
+  auto command_1 =
+      std::make_shared<rmf_fleet_adapter_test::MockTrafficLightCommand>();
+  auto update_1 = adapter.add_traffic_light(
+        command_1, "fleet_1", "robot_1", traits, profile);
+
+  adapter.start();
+
+  WHEN("Crossing paths")
+  {
+    const auto now = adapter.node()->now();
+
+    const auto path_0 = make_path(graph, {0, 1, 5, 8, 10}, M_PI/2.0);
+    update_0->update_path(path_0);
+    std::unique_lock<std::mutex> lock_0(command_0->mutex);
+    command_0->cv.wait_for(
+          lock_0, 100ms,
+          [command_0](){ return command_0->current_version.has_value(); });
+    REQUIRE(command_0->current_version.has_value());
+    CHECK(path_0.size() == command_0->current_timing.size());
+
+    const auto path_1 = make_path(graph, {3, 4, 5, 6, 7}, 0.0);
+    update_1->update_path(path_1);
+    std::unique_lock<std::mutex> lock_1(command_1->mutex);
+    command_1->cv.wait_for(
+          lock_1, 100ms,
+          [command_1](){ return command_1->current_version.has_value(); });
+    REQUIRE(command_1->current_version.has_value());
+    CHECK(path_1.size() == command_1->current_timing.size());
+
+    REQUIRE(command_0->current_timing.size()
+            == command_1->current_timing.size());
+
+    // They would normally collide at index==2, so from index==2 onwards,
+    // the path of command_1 must be lagging behind the path of command_0 by
+    // at least the planner's default minimum holding time, or else the
+    // planner might not have actually avoided the collision as intended.
+    for (std::size_t i=2; i < command_0->current_timing.size(); ++i)
+    {
+      CHECK(command_1->current_timing[i] - command_0->current_timing[i]
+            >= rmf_traffic::agv::Planner::Options::DefaultMinHoldingTime);
+    }
+  }
+}

--- a/rmf_fleet_adapter/test/mock/MockRobotCommand.hpp
+++ b/rmf_fleet_adapter/test/mock/MockRobotCommand.hpp
@@ -15,6 +15,9 @@
  *
 */
 
+#ifndef RMF_FLEET_ADAPTER__TEST__MOCK__MOCKROBOTCOMMAND
+#define RMF_FLEET_ADAPTER__TEST__MOCK__MOCKROBOTCOMMAND
+
 #include <rmf_fleet_adapter/agv/RobotCommandHandle.hpp>
 #include <rmf_fleet_adapter/agv/RobotUpdateHandle.hpp>
 
@@ -179,3 +182,5 @@ private:
 };
 
 } // namespace rmf_fleet_adapter_test
+
+#endif // RMF_FLEET_ADAPTER__TEST__MOCK__MOCKROBOTCOMMAND

--- a/rmf_fleet_adapter/test/mock/MockTrafficLightCommand.hpp
+++ b/rmf_fleet_adapter/test/mock/MockTrafficLightCommand.hpp
@@ -41,6 +41,7 @@ public:
     current_version = version;
     current_timing = timing;
     current_progress_updater = std::move(progress_updater);
+    ++command_counter;
     cv.notify_all();
   }
 
@@ -50,6 +51,7 @@ public:
   }
 
   rmf_utils::optional<std::size_t> current_version;
+  std::size_t command_counter = 0;
   std::vector<rclcpp::Time> current_timing;
   ProgressCallback current_progress_updater;
 

--- a/rmf_fleet_adapter/test/mock/MockTrafficLightCommand.hpp
+++ b/rmf_fleet_adapter/test/mock/MockTrafficLightCommand.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef RMF_FLEET_ADAPTER__TEST__MOCK__MOCKTRAFFICLIGHTCOMMAND_HPP
+#define RMF_FLEET_ADAPTER__TEST__MOCK__MOCKTRAFFICLIGHTCOMMAND_HPP
+
+#include <rmf_fleet_adapter/agv/TrafficLight.hpp>
+
+#include <rmf_utils/optional.hpp>
+
+#include <condition_variable>
+
+namespace rmf_fleet_adapter_test {
+
+//==============================================================================
+class MockTrafficLightCommand
+    : public rmf_fleet_adapter::agv::TrafficLight::CommandHandle
+{
+public:
+
+  void receive_path_timing(
+      std::size_t version,
+      const std::vector<rclcpp::Time>& timing,
+      ProgressCallback progress_updater) final
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    current_version = version;
+    current_timing = timing;
+    current_progress_updater = std::move(progress_updater);
+    cv.notify_all();
+  }
+
+  void deadlock() final
+  {
+    // Do nothing
+  }
+
+  rmf_utils::optional<std::size_t> current_version;
+  std::vector<rclcpp::Time> current_timing;
+  ProgressCallback current_progress_updater;
+
+  std::mutex mutex;
+  std::condition_variable cv;
+
+};
+
+} // namespace rmf_fleet_adapter_test
+
+
+#endif // RMF_FLEET_ADAPTER__TEST__MOCK__MOCKTRAFFICLIGHTCOMMAND_HPP

--- a/rmf_fleet_msgs/package.xml
+++ b/rmf_fleet_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_fleet_msgs</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>A package containing messages used to interface to fleet managers</description>
   <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_lift_msgs/package.xml
+++ b/rmf_lift_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_lift_msgs</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>Messages used to interface to lifts.</description>
   <maintainer email="mquigley@openrobotics.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_task_msgs/package.xml
+++ b/rmf_task_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_task_msgs</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>A package containing messages used to specify tasks</description>
   <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_traffic</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>Package for managing traffic in the Robotics Middleware Framework</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_traffic_msgs/package.xml
+++ b/rmf_traffic_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_traffic_msgs</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>A package containing messages used by the RMF traffic management system.</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_traffic_ros2/CHANGELOG.rst
+++ b/rmf_traffic_ros2/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog for package rmf_traffic_ros2
 Forthcoming
 -----------
 
+1.1.0 (2020-09-XX)
+------------------
+* Add a schedule node factory to the public API: [#147](https://github.com/osrf/rmf_core/pull/147)
+
 1.0.2 (2020-07-27)
 ------------------
 * Always respond to negotiations: [#138](https://github.com/osrf/rmf_core/pull/138)

--- a/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Node.hpp
+++ b/rmf_traffic_ros2/include/rmf_traffic_ros2/schedule/Node.hpp
@@ -1,0 +1,16 @@
+#ifndef RMF_TRAFFIC_ROS2__SCHEDULE__NODE_HPP
+#define RMF_TRAFFIC_ROS2__SCHEDULE__NODE_HPP
+
+#include <rclcpp/node.hpp>
+
+namespace rmf_traffic_ros2 {
+namespace schedule {
+
+/// Make a ScheduleNode instance
+std::shared_ptr<rclcpp::Node> make_node(
+  const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+
+} // namespace schedule
+} // namespace rmf_traffic_ros2
+
+#endif // RMF_TRAFFIC_ROS2__SCHEDULE__NODE_HPP

--- a/rmf_traffic_ros2/package.xml
+++ b/rmf_traffic_ros2/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_traffic_ros2</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>A package containing messages used by the RMF traffic management system.</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Node.cpp
@@ -15,7 +15,7 @@
  *
 */
 
-#include "ScheduleNode.hpp"
+#include "internal_Node.hpp"
 
 #include <rmf_traffic_ros2/Route.hpp>
 #include <rmf_traffic_ros2/StandardNames.hpp>
@@ -35,7 +35,8 @@
 
 #include <unordered_map>
 
-namespace rmf_traffic_schedule {
+namespace rmf_traffic_ros2 {
+namespace schedule {
 
 //==============================================================================
 std::vector<ScheduleNode::ConflictSet> get_conflicts(
@@ -78,8 +79,8 @@ std::vector<ScheduleNode::ConflictSet> get_conflicts(
 }
 
 //==============================================================================
-ScheduleNode::ScheduleNode()
-: Node("rmf_traffic_schedule_node"),
+ScheduleNode::ScheduleNode(const rclcpp::NodeOptions& options)
+: Node("rmf_traffic_schedule_node", options),
   database(std::make_shared<rmf_traffic::schedule::Database>()),
   active_conflicts(database)
 {
@@ -231,7 +232,7 @@ ScheduleNode::ScheduleNode()
       const auto query_all = rmf_traffic::schedule::query_all();
       Version last_checked_version = 0;
 
-      while (rclcpp::ok() && !conflict_check_quit)
+      while (rclcpp::ok(get_node_options().context()) && !conflict_check_quit)
       {
         rmf_utils::optional<rmf_traffic::schedule::Patch> next_patch;
         rmf_traffic::schedule::Viewer::View view_changes;
@@ -841,4 +842,10 @@ void ScheduleNode::receive_forfeit(const ConflictForfeit& msg)
   }
 }
 
-} // namespace rmf_traffic_schedule
+std::shared_ptr<rclcpp::Node> make_node(const rclcpp::NodeOptions& options)
+{
+  return std::make_shared<ScheduleNode>(options);
+}
+
+} // namespace schedule
+} // namespace rmf_traffic_ros2

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/Writer.cpp
@@ -159,6 +159,8 @@ public:
     rclcpp::Publisher<Erase>::SharedPtr erase_pub;
     rclcpp::Publisher<Clear>::SharedPtr clear_pub;
 
+    rclcpp::Context::SharedPtr context;
+
     using Register = rmf_traffic_msgs::srv::RegisterParticipant;
     using Unregister = rmf_traffic_msgs::srv::UnregisterParticipant;
 
@@ -187,6 +189,8 @@ public:
       clear_pub = node.create_publisher<Clear>(
         ItineraryClearTopicName,
         rclcpp::SystemDefaultsQoS().best_effort());
+
+      context = node.get_node_options().context();
 
       register_client =
         node.create_client<Register>(RegisterParticipantSrvName);
@@ -269,7 +273,7 @@ public:
       auto future = register_client->async_send_request(request);
       while (future.wait_for(100ms) != std::future_status::ready)
       {
-        if (!rclcpp::ok())
+        if (!rclcpp::ok(context))
         {
           // *INDENT-OFF*
           throw std::runtime_error(

--- a/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_ros2/schedule/internal_Node.hpp
@@ -18,7 +18,7 @@
 #ifndef SRC__RMF_TRAFFIC_SCHEDULE__SCHEDULENODE_HPP
 #define SRC__RMF_TRAFFIC_SCHEDULE__SCHEDULENODE_HPP
 
-#include "../rmf_traffic_ros2/schedule/NegotiationRoom.hpp"
+#include "NegotiationRoom.hpp"
 
 #include <rmf_traffic/schedule/Database.hpp>
 #include <rmf_traffic/schedule/Negotiation.hpp>
@@ -58,14 +58,15 @@
 #include <set>
 #include <unordered_map>
 
-namespace rmf_traffic_schedule {
+namespace rmf_traffic_ros2 {
+namespace schedule {
 
 //==============================================================================
 class ScheduleNode : public rclcpp::Node
 {
 public:
 
-  ScheduleNode();
+  ScheduleNode(const rclcpp::NodeOptions& options);
 
   ~ScheduleNode();
 
@@ -396,6 +397,7 @@ public:
   std::mutex active_conflicts_mutex;
 };
 
-} // namespace rmf_traffic_schedule
+} // namespace schedule
+} // namespace rmf_traffic_ros2
 
 #endif // SRC__RMF_TRAFFIC_SCHEDULE__SCHEDULENODE_HPP

--- a/rmf_traffic_ros2/src/rmf_traffic_schedule/main.cpp
+++ b/rmf_traffic_ros2/src/rmf_traffic_schedule/main.cpp
@@ -15,7 +15,7 @@
  *
 */
 
-#include "ScheduleNode.hpp"
+#include <rmf_traffic_ros2/schedule/Node.hpp>
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -23,7 +23,7 @@ int main(int argc, char* argv[])
 {
   rclcpp::init(argc, argv);
 
-  const auto node = std::make_shared<rmf_traffic_schedule::ScheduleNode>();
+  const auto node = rmf_traffic_ros2::schedule::make_node();
 
   RCLCPP_INFO(
     node->get_logger(),

--- a/rmf_utils/package.xml
+++ b/rmf_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_utils</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>Simple C++ programming utilities used by Robotics Middleware Framework packages</description>
   <maintainer email="grey@openrobotics.org">Grey</maintainer>
   <license>Apache License 2.0</license>

--- a/rmf_workcell_msgs/package.xml
+++ b/rmf_workcell_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmf_workcell_msgs</name>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <description>A package containing messages used by all workcells generically to interfact with rmf_core</description>
   <maintainer email="aaron@openrobotics.org">Aaron Chong</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
This PR introduces the API for the "traffic light" control category of fleet adapter. This API will allow fleets that only have pause/resume functionalities to integrate into the traffic negotiation system of RMF.

There are some unit tests written for this new API, but integration tests will take considerably longer to develop. Developing a pause/resume fleet manager mockup is a prerequisite for making any integration tests for this API, so that will be a blocker for a time being.