### PR TITLE
Adjust delay threshold

### DIFF
--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/FleetUpdateHandle.hpp
@@ -84,6 +84,15 @@ public:
   /// adapter internally.
   FleetUpdateHandle& accept_delivery_requests(AcceptDeliveryRequest check);
 
+  /// Specify the default value for how high the delay of the current itinerary
+  /// can become before it gets interrupted and replanned. A nullopt value will
+  /// allow for an arbitrarily long delay to build up without being interrupted.
+  FleetUpdateHandle& default_maximum_delay(
+      rmf_utils::optional<rmf_traffic::Duration> value);
+
+  /// Get the default value for the maximum acceptable delay.
+  rmf_utils::optional<rmf_traffic::Duration> default_maximum_delay() const;
+
   class Implementation;
 private:
   FleetUpdateHandle();

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -20,6 +20,7 @@
 
 #include <rmf_traffic/Time.hpp>
 #include <rmf_utils/impl_ptr.hpp>
+#include <rmf_utils/optional.hpp>
 
 #include <Eigen/Geometry>
 
@@ -82,6 +83,19 @@ public:
       const double max_merge_waypoint_distance = 0.1,
       const double max_merge_lane_distance = 1.0,
       const double min_lane_length = 1e-8);
+
+  /// Specify how high the delay of the current itinerary can become before it
+  /// gets interrupted and replanned. A nullopt value will allow for an
+  /// arbitrarily long delay to build up without being interrupted.
+  RobotUpdateHandle& maximum_delay(
+      rmf_utils::optional<rmf_traffic::Duration> value);
+
+  /// Get the value for the maximum delay.
+  ///
+  /// \note The setter for the maximum_delay field is run asynchronously, so
+  /// it may take some time for the return value of this getter to match the
+  /// value that was given to the setter.
+  rmf_utils::optional<rmf_traffic::Duration> maximum_delay() const;
 
   class Implementation;
 private:

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/TrafficLight.hpp
@@ -26,6 +26,7 @@
 #include <rclcpp/time.hpp>
 
 #include <rmf_utils/impl_ptr.hpp>
+#include <rmf_utils/optional.hpp>
 
 namespace rmf_fleet_adapter {
 namespace agv {
@@ -60,6 +61,18 @@ public:
     /// \param[in] new_path
     ///   Submit a new path that the robot intends to follow.
     std::size_t update_path(const std::vector<Waypoint>& new_path);
+
+    /// Set the maximum acceptable delay before the timing gets recomputed. Pass
+    /// in a nullopt to prevent the timing from ever being recomputed.
+    UpdateHandle& maximum_delay(
+        rmf_utils::optional<rmf_traffic::Duration> value);
+
+    /// Get the maximum acceptable delay before the timing gets recomputed.
+    ///
+    /// \note The setter for this field is run asynchronously, so it may take
+    /// some time before the getter has the same value that was given to the
+    /// setter.
+    rmf_utils::optional<rmf_traffic::Duration> maximum_delay() const;
 
     class Implementation;
   private:

--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -17,7 +17,8 @@
   <arg name="footprint_radius" description="The radius of the footprint of the vehicles in this fleet"/>
   <arg name="vicinity_radius" description="The radius of the personal vicinity of the vehicles in this fleet"/>
   <arg name="perform_deliveries" default="false" description="Whether this fleet adapter can perform deliveries"/>
-  <arg name="delay_threshold" default="30.0" description="How long to wait before replanning" />
+  <arg name="delay_threshold" default="10.0" description="How long to wait before replanning" />
+  <arg name="disable_delay_threshold" default="false" description="Disable the delay_threshold behavior" />
   <arg name="retry_wait" default="10.0" description="How long a retry should wait before starting"/>
   <arg name="discovery_timeout" default="10.0" description="How long to wait on discovery before giving up"/>
   <arg name="reversible" default="true" description="Can the robot drive backwards"/>
@@ -45,6 +46,7 @@
     <param name="perform_deliveries" value="$(var perform_deliveries)"/>
 
     <param name="delay_threshold" value="$(var delay_threshold)"/>
+    <param name="disable_delay_threshold" value="$(var disable_delay_threshold)"/>
     <param name="retry_wait" value="$(var retry_wait)"/>
     <param name="discovery_timeout" value="$(var discovery_timeout)"/>
     <param name="reversible" value="$(var reversible)"/>

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -390,6 +390,17 @@ std::shared_ptr<Connections> make_fleet(
           [](const rmf_task_msgs::msg::Delivery&){ return true; });
   }
 
+  if (node->declare_parameter<bool>("disable_delay_threshold", false))
+  {
+    connections->fleet->default_maximum_delay(rmf_utils::nullopt);
+  }
+  else
+  {
+    connections->fleet->default_maximum_delay(
+          rmf_fleet_adapter::get_parameter_or_default_time(
+            *node, "delay_threshold", 10.0));
+  }
+
   connections->path_request_pub = node->create_publisher<
       rmf_fleet_msgs::msg::PathRequest>(
         rmf_fleet_adapter::PathRequestTopicName, rclcpp::SystemDefaultsQoS());

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -305,7 +305,8 @@ void FleetUpdateHandle::add_robot(
             fleet->_pimpl->snappable,
             fleet->_pimpl->planner,
             fleet->_pimpl->node,
-            fleet->_pimpl->worker
+            fleet->_pimpl->worker,
+            fleet->_pimpl->default_maximum_delay
           });
 
     // We schedule the following operations on the worker to make sure we do not
@@ -356,6 +357,21 @@ FleetUpdateHandle& FleetUpdateHandle::accept_delivery_requests(
 {
   _pimpl->accept_delivery = std::move(check);
   return *this;
+}
+
+//==============================================================================
+FleetUpdateHandle& FleetUpdateHandle::default_maximum_delay(
+    rmf_utils::optional<rmf_traffic::Duration> value)
+{
+  _pimpl->default_maximum_delay = value;
+  return *this;
+}
+
+//==============================================================================
+rmf_utils::optional<rmf_traffic::Duration>
+FleetUpdateHandle::default_maximum_delay() const
+{
+  return _pimpl->default_maximum_delay;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -200,6 +200,20 @@ const rxcpp::schedulers::worker& RobotContext::worker() const
 }
 
 //==============================================================================
+rmf_utils::optional<rmf_traffic::Duration> RobotContext::maximum_delay() const
+{
+  return _maximum_delay;
+}
+
+//==============================================================================
+RobotContext& RobotContext::maximum_delay(
+    rmf_utils::optional<rmf_traffic::Duration> value)
+{
+  _maximum_delay = value;
+  return *this;
+}
+
+//==============================================================================
 void RobotContext::respond(
     const TableViewerPtr& table_viewer,
     const ResponderPtr& responder)
@@ -226,7 +240,8 @@ RobotContext::RobotContext(
   std::shared_ptr<const Snappable> schedule,
   std::shared_ptr<const rmf_traffic::agv::Planner> planner,
   std::shared_ptr<rmf_fleet_adapter::agv::Node> node,
-  const rxcpp::schedulers::worker& worker)
+  const rxcpp::schedulers::worker& worker,
+  rmf_utils::optional<rmf_traffic::Duration> maximum_delay)
   : _command_handle(std::move(command_handle)),
     _location(std::move(_initial_location)),
     _itinerary(std::move(itinerary)),
@@ -234,6 +249,7 @@ RobotContext::RobotContext(
     _planner(std::move(planner)),
     _node(std::move(node)),
     _worker(worker),
+    _maximum_delay(maximum_delay),
     _requester_id(
       _itinerary.description().owner() + "/" + _itinerary.description().name())
 {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -101,6 +101,12 @@ public:
   /// callbacks that can modify the state of the robot.
   const rxcpp::schedulers::worker& worker() const;
 
+  /// Get the maximum allowable delay for this robot
+  rmf_utils::optional<rmf_traffic::Duration> maximum_delay() const;
+
+  /// Set the maximum allowable delay for this robot
+  RobotContext& maximum_delay(rmf_utils::optional<rmf_traffic::Duration> value);
+
   // Documentation inherited from rmf_traffic::schedule::Negotiator
   void respond(
       const TableViewerPtr& table_viewer,
@@ -117,7 +123,8 @@ private:
     std::shared_ptr<const Snappable> schedule,
     std::shared_ptr<const rmf_traffic::agv::Planner> planner,
     std::shared_ptr<Node> node,
-    const rxcpp::schedulers::worker& worker);
+    const rxcpp::schedulers::worker& worker,
+    rmf_utils::optional<rmf_traffic::Duration> maximum_delay);
 
   std::weak_ptr<RobotCommandHandle> _command_handle;
   std::vector<rmf_traffic::agv::Plan::Start> _location;
@@ -133,6 +140,7 @@ private:
 
   std::shared_ptr<Node> _node;
   rxcpp::schedulers::worker _worker;
+  rmf_utils::optional<rmf_traffic::Duration> _maximum_delay;
   std::string _requester_id;
 
   rmf_traffic::schedule::Negotiator* _negotiator = nullptr;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -41,6 +41,13 @@ std::shared_ptr<RobotContext> RobotUpdateHandle::Implementation::get_context()
 }
 
 //==============================================================================
+std::shared_ptr<const RobotContext>
+RobotUpdateHandle::Implementation::get_context() const
+{
+  return const_cast<Implementation&>(*this).get_context();
+}
+
+//==============================================================================
 void RobotUpdateHandle::interrupted()
 {
   if (const auto context = _pimpl->get_context())
@@ -153,6 +160,32 @@ void RobotUpdateHandle::update_position(
       context->_location = std::move(starts);
     });
   }
+}
+
+//==============================================================================
+RobotUpdateHandle& RobotUpdateHandle::maximum_delay(
+    rmf_utils::optional<rmf_traffic::Duration> value)
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->worker().schedule(
+          [context, value](const auto&)
+    {
+      context->maximum_delay(value);
+    });
+  }
+
+  return *this;
+}
+
+//==============================================================================
+rmf_utils::optional<rmf_traffic::Duration>
+RobotUpdateHandle::maximum_delay() const
+{
+  if (const auto context = _pimpl->get_context())
+    return context->maximum_delay();
+
+  return rmf_utils::nullopt;
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
@@ -64,6 +64,8 @@ public:
 
   std::size_t processing_version = 0;
 
+  rmf_utils::optional<rmf_traffic::Duration> maximum_delay;
+
   std::shared_ptr<services::FindPath> find_path_service;
   rxcpp::subscription find_path_subscription;
 
@@ -648,8 +650,8 @@ TrafficLight::UpdateHandle::Implementation::Data::update_timing(
         const auto new_delay = now - *expected_time;
 
         // TODO(MXG): Make this threshold configurable
-        const auto delay_threshold = std::chrono::seconds(30);
-        if (new_delay < delay_threshold)
+        const auto max_delay = data->maximum_delay;
+        if (!max_delay || new_delay < *max_delay)
         {
           const auto time_shift = new_delay - data->itinerary.delay();
           if (time_shift > std::chrono::seconds(5))
@@ -926,6 +928,26 @@ std::size_t TrafficLight::UpdateHandle::update_path(
   });
 
   return version;
+}
+
+//==============================================================================
+auto TrafficLight::UpdateHandle::maximum_delay(
+    rmf_utils::optional<rmf_traffic::Duration> value) -> UpdateHandle&
+{
+  _pimpl->data->worker.schedule(
+        [data = _pimpl->data, value](const auto&)
+  {
+    data->maximum_delay = value;
+  });
+
+  return *this;
+}
+
+//==============================================================================
+rmf_utils::optional<rmf_traffic::Duration>
+TrafficLight::UpdateHandle::maximum_delay() const
+{
+  return _pimpl->data->maximum_delay;
 }
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -117,6 +117,9 @@ public:
   std::shared_ptr<rmf_traffic::schedule::Snappable> snappable;
   std::shared_ptr<rmf_traffic_ros2::schedule::Negotiation> negotiation;
 
+  rmf_utils::optional<rmf_traffic::Duration> default_maximum_delay =
+      std::chrono::nanoseconds(std::chrono::seconds(10));
+
   AcceptDeliveryRequest accept_delivery = nullptr;
   std::unordered_map<RobotContextPtr, TaskManager> task_managers = {};
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_RobotUpdateHandle.hpp
@@ -55,6 +55,8 @@ public:
 
   std::shared_ptr<RobotContext> get_context();
 
+  std::shared_ptr<const RobotContext> get_context() const;
+
 };
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/MoveRobot.hpp
@@ -149,11 +149,16 @@ void MoveRobot::Action::operator()(const Subscriber& s)
     const auto newly_expected_arrival = t + estimate;
     const auto new_delay = newly_expected_arrival - previously_expected_arrival;
 
-    if (!action->_interrupted &&
-        std::chrono::seconds(10) < current_delay + new_delay)
+    if (!action->_interrupted)
     {
-      action->_interrupted = true;
-      action->_context->trigger_interrupt();
+      if (const auto max_delay = action->_context->maximum_delay())
+      {
+        if (*max_delay < current_delay + new_delay)
+        {
+          action->_interrupted = true;
+          action->_context->trigger_interrupt();
+        }
+      }
     }
 
     if (std::chrono::milliseconds(500).count() < std::abs(new_delay.count()))


### PR DESCRIPTION
When the delay on an itinerary accumulates to above some threshold, the adapter will attempt to replan the route. This PR adds some methods to the API so that the threshold can be set by the user. It also adds launch parameters for the backwards-compatible fleet adapter to adjust this threshold or to disable the behavior entirely.