### PR TITLE
Use SensorDataQos for state aggregator subscriber

### DIFF
--- a/rmf_fleet_adapter/src/robot_state_aggregator/main.cpp
+++ b/rmf_fleet_adapter/src/robot_state_aggregator/main.cpp
@@ -56,12 +56,13 @@ private:
   : rclcpp::Node("robot_state_aggregator")
   {
     const auto default_qos = rclcpp::SystemDefaultsQoS();
+    const auto sensor_qos = rclcpp::SensorDataQoS();
 
     _fleet_state_pub = create_publisher<FleetState>(
       rmf_fleet_adapter::FleetStateTopicName, default_qos);
 
     _robot_state_sub = create_subscription<RobotState>(
-      "robot_state", default_qos,
+      "robot_state", sensor_qos,
       [&](RobotState::UniquePtr msg)
       {
         _robot_state_update(std::move(msg));


### PR DESCRIPTION
Signed-off-by: Chen Bainian <brian97cbn@gmail.com>
Related to #145, but doesn't fix all the problems.
We found out that sometimes one of the vehicles' `/fleet_states` doesn't get updated properly or missed during the operation. I think this was caused by the two messages are two close to each other in time, which somehow one of them gets missed by the state_aggregator subscriber and sometimes multiple times, causing a 2-4s delay! It turns out fine in `ros2 topic echo` for the `/robot_state`, but bad for `/fleet_states`. So I used the SensorDataQos instead, greatly improved the updates in `/fleet_states`. You can see the improvement in the following videos. We also tested under higher frequency for the fleets.

[Before Video](https://drive.google.com/file/d/1VidXTm12wjMR2JMWHxumoxfdu-x90EQC/view?usp=sharing), [After Video](https://drive.google.com/file/d/1B-qw4Lkti6TTqJElqnmNIzjXYS-8yjAx/view?usp=sharing)

It occurs occasionally for the office demo(very obvious under high publishing frequency), but very bad in our world.

I am not sure this is the best way, or whether state_aggregator will still exists in the new API or maybe a component implementation, please let me know.