### PR TITLE
Required parameter name fix

### DIFF
--- a/rmf_fleet_adapter/src/robot_state_aggregator/main.cpp
+++ b/rmf_fleet_adapter/src/robot_state_aggregator/main.cpp
@@ -40,7 +40,7 @@ public:
     {
       RCLCPP_FATAL(
         node->get_logger(),
-        "Missing required parameter: [fleet_adapter]");
+        "Missing required parameter: [fleet_name]");
       return nullptr;
     }
 


### PR DESCRIPTION
Required parameter is fleet_name instead of fleet_adapter, just fixing the RCLCPP_FATAL message.