### PR TITLE
Tests for maximum_cost_estimate

### DIFF
--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -598,7 +598,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
         options.maximum_cost_estimate(required_cost - 1e-6);
         planner.set_default_options(options);
         plan = planner.plan(start, goal);
-        CHECK(!plan);
+        CHECK_FALSE(plan);
       }
 
       THEN("Cost limit just above actual required limit succeeds")

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -607,7 +607,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
         options.maximum_cost_estimate(required_cost + 1e-6);
         planner.set_default_options(options);
         plan = planner.plan(start, goal);
-        CHECK(!plan);
+        CHECK(plan);
       }
     }
   }

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -589,7 +589,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
         options.maximum_cost_estimate(required_cost / 2);
         planner.set_default_options(options);
         plan = planner.plan(start, goal);
-        CHECK(!plan);
+        CHECK_FALSE(plan);
       }
 
       THEN("Cost limit just below actual required limit fails")

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -458,6 +458,159 @@ SCENARIO("Test Options", "[options]")
     CHECK(*default_options.interrupt_flag());
   }
 
+  Planner::Options default_maxcostestimate(nullptr);
+  WHEN("Maximum cost estimate is default after default construction")
+  {
+    // Converting an optional to a bool returns false if it's empty, which is
+    // the default for constructing Options
+    CHECK(!default_maxcostestimate.maximum_cost_estimate());
+  }
+
+  double local_maximum_cost_estimate(3.14159);
+  Planner::Options set_maxcostestimate(
+    nullptr,
+    Planner::Options::DefaultMinHoldingTime,
+    interrupt_flag,
+    local_maximum_cost_estimate);
+  WHEN("Maximum cost estimate is set after construction")
+  {
+    CHECK(set_maxcostestimate.maximum_cost_estimate().value()
+      == Approx(local_maximum_cost_estimate).margin(1e-6));
+  }
+
+  WHEN("Set the maximum cost estimate")
+  {
+    local_maximum_cost_estimate = 42;
+    set_maxcostestimate.maximum_cost_estimate(local_maximum_cost_estimate);
+    CHECK(set_maxcostestimate.maximum_cost_estimate().value()
+      == Approx(local_maximum_cost_estimate).margin(1e-6));
+  }
+}
+
+SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
+{
+  GIVEN("A graph")
+  {
+    const std::string test_map_name = "test_map";
+    rmf_traffic::agv::Graph graph;
+    graph.add_waypoint(test_map_name, {-5, -5}).set_passthrough_point(true); // 0
+    graph.add_waypoint(test_map_name, { 0, -5}).set_passthrough_point(true); // 1
+    graph.add_waypoint(test_map_name, { 5, -5}).set_passthrough_point(true); // 2
+    graph.add_waypoint(test_map_name, {10, -5}).set_passthrough_point(true); // 3
+    graph.add_waypoint(test_map_name, {-5, 0}); // 4
+    graph.add_waypoint(test_map_name, { 0, 0}); // 5
+    graph.add_waypoint(test_map_name, { 5, 0}); // 6
+    graph.add_waypoint(test_map_name, {10, 0}).set_passthrough_point(true); // 7
+    graph.add_waypoint(test_map_name, {10, 4}).set_passthrough_point(true); // 8
+    graph.add_waypoint(test_map_name, { 0, 8}).set_passthrough_point(true); // 9
+    graph.add_waypoint(test_map_name, { 5, 8}).set_passthrough_point(true); // 10
+    graph.add_waypoint(test_map_name, {10, 12}).set_passthrough_point(true); // 11
+    graph.add_waypoint(test_map_name, {12, 12}).set_passthrough_point(true); // 12
+    CHECK(graph.num_waypoints() == 13);
+
+    auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
+      {
+        graph.add_lane(w0, w1);
+        graph.add_lane(w1, w0);
+      };
+
+    add_bidir_lane(0, 1);
+    add_bidir_lane(1, 2);
+    add_bidir_lane(2, 3);
+    add_bidir_lane(1, 5);
+    add_bidir_lane(3, 7);
+    add_bidir_lane(4, 5);
+    add_bidir_lane(6, 10);
+    add_bidir_lane(7, 8);
+    add_bidir_lane(9, 10);
+    add_bidir_lane(10, 11);
+    add_bidir_lane(5, 9);
+    add_bidir_lane(11, 12);
+
+    const rmf_traffic::Profile profile = create_test_profile(UnitCircle);
+    const rmf_traffic::agv::VehicleTraits traits(
+      {0.7, 0.3}, {1.0, 0.45}, profile);
+    auto interrupt_flag = std::make_shared<bool>(false);
+
+    WHEN("Goal from 12->1")
+    {
+      const rmf_traffic::Time time = std::chrono::steady_clock::now();
+      const auto start = rmf_traffic::agv::Planner::Start{time, 12, 0.0};
+      const auto goal = rmf_traffic::agv::Planner::Goal{1};
+
+      THEN("No cost limit succeeds")
+      {
+        auto options = rmf_traffic::agv::Planner::Options{nullptr};
+        rmf_traffic::agv::Planner planner{
+          rmf_traffic::agv::Planner::Configuration{graph, traits},
+          options
+        };
+        auto plan = planner.plan(start, goal);
+        REQUIRE(plan);
+        REQUIRE(plan.cost_estimate());
+      }
+
+      THEN("Cost limit of zero fails")
+      {
+        auto options = rmf_traffic::agv::Planner::Options{
+          nullptr,
+          rmf_traffic::agv::Planner::Options::DefaultMinHoldingTime,
+          interrupt_flag,
+          0 // Maximum cost estimate must be 0
+        };
+        rmf_traffic::agv::Planner planner{
+          rmf_traffic::agv::Planner::Configuration{graph, traits},
+          options
+        };
+        auto plan = planner.plan(start, goal);
+        CHECK(!plan);
+      }
+    }
+
+    WHEN("Goal from 12->1 and known required cost limit")
+    {
+      const rmf_traffic::Time time = std::chrono::steady_clock::now();
+      const auto start = rmf_traffic::agv::Planner::Start{time, 12, 0.0};
+      const auto goal = rmf_traffic::agv::Planner::Goal{1};
+
+      auto options = rmf_traffic::agv::Planner::Options{nullptr};
+      rmf_traffic::agv::Planner planner{
+        rmf_traffic::agv::Planner::Configuration{graph, traits},
+        options
+      };
+      auto plan = planner.plan(start, goal);
+      REQUIRE(plan);
+      REQUIRE(plan.cost_estimate());
+      auto required_cost = plan.cost_estimate().value();
+
+      THEN("Cost limit half actual required limit fails")
+      {
+
+        options.maximum_cost_estimate(required_cost / 2);
+        planner.set_default_options(options);
+        plan = planner.plan(start, goal);
+        CHECK(!plan);
+      }
+
+      THEN("Cost limit just below actual required limit fails")
+      {
+
+        options.maximum_cost_estimate(required_cost - 1e-6);
+        planner.set_default_options(options);
+        plan = planner.plan(start, goal);
+        CHECK(!plan);
+      }
+
+      THEN("Cost limit just above actual required limit succeeds")
+      {
+
+        options.maximum_cost_estimate(required_cost + 1e-6);
+        planner.set_default_options(options);
+        plan = planner.plan(start, goal);
+        CHECK(!plan);
+      }
+    }
+  }
 }
 
 SCENARIO("Test Start")

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -474,6 +474,7 @@ SCENARIO("Test Options", "[options]")
     local_maximum_cost_estimate);
   WHEN("Maximum cost estimate is set after construction")
   {
+    REQUIRE(set_max_cost_estimate_options.maximum_cost_estimate());
     CHECK(set_max_cost_estimate_options.maximum_cost_estimate().value()
       == Approx(local_maximum_cost_estimate));
   }
@@ -481,6 +482,7 @@ SCENARIO("Test Options", "[options]")
   WHEN("Set the maximum cost estimate")
   {
     local_maximum_cost_estimate = 42;
+    REQUIRE(set_max_cost_estimate_options.maximum_cost_estimate());
     set_max_cost_estimate_options.maximum_cost_estimate(local_maximum_cost_estimate);
     CHECK(set_max_cost_estimate_options.maximum_cost_estimate().value()
       == Approx(local_maximum_cost_estimate));
@@ -530,7 +532,6 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
     const rmf_traffic::Profile profile = create_test_profile(UnitCircle);
     const rmf_traffic::agv::VehicleTraits traits(
       {0.7, 0.3}, {1.0, 0.45}, profile);
-    auto interrupt_flag = std::make_shared<bool>(false);
 
     WHEN("Goal from 12->1")
     {
@@ -538,7 +539,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
       const auto start = rmf_traffic::agv::Planner::Start{time, 12, 0.0};
       const auto goal = rmf_traffic::agv::Planner::Goal{1};
 
-      THEN("No cost limit succeeds")
+      THEN("Success when there is no cost limit")
       {
         auto options = rmf_traffic::agv::Planner::Options{nullptr};
         rmf_traffic::agv::Planner planner{
@@ -554,7 +555,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
         auto options = rmf_traffic::agv::Planner::Options{
           nullptr,
           rmf_traffic::agv::Planner::Options::DefaultMinHoldingTime,
-          interrupt_flag,
+          std::shared_ptr<bool>(nullptr),
           0 // Maximum cost estimate must be 0
         };
         rmf_traffic::agv::Planner planner{
@@ -584,8 +585,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
       THEN("Cost limit half actual required limit fails")
       {
         options.maximum_cost_estimate(required_cost / 2);
-        planner.set_default_options(options);
-        result = planner.plan(start, goal);
+        result = planner.plan(start, goal, options);
         CHECK_FALSE(result);
       }
 

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -483,7 +483,7 @@ SCENARIO("Test Options", "[options]")
     local_maximum_cost_estimate = 42;
     set_max_cost_estimate_options.maximum_cost_estimate(local_maximum_cost_estimate);
     CHECK(set_max_cost_estimate_options.maximum_cost_estimate().value()
-      == Approx(local_maximum_cost_estimate).margin(1e-6));
+      == Approx(local_maximum_cost_estimate));
   }
 }
 

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -475,7 +475,7 @@ SCENARIO("Test Options", "[options]")
   WHEN("Maximum cost estimate is set after construction")
   {
     CHECK(set_max_cost_estimate_options.maximum_cost_estimate().value()
-      == Approx(local_maximum_cost_estimate).margin(1e-6));
+      == Approx(local_maximum_cost_estimate));
   }
 
   WHEN("Set the maximum cost estimate")

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -463,7 +463,7 @@ SCENARIO("Test Options", "[options]")
   {
     // Converting an optional to a bool returns false if it's empty, which is
     // the default for constructing Options
-    CHECK(!default_maxcostestimate.maximum_cost_estimate());
+    CHECK_FALSE(default_max_cost_estimate_options.maximum_cost_estimate());
   }
 
   double local_maximum_cost_estimate(3.14159);

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -545,9 +545,8 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
           rmf_traffic::agv::Planner::Configuration{graph, traits},
           options
         };
-        auto plan = planner.plan(start, goal);
-        REQUIRE(plan);
-        REQUIRE(plan.cost_estimate());
+        auto result = planner.plan(start, goal);
+        REQUIRE(result);
       }
 
       THEN("Cost limit of zero fails")
@@ -562,8 +561,8 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
           rmf_traffic::agv::Planner::Configuration{graph, traits},
           options
         };
-        auto plan = planner.plan(start, goal);
-        CHECK_FALSE(plan);
+        auto result = planner.plan(start, goal);
+        CHECK_FALSE(result);
       }
     }
 
@@ -578,36 +577,32 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
         rmf_traffic::agv::Planner::Configuration{graph, traits},
         options
       };
-      auto plan = planner.plan(start, goal);
-      REQUIRE(plan);
-      REQUIRE(plan.cost_estimate());
-      auto required_cost = plan->get_cost();
+      auto result = planner.plan(start, goal);
+      REQUIRE(result);
+      auto required_cost = result->get_cost();
 
       THEN("Cost limit half actual required limit fails")
       {
-
         options.maximum_cost_estimate(required_cost / 2);
         planner.set_default_options(options);
-        plan = planner.plan(start, goal);
-        CHECK_FALSE(plan);
+        result = planner.plan(start, goal);
+        CHECK_FALSE(result);
       }
 
       THEN("Cost limit just below actual required limit fails")
       {
-
         options.maximum_cost_estimate(required_cost - 1e-6);
         planner.set_default_options(options);
-        plan = planner.plan(start, goal);
-        CHECK_FALSE(plan);
+        result = planner.plan(start, goal);
+        CHECK_FALSE(result);
       }
 
       THEN("Cost limit just above actual required limit succeeds")
       {
-
         options.maximum_cost_estimate(required_cost + 1e-6);
         planner.set_default_options(options);
-        plan = planner.plan(start, goal);
-        CHECK(plan);
+        result = planner.plan(start, goal);
+        CHECK(result);
       }
     }
   }

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -466,7 +466,7 @@ SCENARIO("Test Options", "[options]")
     CHECK_FALSE(default_max_cost_estimate_options.maximum_cost_estimate());
   }
 
-  double local_maximum_cost_estimate(3.14159);
+  double local_maximum_cost_estimate = 3.14159;
   Planner::Options set_maxcostestimate(
     nullptr,
     Planner::Options::DefaultMinHoldingTime,

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -467,7 +467,7 @@ SCENARIO("Test Options", "[options]")
   }
 
   double local_maximum_cost_estimate = 3.14159;
-  Planner::Options set_maxcostestimate(
+  Planner::Options set_max_cost_estimate_options(
     nullptr,
     Planner::Options::DefaultMinHoldingTime,
     interrupt_flag,

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -458,7 +458,7 @@ SCENARIO("Test Options", "[options]")
     CHECK(*default_options.interrupt_flag());
   }
 
-  Planner::Options default_maxcostestimate(nullptr);
+  Planner::Options default_max_cost_estimate_options(nullptr);
   WHEN("Maximum cost estimate is default after default construction")
   {
     // Converting an optional to a bool returns false if it's empty, which is

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -482,7 +482,7 @@ SCENARIO("Test Options", "[options]")
   {
     local_maximum_cost_estimate = 42;
     set_max_cost_estimate_options.maximum_cost_estimate(local_maximum_cost_estimate);
-    CHECK(set_maxcostestimate.maximum_cost_estimate().value()
+    CHECK(set_max_cost_estimate_options.maximum_cost_estimate().value()
       == Approx(local_maximum_cost_estimate).margin(1e-6));
   }
 }

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -563,7 +563,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
           options
         };
         auto plan = planner.plan(start, goal);
-        CHECK(!plan);
+        CHECK_FALSE(plan);
       }
     }
 

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -481,7 +481,7 @@ SCENARIO("Test Options", "[options]")
   WHEN("Set the maximum cost estimate")
   {
     local_maximum_cost_estimate = 42;
-    set_maxcostestimate.maximum_cost_estimate(local_maximum_cost_estimate);
+    set_max_cost_estimate_options.maximum_cost_estimate(local_maximum_cost_estimate);
     CHECK(set_maxcostestimate.maximum_cost_estimate().value()
       == Approx(local_maximum_cost_estimate).margin(1e-6));
   }

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -581,7 +581,7 @@ SCENARIO("Maximum Cost Estimates", "[maximum_cost_estimate]")
       auto plan = planner.plan(start, goal);
       REQUIRE(plan);
       REQUIRE(plan.cost_estimate());
-      auto required_cost = plan.cost_estimate().value();
+      auto required_cost = plan->get_cost();
 
       THEN("Cost limit half actual required limit fails")
       {

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -474,7 +474,7 @@ SCENARIO("Test Options", "[options]")
     local_maximum_cost_estimate);
   WHEN("Maximum cost estimate is set after construction")
   {
-    CHECK(set_maxcostestimate.maximum_cost_estimate().value()
+    CHECK(set_max_cost_estimate_options.maximum_cost_estimate().value()
       == Approx(local_maximum_cost_estimate).margin(1e-6));
   }
 


### PR DESCRIPTION
Adds tests relating to the `maximum_cost_estimate` option for planners.

Tests for setting and getting the option are provided.

Tests for the option's impact on planning are provided. These attempt to test rational allowable ranges. Currently the final test (`Cost limit just above actual required limit succeeds`) is failing.

The graph is probably overkill.

I'd welcome any suggests to make these tests more succinct, as well as any suggestions on what else should be tested.

Signed-off-by: Geoffrey Biggs <gbiggs@killbots.net>