### PR TITLE
Add a mandatory waiting event

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/TrafficLight.cpp
@@ -211,8 +211,7 @@ void TrafficLight::UpdateHandle::Implementation::Data::update_path(
       {
         // We use DoorOpen for lack of a better placeholder
         event = rmf_traffic::agv::Graph::Lane::Event::make(
-              rmf_traffic::agv::Graph::Lane::DoorOpen(
-                "", last_wp.mandatory_delay()));
+              rmf_traffic::agv::Graph::Lane::Wait(last_wp.mandatory_delay()));
       }
 
       graph.add_lane(rmf_traffic::agv::Graph::Lane::Node(i-1, event), i);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/GoToPlace.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/GoToPlace.cpp
@@ -386,6 +386,11 @@ public:
     // Not supported yet
   }
 
+  void execute(const Wait&) final
+  {
+    // Do nothing
+  }
+
 private:
   agv::RobotContextPtr _context;
   Task::PendingPhases& _phases;

--- a/rmf_fleet_adapter/test/mock/MockRobotCommand.hpp
+++ b/rmf_fleet_adapter/test/mock/MockRobotCommand.hpp
@@ -53,6 +53,7 @@ public:
     void execute(const DoorClose&) override { }
     void execute(const LiftDoorOpen&) override { }
     void execute(const LiftDoorClose&) override { }
+    void execute(const Wait&) override { }
 
   private:
     std::unordered_map<std::string, std::size_t>& _dock_to_wp;

--- a/rmf_traffic/CHANGELOG.rst
+++ b/rmf_traffic/CHANGELOG.rst
@@ -10,6 +10,7 @@ Forthcoming
 * Allow a Negotiation Table Viewer to see rejected and forfeited statuses, and to check for a submission: [#140](https://github.com/osrf/rmf_core/pull/140/)
 * Improve heuristic to account for events: [#159](https://github.com/osrf/rmf_core/pull/159/)
 * Fix an issue with moving robots between floors: [#163](https://github.com/osrf/rmf_core/pull/163/)
+* Add a generic waiting event: [#158](https://github.com/osrf/rmf_core/pull/158)
 
 1.0.2 (2020-07-27)
 ------------------

--- a/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Graph.hpp
@@ -278,7 +278,8 @@ public:
       ///
       /// \param[in]
       ///   How long the robot will take to dock
-      Dock(std::string dock_name,
+      Dock(
+        std::string dock_name,
         Duration duration);
 
       /// Get the name of the dock
@@ -298,6 +299,27 @@ public:
       rmf_utils::impl_ptr<Implementation> _pimpl;
     };
 
+    class Wait
+    {
+    public:
+
+      /// Constructor
+      ///
+      /// \param[in] duration
+      ///   How long the wait will be.
+      Wait(Duration value);
+
+      /// Get how long the wait will be.
+      Duration duration() const;
+
+      /// Set how long the wait will be.
+      Wait& duration(Duration value);
+
+      class Implementation;
+    private:
+      rmf_utils::impl_ptr<Implementation> _pimpl;
+    };
+
     /// A customizable Executor that can carry out actions based on which Event
     /// type is present.
     class Executor
@@ -310,6 +332,7 @@ public:
       using LiftDoorClose = Lane::LiftDoorClose;
       using LiftMove = Lane::LiftMove;
       using Dock = Lane::Dock;
+      using Wait = Lane::Wait;
 
       virtual void execute(const DoorOpen& open) = 0;
       virtual void execute(const DoorClose& close) = 0;
@@ -317,6 +340,7 @@ public:
       virtual void execute(const LiftDoorClose& close) = 0;
       virtual void execute(const LiftMove& move) = 0;
       virtual void execute(const Dock& dock) = 0;
+      virtual void execute(const Wait& wait) = 0;
 
       virtual ~Executor() = default;
     };
@@ -353,6 +377,7 @@ public:
       static EventPtr make(LiftDoorClose close);
       static EventPtr make(LiftMove move);
       static EventPtr make(Dock dock);
+      static EventPtr make(Wait wait);
     };
 
 

--- a/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Graph.cpp
@@ -502,6 +502,41 @@ auto Graph::Lane::Dock::duration(Duration d) -> Dock&
   return *this;
 }
 
+//==============================================================================
+class Graph::Lane::Wait::Implementation
+{
+public:
+
+  Duration duration;
+
+};
+
+//==============================================================================
+Graph::Lane::Wait::Wait(Duration value)
+  : _pimpl(rmf_utils::make_impl<Implementation>(Implementation{value}))
+{
+  // Do nothing
+}
+
+//==============================================================================
+Duration Graph::Lane::Wait::duration() const
+{
+  return _pimpl->duration;
+}
+
+//==============================================================================
+auto Graph::Lane::Wait::duration(Duration value) -> Wait&
+{
+  _pimpl->duration = value;
+  return *this;
+}
+
+//==============================================================================
+void Graph::Lane::Executor::execute(const Wait&)
+{
+  // Do nothing
+}
+
 namespace {
 //==============================================================================
 template<typename EventT>
@@ -579,6 +614,12 @@ auto Graph::Lane::Event::make(LiftMove move) -> EventPtr
 auto Graph::Lane::Event::make(Dock dock) -> EventPtr
 {
   return TemplateEvent<Dock>::make(std::move(dock));
+}
+
+//==============================================================================
+auto Graph::Lane::Event::make(Wait wait) -> EventPtr
+{
+  return TemplateEvent<Wait>::make(std::move(wait));
 }
 
 //==============================================================================

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
@@ -727,6 +727,12 @@ struct DifferentialDriveExpander
       _event = agv::Graph::Lane::Event::make(dock);
     }
 
+    void execute(const agv::Graph::Lane::Wait& wait) final
+    {
+      assert(_parent);
+      _event = agv::Graph::Lane::Event::make(wait);
+    }
+
     NodePtr get(DifferentialDriveExpander* expander)
     {
       assert(_event);

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1799,7 +1799,8 @@ public:
     LiftDoorOpen,
     LiftDoorClose,
     LiftMove,
-    Dock
+    Dock,
+    Wait
   };
 
   using Lane = rmf_traffic::agv::Graph::Lane;
@@ -1839,6 +1840,11 @@ public:
   void execute(const Lane::Dock&) final
   {
     _result = _expectation == Dock;
+  }
+
+  void execute(const Lane::Wait& wait) final
+  {
+    _result = _expectation == Wait;
   }
 
   bool result() const


### PR DESCRIPTION
The mandatory wait event is a generic placeholder for "events" that require the fleet adapter to simply wait for a period of time. Unlike other event types, this event does not expect the fleet adapter to do anything or wait for anything besides the elapsed amount of time.