### PR TITLE
Implement Ingestors

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -30,6 +30,7 @@ set(dep_pkgs
   rclcpp
   rmf_utils
   rmf_dispenser_msgs
+  rmf_ingestor_msgs
   rmf_door_msgs
   rmf_fleet_msgs
   rmf_lift_msgs
@@ -65,6 +66,8 @@ target_link_libraries(rmf_fleet_adapter
     ${rmf_task_msgs_LIBRARIES}
     ${rmf_door_msgs_LIBRARIES}
     ${rmf_lift_msgs_LIBRARIES}
+    ${rmf_dispenser_msgs_LIBRARIES}
+    ${rmf_ingestor_msgs_LIBRARIES}
 )
 
 target_include_directories(rmf_fleet_adapter
@@ -78,6 +81,8 @@ target_include_directories(rmf_fleet_adapter
     ${rmf_task_msgs_INCLUDE_DIRS}
     ${rmf_door_msgs_INCLUDE_DIRS}
     ${rmf_lift_msgs_INCLUDE_DIRS}
+    ${rmf_dispenser_msgs_INCLUDE_DIRS}
+    ${rmf_ingestor_msgs_INCLUDE_DIRS}
 )
 
 if (BUILD_TESTING)
@@ -93,6 +98,7 @@ if (BUILD_TESTING)
       test/phases/DoorCloseTest.cpp
       test/phases/RequestLiftTest.cpp
       test/phases/DispenseItemTest.cpp
+      test/phases/IngestItemTest.cpp
       test/phases/test_GoToPlace.cpp
       test/services/test_FindEmergencyPullover.cpp
       test/services/test_FindPath.cpp
@@ -108,7 +114,8 @@ if (BUILD_TESTING)
       ${rmf_task_msgs_INCLUDE_DIRS}
       ${rmf_door_msgs_INCLUDE_DIRS}
       ${rmf_lift_msgs_INCLUDE_DIRS}
-
+      ${rmf_dispenser_msgs_INCLUDE_DIRS}
+      ${rmf_ingestor_msgs_INCLUDE_DIRS}
       ${std_msgs_INCLUDE_DIRS}
   )
   target_link_libraries(rmf_fleet_adapter_test
@@ -118,7 +125,8 @@ if (BUILD_TESTING)
       ${rmf_task_msgs_LIBRARIES}
       ${rmf_door_msgs_LIBRARIES}
       ${rmf_lift_msgs_LIBRARIES}
-
+      ${rmf_dispenser_msgs_LIBRARIES}
+      ${rmf_ingestor_msgs_LIBRARIES}
       rmf_fleet_adapter
       rmf_utils::rmf_utils
       ${std_msgs_LIBRARIES}
@@ -154,6 +162,7 @@ target_link_libraries(full_control
     rmf_fleet_adapter
     ${rmf_task_msgs_LIBRARIES}
     ${rmf_dispenser_msgs_LIBRARIES}
+    ${rmf_ingestor_msgs_LIBRARIES}
     ${rmf_door_msgs_LIBRARIES}
     ${rmf_lift_msgs_LIBRARIES}
     ${std_msgs_LIBRARIES}
@@ -163,6 +172,7 @@ target_include_directories(full_control
   PRIVATE
     ${rmf_task_msgs_INCLUDE_DIRS}
     ${rmf_dispenser_msgs_INCLUDE_DIRS}
+    ${rmf_ingestor_msgs_INCLUDE_DIRS}
     ${rmf_door_msgs_INCLUDE_DIRS}
     ${rmf_lift_msgs_INCLUDE_DIRS}
     ${std_msgs_INCLUDE_DIRS}

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/StandardNames.hpp
@@ -41,6 +41,10 @@ const std::string DispenserRequestTopicName = "dispenser_requests";
 const std::string DispenserResultTopicName = "dispenser_results";
 const std::string DispenserStateTopicName = "dispenser_states";
 
+const std::string IngestorRequestTopicName = "ingestor_requests";
+const std::string IngestorResultTopicName = "ingestor_results";
+const std::string IngestorStateTopicName = "ingestor_states";
+
 const std::string DeliveryTopicName = "delivery_requests";
 const std::string LoopRequestTopicName = "loop_requests";
 const std::string TaskSummaryTopicName = "task_summaries";

--- a/rmf_fleet_adapter/package.xml
+++ b/rmf_fleet_adapter/package.xml
@@ -13,6 +13,7 @@
   <depend>rclcpp</depend>
   <depend>rmf_utils</depend>
   <depend>rmf_door_msgs</depend>
+  <depend>rmf_ingestor_msgs</depend>
   <depend>rmf_dispenser_msgs</depend>
   <depend>rmf_fleet_msgs</depend>
   <depend>rmf_lift_msgs</depend>

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.cpp
@@ -53,6 +53,12 @@ std::shared_ptr<Node> Node::make(
         DispenserStateTopicName, default_qos);
   node->_emergency_notice_obs = node->create_observable<EmergencyNotice>(
         rmf_traffic_ros2::EmergencyTopicName, default_qos);
+  node->_ingestor_request_pub = node->create_publisher<IngestorRequest>(
+        IngestorRequestTopicName, default_qos);
+  node->_ingestor_result_obs = node->create_observable<IngestorResult>(
+        IngestorResultTopicName, default_qos);
+  node->_ingestor_state_obs = node->create_observable<IngestorState>(
+        IngestorStateTopicName, default_qos);
 
   return node;
 }
@@ -126,6 +132,24 @@ auto Node::emergency_notice() const -> const EmergencyNoticeObs&
 {
   return _emergency_notice_obs;
 }
+
+auto Node::ingestor_request() const -> const IngestorRequestPub&
+{
+  return _ingestor_request_pub;
+}
+
+//==============================================================================
+auto Node::ingestor_result() const -> const IngestorResultObs&
+{
+  return _ingestor_result_obs;
+}
+
+//==============================================================================
+auto Node::ingestor_state() const -> const IngestorStateObs&
+{
+  return _ingestor_state_obs;
+}
+
 
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Node.hpp
@@ -23,6 +23,9 @@
 #include <rmf_dispenser_msgs/msg/dispenser_request.hpp>
 #include <rmf_dispenser_msgs/msg/dispenser_result.hpp>
 #include <rmf_dispenser_msgs/msg/dispenser_state.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_state.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_result.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_request.hpp>
 #include <rmf_door_msgs/msg/door_state.hpp>
 #include <rmf_door_msgs/msg/door_request.hpp>
 #include <rmf_door_msgs/msg/supervisor_heartbeat.hpp>
@@ -84,6 +87,18 @@ public:
   using EmergencyNoticeObs = rxcpp::observable<EmergencyNotice::SharedPtr>;
   const EmergencyNoticeObs& emergency_notice() const;
 
+  using IngestorRequest = rmf_ingestor_msgs::msg::IngestorRequest;
+  using IngestorRequestPub = rclcpp::Publisher<IngestorRequest>::SharedPtr;
+  const IngestorRequestPub& ingestor_request() const;
+
+  using IngestorResult = rmf_ingestor_msgs::msg::IngestorResult;
+  using IngestorResultObs = rxcpp::observable<IngestorResult::SharedPtr>;
+  const IngestorResultObs& ingestor_result() const;
+
+  using IngestorState = rmf_ingestor_msgs::msg::IngestorState;
+  using IngestorStateObs = rxcpp::observable<IngestorState::SharedPtr>;
+  const IngestorStateObs& ingestor_state() const;
+
 private:
 
   Node(
@@ -101,6 +116,9 @@ private:
   DispenserResultObs _dispenser_result_obs;
   DispenserStateObs _dispenser_state_obs;
   EmergencyNoticeObs _emergency_notice_obs;
+  IngestorRequestPub _ingestor_request_pub;
+  IngestorResultObs _ingestor_result_obs;
+  IngestorStateObs _ingestor_state_obs;
 };
 
 } // namespace agv

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/IngestItem.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/IngestItem.cpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "IngestItem.hpp"
+#include "Utils.hpp"
+
+namespace rmf_fleet_adapter {
+namespace phases {
+
+//==============================================================================
+std::shared_ptr<IngestItem::ActivePhase> IngestItem::ActivePhase::make(
+  agv::RobotContextPtr context,
+  std::string request_guid,
+  std::string target,
+  std::string transporter_type,
+  std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> items)
+{
+  auto inst = std::shared_ptr<ActivePhase>(
+    new ActivePhase(
+      std::move(context),
+      std::move(request_guid),
+      std::move(target),
+      std::move(transporter_type),
+      std::move(items)
+  ));
+  inst->_init_obs();
+  return inst;
+}
+
+//==============================================================================
+const rxcpp::observable<Task::StatusMsg>& IngestItem::ActivePhase::observe() const
+{
+  return _obs;
+}
+
+//==============================================================================
+rmf_traffic::Duration IngestItem::ActivePhase::estimate_remaining_time() const
+{
+  // TODO: implement
+  return rmf_traffic::Duration{0};
+}
+
+//==============================================================================
+void IngestItem::ActivePhase::emergency_alarm(bool on)
+{
+  // TODO: implement
+}
+
+//==============================================================================
+void IngestItem::ActivePhase::cancel()
+{
+  // no op
+}
+
+//==============================================================================
+const std::string& IngestItem::ActivePhase::description() const
+{
+  return _description;
+}
+
+//==============================================================================
+IngestItem::ActivePhase::ActivePhase(
+  agv::RobotContextPtr context,
+  std::string request_guid,
+  std::string target,
+  std::string transporter_type,
+  std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> items)
+  : _context(std::move(context)),
+    _request_guid(std::move(request_guid)),
+    _target(std::move(target)),
+    _transporter_type(std::move(transporter_type)),
+    _items(std::move(items))
+{
+  std::ostringstream oss;
+  oss << "Ingest items (";
+  for (size_t i = 0; i < _items.size(); i++)
+  {
+    oss << _items[i].type_guid;
+    if (i < _items.size()-1)
+      oss << ", ";
+  }
+  oss << ")";
+
+  _description = oss.str();
+}
+
+//==============================================================================
+void IngestItem::ActivePhase::_init_obs()
+{
+  using rmf_ingestor_msgs::msg::IngestorResult;
+  using rmf_ingestor_msgs::msg::IngestorState;
+  using CombinedType = std::tuple<IngestorResult::SharedPtr, IngestorState::SharedPtr>;
+
+  const auto& node = _context->node();
+  _obs = node->ingestor_result()
+    .start_with(std::shared_ptr<IngestorResult>(nullptr))
+    .combine_latest(
+      rxcpp::observe_on_event_loop(),
+      node->ingestor_state().start_with(std::shared_ptr<IngestorState>(nullptr)))
+    .lift<CombinedType>(on_subscribe([weak = weak_from_this(), &node]()
+    {
+      auto me = weak.lock();
+      if (!me)
+        return;
+
+      me->_do_publish();
+      me->_timer = node->create_wall_timer(std::chrono::milliseconds(1000), [weak]()
+      {
+        auto me = weak.lock();
+        if (!me)
+          return;
+
+        me->_do_publish();
+      });
+    }))
+    .map([weak = weak_from_this()](const auto& v)
+    {
+      auto me = weak.lock();
+      if (!me)
+        return Task::StatusMsg();
+
+      return me->_get_status(std::get<0>(v), std::get<1>(v));
+    })
+    .lift<Task::StatusMsg>(grab_while_active())
+    .finally([weak = weak_from_this()]()
+    {
+      auto me = weak.lock();
+      if (!me)
+        return;
+
+      if (me->_timer)
+        me->_timer.reset();
+    });
+}
+
+//==============================================================================
+Task::StatusMsg IngestItem::ActivePhase::_get_status(
+  const rmf_ingestor_msgs::msg::IngestorResult::SharedPtr& ingestor_result,
+  const rmf_ingestor_msgs::msg::IngestorState::SharedPtr& ingestor_state)
+{
+  Task::StatusMsg status{};
+  status.state = Task::StatusMsg::STATE_ACTIVE;
+
+  using rmf_ingestor_msgs::msg::IngestorResult;
+  if (ingestor_result
+    && ingestor_result->request_guid == _request_guid
+    && is_newer(ingestor_result->time, _last_msg))
+  {
+    _last_msg = ingestor_result->time;
+    switch (ingestor_result->status)
+    {
+      case IngestorResult::ACKNOWLEDGED:
+        _request_acknowledged = true;
+        break;
+      case IngestorResult::SUCCESS:
+        status.state = Task::StatusMsg::STATE_COMPLETED;
+        break;
+      case IngestorResult::FAILED:
+        status.state = Task::StatusMsg::STATE_FAILED;
+        break;
+    }
+  }
+
+  if (ingestor_state
+    && ingestor_state->guid == _target
+    && is_newer(ingestor_state->time, _last_msg))
+  {
+    _last_msg = ingestor_state->time;
+    if (!_request_acknowledged)
+    {
+      _request_acknowledged = std::find(
+            ingestor_state->request_guid_queue.begin(),
+            ingestor_state->request_guid_queue.end(),
+            _request_guid) != ingestor_state->request_guid_queue.end();
+    }
+    else if (
+      std::find(
+        ingestor_state->request_guid_queue.begin(),
+        ingestor_state->request_guid_queue.end(),
+        _request_guid
+      ) == ingestor_state->request_guid_queue.end())
+    {
+      // The request has been received, so if it's no longer in the queue,
+      // then we'll assume it's finished.
+      status.state = Task::StatusMsg::STATE_COMPLETED;
+    }
+  }
+
+  return status;
+}
+
+//==============================================================================
+void IngestItem::ActivePhase::_do_publish()
+{
+  rmf_ingestor_msgs::msg::IngestorRequest msg{};
+  msg.request_guid = _request_guid;
+  msg.target_guid = _target;
+  msg.transporter_type = _transporter_type;
+  msg.items = _items;
+  _context->node()->ingestor_request()->publish(msg);
+}
+
+//==============================================================================
+IngestItem::PendingPhase::PendingPhase(
+  agv::RobotContextPtr context,
+  std::string request_guid,
+  std::string target,
+  std::string transporter_type,
+  std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> items)
+  : _context(std::move(context)),
+    _request_guid(std::move(request_guid)),
+    _target(std::move(target)),
+    _transporter_type(std::move(transporter_type)),
+    _items(std::move(items))
+{
+  std::ostringstream oss;
+  oss << "Ingest items (";
+  for (size_t i = 0; i < _items.size(); i++)
+  {
+    oss << _items[i].type_guid;
+    if (i < _items.size()-1)
+      oss << ", ";
+  }
+  oss << ")";
+
+  _description = oss.str();
+}
+
+//==============================================================================
+std::shared_ptr<Task::ActivePhase> IngestItem::PendingPhase::begin()
+{
+  return IngestItem::ActivePhase::make(
+    _context,
+    _request_guid,
+    _target,
+    _transporter_type,
+    _items);
+}
+
+//==============================================================================
+rmf_traffic::Duration IngestItem::PendingPhase::estimate_phase_duration() const
+{
+  // TODO: implement
+  return rmf_traffic::Duration{0};
+}
+
+//==============================================================================
+const std::string& IngestItem::PendingPhase::description() const
+{
+  return _description;
+}
+
+} // namespace phases
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/IngestItem.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/IngestItem.hpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__PHASES__INGESTITEM_HPP
+#define SRC__RMF_FLEET_ADAPTER__PHASES__INGESTITEM_HPP
+
+#include "RxOperators.hpp"
+#include "../Task.hpp"
+#include "../agv/RobotContext.hpp"
+#include "rmf_fleet_adapter/StandardNames.hpp"
+
+#include <rmf_rxcpp/Transport.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_state.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_result.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_request.hpp>
+
+namespace rmf_fleet_adapter {
+namespace phases {
+
+struct IngestItem
+{
+  class ActivePhase : public Task::ActivePhase, public std::enable_shared_from_this<ActivePhase>
+  {
+  public:
+
+    static std::shared_ptr<ActivePhase> make(
+      agv::RobotContextPtr context,
+      std::string request_guid,
+      std::string target,
+      std::string transporter_type,
+      std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> items);
+
+    const rxcpp::observable<Task::StatusMsg>& observe() const override;
+
+    rmf_traffic::Duration estimate_remaining_time() const override;
+
+    void emergency_alarm(bool on) override;
+
+    void cancel() override;
+
+    const std::string& description() const override;
+
+  private:
+
+    agv::RobotContextPtr _context;
+    std::string _request_guid;
+    std::string _target;
+    std::string _transporter_type;
+    std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> _items;
+    std::string _description;
+    rxcpp::observable<Task::StatusMsg> _obs;
+    rclcpp::TimerBase::SharedPtr _timer;
+    bool _request_acknowledged = false;
+    builtin_interfaces::msg::Time _last_msg;
+
+    ActivePhase(
+      agv::RobotContextPtr context,
+      std::string request_guid,
+      std::string target,
+      std::string transporter_type,
+      std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> items);
+
+    void _init_obs();
+
+    Task::StatusMsg _get_status(
+      const rmf_ingestor_msgs::msg::IngestorResult::SharedPtr& ingestor_result,
+      const rmf_ingestor_msgs::msg::IngestorState::SharedPtr& ingestor_state);
+
+    void _do_publish();
+  };
+
+  class PendingPhase : public Task::PendingPhase
+  {
+  public:
+
+    PendingPhase(
+      agv::RobotContextPtr context,
+      std::string request_guid,
+      std::string target,
+      std::string transporter_type,
+      std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> items);
+
+    std::shared_ptr<Task::ActivePhase> begin() override;
+
+    rmf_traffic::Duration estimate_phase_duration() const override;
+
+    const std::string& description() const override;
+
+  private:
+
+    agv::RobotContextPtr _context;
+    std::string _request_guid;
+    std::string _target;
+    std::string _transporter_type;
+    std::vector<rmf_ingestor_msgs::msg::IngestorRequestItem> _items;
+    std::string _description;
+  };
+};
+
+} // namespace phases
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__PHASES__INGESTITEM_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/Utils.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/Utils.cpp
@@ -15,17 +15,18 @@
  *
 */
 
-#ifndef SRC__RMF_FLEET_ADAPTER__PHASES__UTILS_HPP
-#define SRC__RMF_FLEET_ADAPTER__PHASES__UTILS_HPP
-
-#include <builtin_interfaces/msg/time.hpp>
+#include "Utils.hpp"
 
 namespace rmf_fleet_adapter {
 namespace phases {
 
-bool is_newer(const builtin_interfaces::msg::Time& a, const builtin_interfaces::msg::Time& b);
+bool is_newer(const builtin_interfaces::msg::Time& a, const builtin_interfaces::msg::Time& b)
+{
+  return a.sec > b.sec || (a.sec == b.sec && a.nanosec > b.nanosec);
+}
 
 } // namespace phases
 } // namespace rmf_fleet_adapter
 
-#endif // SRC__RMF_FLEET_ADAPTER__PHASES__UTILS_HPP
+
+

--- a/rmf_fleet_adapter/test/phases/IngestItemTest.cpp
+++ b/rmf_fleet_adapter/test/phases/IngestItemTest.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "MockAdapterFixture.hpp"
+
+#include <phases/IngestItem.hpp>
+#include <rmf_fleet_adapter/StandardNames.hpp>
+#include <rmf_utils/catch.hpp>
+
+namespace rmf_fleet_adapter {
+namespace phases {
+namespace test {
+
+using rmf_ingestor_msgs::msg::IngestorResult;
+using rmf_ingestor_msgs::msg::IngestorRequest;
+using rmf_ingestor_msgs::msg::IngestorRequestItem;
+using rmf_ingestor_msgs::msg::IngestorState;
+
+SCENARIO_METHOD(MockAdapterFixture, "ingest item phase", "[phases]")
+{
+  std::mutex m;
+  std::condition_variable received_requests_cv;
+  std::list<IngestorRequest> received_requests;
+  auto rcl_subscription = adapter->node()->create_subscription<IngestorRequest>(
+    IngestorRequestTopicName,
+    10,
+    [&](IngestorRequest::UniquePtr ingestor_request)
+    {
+      std::unique_lock<std::mutex> lk(m);
+      received_requests.emplace_back(*ingestor_request);
+      received_requests_cv.notify_all();
+    });
+
+  std::string request_guid = "test_guid";
+  std::string target = "test_ingestor";
+  std::string transporter_type = "test_type";
+  std::vector<IngestorRequestItem> items;
+  IngestorRequestItem item;
+  item.type_guid = "test_item_type";
+  item.compartment_name = "test_compartment";
+  item.quantity = 1;
+  items.emplace_back(std::move(item));
+
+
+  const auto info = add_robot();
+  const auto& context = info.context;
+
+  auto dispenser_request_pub = adapter->node()->create_publisher<IngestorRequest>(
+    IngestorRequestTopicName, 10);
+  auto pending_phase = std::make_shared<IngestItem::PendingPhase>(
+    context,
+    request_guid,
+    target,
+    transporter_type,
+    items
+  );
+  auto active_phase = pending_phase->begin();
+
+  WHEN("it is started")
+  {
+    std::condition_variable status_updates_cv;
+    std::list<Task::StatusMsg> status_updates;
+    auto sub = active_phase->observe().subscribe(
+      [&](const auto& status)
+      {
+        std::unique_lock<std::mutex> lk(m);
+        status_updates.emplace_back(status);
+        status_updates_cv.notify_all();
+      });
+
+    THEN("it should send ingest item request")
+    {
+      std::unique_lock<std::mutex> lk(m);
+      if (received_requests.empty())
+        received_requests_cv.wait(lk, [&]() { return !received_requests.empty(); });
+      REQUIRE(received_requests.size() == 1);
+    }
+
+    THEN("it should continuously send ingest item request")
+    {
+      std::unique_lock<std::mutex> lk(m);
+      received_requests_cv.wait(lk, [&]() { return received_requests.size() >= 3; });
+    }
+
+    THEN("cancelled, it should not do anything")
+    {
+      active_phase->cancel();
+      std::unique_lock<std::mutex> lk(m);
+
+      bool completed = status_updates_cv.wait_for(lk, std::chrono::seconds(3), [&]()
+      {
+        for (const auto& status : status_updates)
+        {
+          if (status.state == Task::StatusMsg::STATE_COMPLETED)
+            return true;
+        }
+        status_updates.clear();
+        return false;
+      });
+      CHECK(!completed);
+    }
+
+    AND_WHEN("ingestor result is success")
+    {
+      auto result_pub = ros_node->create_publisher<IngestorResult>(IngestorResultTopicName, 10);
+      auto state_pub = ros_node->create_publisher<IngestorState>(IngestorStateTopicName, 10);
+      auto timer = ros_node->create_wall_timer(std::chrono::milliseconds(100), [&]()
+      {
+        std::unique_lock<std::mutex> lk(m);
+        IngestorResult result;
+        result.request_guid = request_guid;
+        result.status = IngestorResult::SUCCESS;
+        result.time = ros_node->now();
+        result_pub->publish(result);
+
+        IngestorState state;
+        state.guid = request_guid;
+        state.mode = IngestorState::IDLE;
+        state.time = ros_node->now();
+        state_pub->publish(state);
+      });
+
+      THEN("it is completed")
+      {
+        std::unique_lock<std::mutex> lk(m);
+        bool completed = status_updates_cv.wait_for(lk, std::chrono::milliseconds(1000), [&]()
+        {
+          return status_updates.back().state == Task::StatusMsg::STATE_COMPLETED;
+        });
+        CHECK(completed);
+      }
+
+      timer.reset();
+    }
+
+    AND_WHEN("ingestor result is failed")
+    {
+      auto result_pub = ros_node->create_publisher<IngestorResult>(IngestorResultTopicName, 10);
+      auto state_pub = ros_node->create_publisher<IngestorState>(IngestorStateTopicName, 10);
+      auto timer = ros_node->create_wall_timer(std::chrono::milliseconds(100), [&]()
+      {
+        std::unique_lock<std::mutex> lk(m);
+        IngestorResult result;
+        result.request_guid = request_guid;
+        result.status = IngestorResult::FAILED;
+        result.time = ros_node->now();
+        result_pub->publish(result);
+
+        IngestorState state;
+        state.guid = request_guid;
+        state.mode = IngestorState::IDLE;
+        state.time = ros_node->now();
+        state_pub->publish(state);
+      });
+
+      THEN("it is failed")
+      {
+        std::unique_lock<std::mutex> lk(m);
+        bool failed = status_updates_cv.wait_for(lk, std::chrono::milliseconds(1000), [&]()
+        {
+          return status_updates.back().state == Task::StatusMsg::STATE_FAILED;
+        });
+        CHECK(failed);
+      }
+
+      timer.reset();
+    }
+
+    AND_WHEN("request is acknowledged and request is no longer in queue")
+    {
+      auto result_pub = ros_node->create_publisher<IngestorResult>(IngestorResultTopicName, 10);
+      auto state_pub = ros_node->create_publisher<IngestorState>(IngestorStateTopicName, 10);
+      auto interval = rxcpp::observable<>::interval(std::chrono::milliseconds(100))
+        .subscribe_on(rxcpp::observe_on_new_thread())
+        .subscribe([&](const auto&)
+        {
+          IngestorResult result;
+          result.request_guid = request_guid;
+          result.status = IngestorResult::ACKNOWLEDGED;
+          result.time = ros_node->now();
+          result_pub->publish(result);
+
+          IngestorState state;
+          state.time = ros_node->now();
+          state.guid = target;
+          state.mode = IngestorState::BUSY;
+          state_pub->publish(state);
+        });
+
+      THEN("it is completed")
+      {
+        std::unique_lock<std::mutex> lk(m);
+        bool completed = status_updates_cv.wait_for(lk, std::chrono::milliseconds(1000), [&]()
+        {
+          return status_updates.back().state == Task::StatusMsg::STATE_COMPLETED;
+        });
+        CHECK(completed);
+      }
+
+      interval.unsubscribe();
+    }
+
+    AND_WHEN("request acknowledged result arrives before request state in queue")
+    {
+      auto result_pub = ros_node->create_publisher<IngestorResult>(IngestorResultTopicName, 10);
+      auto state_pub = ros_node->create_publisher<IngestorState>(IngestorStateTopicName, 10);
+      auto interval = rxcpp::observable<>::interval(std::chrono::milliseconds(100))
+        .subscribe_on(rxcpp::observe_on_new_thread())
+        .subscribe([&](const auto&)
+        {
+          IngestorResult result;
+          result.request_guid = request_guid;
+          result.status = IngestorResult::ACKNOWLEDGED;
+          result.time = ros_node->now();
+          result_pub->publish(result);
+
+          IngestorState state;
+          // simulate state arriving late
+          state.time.sec = 0;
+          state.time.nanosec = 0;
+          state.guid = target;
+          state.mode = IngestorState::BUSY;
+          state_pub->publish(state);
+        });
+
+      THEN("it is not completed")
+      {
+        std::unique_lock<std::mutex> lk(m);
+        bool completed = status_updates_cv.wait_for(lk, std::chrono::milliseconds(1000), [&]()
+        {
+          return status_updates.back().state == Task::StatusMsg::STATE_COMPLETED;
+        });
+        CHECK(!completed);
+      }
+
+      interval.unsubscribe();
+    }
+
+    sub.unsubscribe();
+  }
+}
+
+} // namespace test
+} // namespace phases
+} // namespace rmf_fleet_adapter

--- a/rmf_ingestor_msgs/CHANGELOG.rst
+++ b/rmf_ingestor_msgs/CHANGELOG.rst
@@ -1,0 +1,11 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rmf_ingestor_msgs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+
+1.0.0 (2020-09-XX)
+------------------
+* Initial set of messages for interfacing with ingestors over ROS2
+* Contributors: Aaron Chong, Grey, Morgan Quigley, Rushyendra Maganty

--- a/rmf_ingestor_msgs/CMakeLists.txt
+++ b/rmf_ingestor_msgs/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rmf_ingestor_msgs)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set(msg_files
+  "msg/IngestorRequest.msg"
+  "msg/IngestorRequestItem.msg"
+  "msg/IngestorResult.msg"
+  "msg/IngestorState.msg"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${msg_files}
+  ${srv_files}
+  DEPENDENCIES
+    builtin_interfaces
+    geometry_msgs
+  ADD_LINTER_TESTS
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+ament_package()

--- a/rmf_ingestor_msgs/msg/IngestorRequest.msg
+++ b/rmf_ingestor_msgs/msg/IngestorRequest.msg
@@ -1,0 +1,11 @@
+builtin_interfaces/Time time
+
+# A unique ID for this request
+string request_guid
+
+# The unique name of the ingestor that this request is aimed at
+string target_guid
+
+# below are custom workcell message fields
+string transporter_type
+IngestorRequestItem[] items

--- a/rmf_ingestor_msgs/msg/IngestorRequestItem.msg
+++ b/rmf_ingestor_msgs/msg/IngestorRequestItem.msg
@@ -1,0 +1,3 @@
+string type_guid
+int32 quantity
+string compartment_name

--- a/rmf_ingestor_msgs/msg/IngestorResult.msg
+++ b/rmf_ingestor_msgs/msg/IngestorResult.msg
@@ -1,0 +1,15 @@
+builtin_interfaces/Time time
+
+# A unique ID for the request which this result is for
+string request_guid
+
+# The unique ID of the workcell that this result was sent from
+string source_guid
+
+# Different basic result statuses
+uint8 status
+uint8 ACKNOWLEDGED=0
+uint8 SUCCESS=1
+uint8 FAILED=2
+
+# below are custom workcell message fields

--- a/rmf_ingestor_msgs/msg/IngestorState.msg
+++ b/rmf_ingestor_msgs/msg/IngestorState.msg
@@ -1,0 +1,16 @@
+builtin_interfaces/Time time
+
+# A unique ID for this workcell
+string guid
+
+# Different basic modes that the workcell could be in
+int32 mode
+int32 IDLE=0
+int32 BUSY=1
+int32 OFFLINE=2
+
+# Queued up requests that are being handled by this workcell
+string[] request_guid_queue
+
+# below are custom workcell message fields
+float32 seconds_remaining

--- a/rmf_ingestor_msgs/package.xml
+++ b/rmf_ingestor_msgs/package.xml
@@ -4,7 +4,7 @@
   <name>rmf_ingestor_msgs</name>
   <version>1.0.0</version>
   <description>A package containing messages used to interface to ingestor workcells</description>
-  <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
+  <maintainer email="rushy_maganty@openrobotics.org">Rushyendra Maganty</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/rmf_ingestor_msgs/package.xml
+++ b/rmf_ingestor_msgs/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rmf_ingestor_msgs</name>
+  <version>1.0.0</version>
+  <description>A package containing messages used to interface to ingestor workcells</description>
+  <maintainer email="morgan@openrobotics.org">Morgan Quigley</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>rmf_dispenser_msgs</build_depend>
+
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>rmf_dispenser_msgs</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+

--- a/rmf_task_msgs/msg/Delivery.msg
+++ b/rmf_task_msgs/msg/Delivery.msg
@@ -10,5 +10,5 @@ string pickup_dispenser
 Behavior pickup_behavior
 
 string dropoff_place_name
-string dropoff_dispenser
+string dropoff_ingestor
 Behavior dropoff_behavior


### PR DESCRIPTION
- Split the existing Dispensers into Dispensers and Ingestors. Ingestors will handle the taking in of objects delivered to them.
- Added a new set of messages for the Ingestors, which mimics the existing Dispenser messages.
- Modified the Delivery task to make use of the Ingestors.
- Added unit tests for the Ingestor and modified the existing Delivery test to use a flaky Ingestor 
instead of a flaky Dispenser.

Initially considered refactoring the `IngestItem` and `DispenseItem` structs into a common `HandleItem` template struct, but it was not very extensible or modifiable, did not shorten the code by much, and also added a lot of complexity.