### PR TITLE
Fix exit events so they do not get optimized away

### DIFF
--- a/rmf_traffic/CHANGELOG.rst
+++ b/rmf_traffic/CHANGELOG.rst
@@ -11,6 +11,7 @@ Forthcoming
 * Improve heuristic to account for events: [#159](https://github.com/osrf/rmf_core/pull/159/)
 * Fix an issue with moving robots between floors: [#163](https://github.com/osrf/rmf_core/pull/163/)
 * Add a generic waiting event: [#158](https://github.com/osrf/rmf_core/pull/158)
+* Fix bug that caused exit events to get skipped sometimes: [#166](https://github.com/osrf/rmf_core/pull/166)
 
 1.0.2 (2020-07-27)
 ------------------

--- a/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/internal_planning.cpp
@@ -744,18 +744,18 @@ struct DifferentialDriveExpander
         std::move(_event));
     }
 
-    LaneEventExecutor& add_if_valid(
+    LaneEventExecutor& add_exit_if_valid(
       DifferentialDriveExpander* expander,
       SearchQueue& queue)
     {
       assert(_event);
       const auto duration = _event->duration();
+      _parent->event = std::move(_event);
       expander->expand_delay(
         *_parent->waypoint,
         _parent,
         duration,
-        queue,
-        std::move(_event));
+        queue);
       return *this;
     }
 
@@ -1478,7 +1478,7 @@ struct DifferentialDriveExpander
         }
 
         event->execute(_executor.update(parent_to_event))
-          .add_if_valid(this, queue);
+          .add_exit_if_valid(this, queue);
 
         continue;
       }

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -1842,7 +1842,7 @@ public:
     _result = _expectation == Dock;
   }
 
-  void execute(const Lane::Wait& wait) final
+  void execute(const Lane::Wait&) final
   {
     _result = _expectation == Wait;
   }


### PR DESCRIPTION
Some upcoming unit tests revealed that exit events were sometimes being accidentally "optimized" away in the post-processing of the plan. This was likely causing doors to dangle open and perhaps could result in other issues in the future.

This PR should fix that problem and ensure that exit events are respected.