### PR TITLE
Add first pass of quality declarations for all packages

### DIFF
--- a/ament_cmake_catch2/QUALITY_DECLARATION.md
+++ b/ament_cmake_catch2/QUALITY_DECLARATION.md
@@ -1,0 +1,127 @@
+This document is a declaration of software quality for the `ament_cmake_catch2` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `ament_cmake_catch2` Quality Declaration
+
+The package `ament_cmake_catch2` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`ament_cmake_catch2` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`ament_cmake_catch2` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+The CMake macros provided in the `cmake` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`ament_cmake_catch2` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`ament_cmake_catch2` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`ament_cmake_catch2` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`ament_cmake_catch2` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`ament_cmake_catch2` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`ament_cmake_catch2` has documentation for each CMake macro in the macro definition file.
+A usage guide is provided in the `doc` directory.
+
+### Public API Documentation [3.ii]
+
+`ament_cmake_catch2` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `ament_cmake_catch2` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+The CMake files contain copyright headers, although this is not automatically verified using linters.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `ament_cmake_catch2`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`ament_cmake_catch2` is a package providing strictly CMake macros and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`ament_cmake_catch2` is a package providing strictly CMake macros and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`ament_cmake_catch2` is a package providing strictly CMake macros and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`ament_cmake_catch2` is a package providing strictly CMake macros and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`ament_cmake_catch2` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`ament_cmake_catch2` has no required runtime dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`ament_cmake_catch2` has no optional runtime dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`ament_cmake_catch2` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure CMake package, `ament_cmake_catch2` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/ament_cmake_catch2/README.md
+++ b/ament_cmake_catch2/README.md
@@ -1,0 +1,7 @@
+# ament_cmake_catch2
+
+`ament_cmake_catch2` provides CMake macros for adding tests written using [Catch2](https://github.com/catchorg/Catch2).
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/ament_cmake_catch2/doc/usage.md
+++ b/ament_cmake_catch2/doc/usage.md
@@ -1,4 +1,3 @@
-
 ## Usage
 
 To use this package do the following things.

--- a/rmf_cmake_uncrustify/QUALITY_DECLARATION.md
+++ b/rmf_cmake_uncrustify/QUALITY_DECLARATION.md
@@ -1,0 +1,127 @@
+This document is a declaration of software quality for the `rmf_cmake_uncrustify` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_cmake_uncrustify` Quality Declaration
+
+The package `rmf_cmake_uncrustify` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_cmake_uncrustify` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_cmake_uncrustify` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+The CMake macros provided in the `cmake` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_cmake_uncrustify` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_cmake_uncrustify` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_cmake_uncrustify` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_cmake_uncrustify` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_cmake_uncrustify` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_cmake_uncrustify` has documentation for each CMake macro in the macro definition file.
+A usage guide is provided in the `doc` directory.
+
+### Public API Documentation [3.ii]
+
+`rmf_cmake_uncrustify` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_cmake_uncrustify` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+The CMake files contain copyright headers, although this is not automatically verified using linters.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_cmake_uncrustify`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_cmake_uncrustify` is a package providing strictly CMake macros and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_cmake_uncrustify` is a package providing strictly CMake macros and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_cmake_uncrustify` is a package providing strictly CMake macros and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_cmake_uncrustify` is a package providing strictly CMake macros and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_cmake_uncrustify` uses the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_cmake_uncrustify` has no required runtime dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_cmake_uncrustify` has no optional runtime dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_cmake_uncrustify` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure CMake package, `rmf_cmake_uncrustify` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_cmake_uncrustify/README.md
+++ b/rmf_cmake_uncrustify/README.md
@@ -1,0 +1,7 @@
+# rmf_cmake_uncrustify
+
+`rmf_cmake_uncrustify` provides `ament_cmake_uncrustify` with support for parsing a config file.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_dispenser_msgs/QUALITY_DECLARATION.md
+++ b/rmf_dispenser_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_dispenser_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_dispenser_msgs` Quality Declaration
+
+The package `rmf_dispenser_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_dispenser_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_dispenser_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_dispenser_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_dispenser_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_dispenser_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_dispenser_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_dispenser_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_dispenser_msgs` has basic comments in the message definition files, but no list of messages or usage guide is provided.
+New messages require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`rmf_dispenser_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_dispenser_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_dispenser_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_dispenser_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_dispenser_msgs` is a package providing strictly message definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_dispenser_msgs` is a package providing strictly message definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_dispenser_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_dispenser_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_dispenser_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_dispenser_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message definitions package, `rmf_dispenser_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_dispenser_msgs/README.md
+++ b/rmf_dispenser_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf_dispenser_msgs
+
+`rmf_dispenser_msgs` provides message types for interacting with dispensers.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_door_msgs/QUALITY_DECLARATION.md
+++ b/rmf_door_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_door_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_door_msgs` Quality Declaration
+
+The package `rmf_door_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_door_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_door_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_door_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_door_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_door_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_door_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_door_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_door_msgs` has basic comments in the message definition files, but no list of messages or usage guide is provided.
+New messages require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`rmf_door_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_door_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_door_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_door_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_door_msgs` is a package providing strictly message definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_door_msgs` is a package providing strictly message definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_door_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_door_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_door_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_door_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message definitions package, `rmf_door_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_door_msgs/README.md
+++ b/rmf_door_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf_door_msgs
+
+`rmf_door_msgs` provides message types for interacting with doors.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_fleet_adapter/QUALITY_DECLARATION.md
+++ b/rmf_fleet_adapter/QUALITY_DECLARATION.md
@@ -1,0 +1,187 @@
+This document is a declaration of software quality for the `rmf_fleet_adapter` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_fleet_adapter` Quality Declaration
+
+The package `rmf_fleet_adapter` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_fleet_adapter` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_fleet_adapter` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package.
+Headers in any other folders are not installed and are considered private.
+
+All launch files in the installed `launch` directory are considered part of the public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_fleet_adapter` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`rmf_fleet_adapter` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_fleet_adapter` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`rmf_fleet_adapter` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_fleet_adapter` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_fleet_adapter` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_core/actions?query=workflow%3Abuild+branch%3Amaster).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_fleet_adapter` does not provide documentation.
+
+### Public API Documentation [3.ii]
+
+`rmf_fleet_adapter` documents its public API.
+The documentation is not hosted.
+
+### License [3.iii]
+
+The license for `rmf_fleet_adapter` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_fleet_adapter`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+Each feature in `rmf_fleet_adapter` has corresponding tests which simulate typical usage.
+They are located in the [`test`](https://github.com/osrf/rmf_core/tree/master/rmf_fleet_adapter/test) directory.
+New features are required to have tests before being added.
+
+### Public API Testing [4.ii]
+
+Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
+The tests are not run automatically.
+They are located in the [`test`](https://github.com/osrf/rmf_core/tree/master/rmf_fleet_adapter/test) directory.
+
+### Coverage [4.iii]
+
+`rmf_fleet_adapter` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rmf_fleet_adapter` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_fleet_adapter` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+`rmf_fleet_adapter` uses a custom `uncrustify` configuration matching its coding style.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+Below are the required direct runtime ROS dependencies of `rmf_fleet_adapter` and their evaluations.
+
+#### rmf_utils
+
+`rmf_utils` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_utils/QUALITY_DECLARATION.md).
+
+#### rmf_door_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_door_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_ingestor_msgs
+
+`rmf_ingestor_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_ingestor_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_dispenser_msgs
+
+`rmf_dispenser_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_dispenser_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_fleet_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_lift_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_lift_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_task_msgs
+
+`rmf_task_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_task_msgs/QUALITY_DECLARATION.md).
+
+#### rmf_traffic
+
+`rmf_traffic` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic/QUALITY_DECLARATION.md).
+
+#### rmf_traffic_ros2
+
+`rmf_traffic_ros2` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic_ros2/QUALITY_DECLARATION.md).
+
+#### rmf_traffic_msgs
+
+`rmf_traffic_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic_msgs/QUALITY_DECLARATION.md).
+
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_fleet_adapter` has no optional runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_fleet_adapter` uses the [`yaml-cpp` library](https://github.com/jbeder/yaml-cpp).
+This is assumed to be **Quality Level 3** due to its wide use, provided documentation, use of testing, and version number above 1.0.0.
+
+## Platform Support [6]
+
+### Target platforms [6.i]
+
+`rmf_fleet_adapter` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_fleet_adapter` supports ROS Eloquent.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_fleet_adapter/README.md
+++ b/rmf_fleet_adapter/README.md
@@ -1,3 +1,8 @@
 # rmf\_fleet\_adapter package
 
-This package contains the various fleet adapter nodes for different levels of control. Using specific messages from `rmf_fleet_msgs`, it communicates with proprietary fleet drivers and managers through ROS2.
+This package contains the various fleet adapter nodes for different levels of control.
+Using specific messages from `rmf_fleet_msgs`, it communicates with proprietary fleet drivers and managers through ROS2.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_fleet_msgs/QUALITY_DECLARATION.md
+++ b/rmf_fleet_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_fleet_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_fleet_msgs` Quality Declaration
+
+The package `rmf_fleet_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_fleet_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_fleet_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_fleet_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_fleet_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_fleet_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_fleet_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_fleet_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_fleet_msgs` has basic comments in the message definition files, but no list of messages or usage guide is provided.
+New messages require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`rmf_fleet_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_fleet_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_fleet_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_fleet_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_fleet_msgs` is a package providing strictly message definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_fleet_msgs` is a package providing strictly message definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_fleet_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_fleet_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_fleet_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_fleet_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message definitions package, `rmf_fleet_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_fleet_msgs/README.md
+++ b/rmf_fleet_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf_fleet_msgs
+
+`rmf_fleet_msgs` provides message types for interacting with robot fleet adapters.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_ingestor_msgs/QUALITY_DECLARATION.md
+++ b/rmf_ingestor_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_ingestor_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_ingestor_msgs` Quality Declaration
+
+The package `rmf_ingestor_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_ingestor_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_ingestor_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_ingestor_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_ingestor_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_ingestor_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_ingestor_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_ingestor_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_ingestor_msgs` has basic comments in the message definition files, but no list of messages or usage guide is provided.
+New messages require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`rmf_ingestor_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_ingestor_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_ingestor_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_ingestor_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_ingestor_msgs` is a package providing strictly message definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_ingestor_msgs` is a package providing strictly message definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_ingestor_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_ingestor_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_ingestor_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_ingestor_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message definitions package, `rmf_ingestor_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_ingestor_msgs/README.md
+++ b/rmf_ingestor_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf_ingestor_msgs
+
+`rmf_ingestor_msgs` provides message types for interacting with ingestors.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_lift_msgs/QUALITY_DECLARATION.md
+++ b/rmf_lift_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_lift_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_lift_msgs` Quality Declaration
+
+The package `rmf_lift_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_lift_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_lift_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_lift_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_lift_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_lift_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_lift_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_lift_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_lift_msgs` has basic comments in the message definition files, but no list of messages or usage guide is provided.
+New messages require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`rmf_lift_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_lift_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_lift_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_lift_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_lift_msgs` is a package providing strictly message definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_lift_msgs` is a package providing strictly message definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_lift_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_lift_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_lift_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_lift_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message definitions package, `rmf_lift_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_lift_msgs/README.md
+++ b/rmf_lift_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf_lift_msgs
+
+`rmf_lift_msgs` provides message types for interacting with lifts.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_task_msgs/QUALITY_DECLARATION.md
+++ b/rmf_task_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_task_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_task_msgs` Quality Declaration
+
+The package `rmf_task_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_task_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_task_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_task_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_task_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_task_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_task_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_task_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_task_msgs` has basic comments in the message definition files, but no list of messages or usage guide is provided.
+New messages require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`rmf_task_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_task_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_task_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_task_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_task_msgs` is a package providing strictly message definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_task_msgs` is a package providing strictly message definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_task_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_task_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_task_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_task_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message definitions package, `rmf_task_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_task_msgs/README.md
+++ b/rmf_task_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf_task_msgs
+
+`rmf_task_msgs` provides message types for communicating task information.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_traffic/QUALITY_DECLARATION.md
+++ b/rmf_traffic/QUALITY_DECLARATION.md
@@ -1,0 +1,159 @@
+This document is a declaration of software quality for the `rmf_traffic` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_traffic` Quality Declaration
+
+The package `rmf_traffic` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_traffic` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_traffic` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package.
+Headers in any other folders are not installed and are considered private.
+
+All launch files in the installed `launch` directory are considered part of the public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_traffic` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`rmf_traffic` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_traffic` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`rmf_traffic` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_traffic` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_traffic` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_core/actions?query=workflow%3Abuild+branch%3Amaster).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_traffic` does not provide documentation.
+
+### Public API Documentation [3.ii]
+
+`rmf_traffic` documents its public API.
+The documentation is not hosted.
+
+### License [3.iii]
+
+The license for `rmf_traffic` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_traffic`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+Each feature in `rmf_traffic` has corresponding tests which simulate typical usage.
+They are located in the [`test`](https://github.com/osrf/rmf_core/tree/master/rmf_traffic/test) directory.
+New features are required to have tests before being added.
+
+### Public API Testing [4.ii]
+
+Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
+The tests are not run automatically.
+They are located in the [`test`](https://github.com/osrf/rmf_core/tree/master/rmf_traffic/test) directory.
+
+### Coverage [4.iii]
+
+`rmf_traffic` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rmf_traffic` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_traffic` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+`rmf_traffic` uses a custom `uncrustify` configuration matching its coding style.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+Below are the required direct runtime ROS dependencies of `rmf_traffic` and their evaluations.
+
+#### rmf_utils
+
+`rmf_utils` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_utils/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_traffic` has no optional runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+Below are the required direct runtime non-ROS dependencies of `rmf_traffic` and their evaluations.
+
+#### libccd-dev
+
+`rmf_traffic` uses the [`libccd` library](https://github.com/danfis/libccd).
+This is assumed to be **Quality Level 3** due to its provided documentation, use of testing, and version number above 1.0.0.
+
+#### libfcl-dev
+
+`rmf_traffic` uses [`fcl` (the Flexible Collision Library)](https://github.com/flexible-collision-library/fcl).
+This is assumed to be **Quality Level 3** due to its provided feature documentation, use of testing, and version number above 1.0.0.
+
+## Platform Support [6]
+
+### Target platforms [6.i]
+
+`rmf_traffic` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_traffic` supports ROS Eloquent.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_traffic/QUALITY_DECLARATION.md
+++ b/rmf_traffic/QUALITY_DECLARATION.md
@@ -135,6 +135,10 @@ Below are the required direct runtime ROS dependencies of `rmf_traffic` and thei
 
 Below are the required direct runtime non-ROS dependencies of `rmf_traffic` and their evaluations.
 
+#### eigen
+
+`eigen` is taken to be **Quality Level 3** due to its wide-spread use, history, use of CI, and use of testing.
+
 #### libccd-dev
 
 `rmf_traffic` uses the [`libccd` library](https://github.com/danfis/libccd).

--- a/rmf_traffic/README.md
+++ b/rmf_traffic/README.md
@@ -1,0 +1,7 @@
+# rmf\_traffic package
+
+This package provides functionality for managing traffic in the Robotics Middleware Framework.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_traffic_msgs/QUALITY_DECLARATION.md
+++ b/rmf_traffic_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_traffic_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_traffic_msgs` Quality Declaration
+
+The package `rmf_traffic_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_traffic_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_traffic_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory and service definition files located in the `srv` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_traffic_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_traffic_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_traffic_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_traffic_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_traffic_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_traffic_msgs` has basic comments in the message and service definition files, but no list of messages, services, or usage guide is provided.
+New messages and services require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`rmf_traffic_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_traffic_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_traffic_msgs` is a package providing strictly message and service definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_traffic_msgs` is a package providing strictly message and service definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_traffic_msgs` is a package providing strictly message and service definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_traffic_msgs` is a package providing strictly message and service definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_traffic_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_traffic_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_traffic_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_traffic_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message and service definitions package, `rmf_traffic_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_traffic_msgs/README.md
+++ b/rmf_traffic_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf_traffic_msgs
+
+`rmf_traffic_msgs` provides message types for managing and communicating traffic plans.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_traffic_ros2/QUALITY_DECLARATION.md
+++ b/rmf_traffic_ros2/QUALITY_DECLARATION.md
@@ -1,0 +1,165 @@
+This document is a declaration of software quality for the `rmf_traffic_ros2` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_traffic_ros2` Quality Declaration
+
+The package `rmf_traffic_ros2` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_traffic_ros2` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_traffic_ros2` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package.
+Headers in any other folders are not installed and are considered private.
+
+All launch files in the installed `launch` directory are considered part of the public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_traffic_ros2` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`rmf_traffic_ros2` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_traffic_ros2` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`rmf_traffic_ros2` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_traffic_ros2` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_traffic_ros2` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_core/actions?query=workflow%3Abuild+branch%3Amaster).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_traffic_ros2` does not provide documentation.
+
+### Public API Documentation [3.ii]
+
+`rmf_traffic_ros2` documents its public API.
+The documentation is not hosted.
+
+### License [3.iii]
+
+The license for `rmf_traffic_ros2` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_traffic_ros2`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+Each feature in `rmf_traffic_ros2` has corresponding tests which simulate typical usage.
+They are located in the [`test`](https://github.com/osrf/rmf_core/tree/master/rmf_traffic_ros2/test) directory.
+New features are required to have tests before being added.
+
+### Public API Testing [4.ii]
+
+Each part of the public API has tests, and new additions or changes to the public API require tests before being added.
+The tests are not run automatically.
+They are located in the [`test`](https://github.com/osrf/rmf_core/tree/master/rmf_traffic_ros2/test) directory.
+
+### Coverage [4.iii]
+
+`rmf_traffic_ros2` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rmf_traffic_ros2` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_traffic_ros2` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+`rmf_traffic_ros2` uses a custom `uncrustify` configuration matching its coding style.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+Below are the required direct runtime ROS dependencies of `rmf_traffic_ros2` and their evaluations.
+
+#### rmf\_utils
+
+`rmf_utils` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_utils/QUALITY_DECLARATION.md).
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_traffic
+
+`rmf_traffic` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic/QUALITY_DECLARATION.md).
+
+#### rmf\_traffic\_msgs
+
+`rmf_traffic_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic_msgs/QUALITY_DECLARATION.md).
+
+#### rclcpp
+
+`rclcpp` is [**Quality Level 3**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_traffic_ros2` has no optional runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_traffic_ros2` has no direct runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+### Target platforms [6.i]
+
+`rmf_traffic_ros2` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_traffic_ros2` supports ROS Eloquent.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_traffic_ros2/QUALITY_DECLARATION.md
+++ b/rmf_traffic_ros2/QUALITY_DECLARATION.md
@@ -149,7 +149,11 @@ Below are the required direct runtime ROS dependencies of `rmf_traffic_ros2` and
 
 ### Direct Runtime non-ROS Dependency [5.iii]
 
-`rmf_traffic_ros2` has no direct runtime non-ROS dependencies.
+`rmf_traffic_ros2` has the following direct runtime non-ROS dependencies.
+
+#### eigen
+
+`eigen` is taken to be **Quality Level 3** due to its wide-spread use, history, use of CI, and use of testing.
 
 ## Platform Support [6]
 

--- a/rmf_traffic_ros2/README.md
+++ b/rmf_traffic_ros2/README.md
@@ -1,0 +1,7 @@
+# rmf\_traffic\_ros2 package
+
+This package provides interfaces between `rmf_traffic` and ROS 2 interfaces.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_utils/QUALITY_DECLARATION.md
+++ b/rmf_utils/QUALITY_DECLARATION.md
@@ -1,0 +1,141 @@
+This document is a declaration of software quality for the `rmf_utils` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_utils` Quality Declaration
+
+The package `rmf_utils` claims to be in the **Quality Level 4** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_utils` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_utils` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All symbols in the installed headers are considered part of the public API.
+
+All installed headers are in the `include` directory of the package.
+Headers in any other folders are not installed and are considered private.
+
+The generated CMake config file is installed and therefore part of the public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_utils` will not break public API within a major version number.
+
+### ABI Stability Policy [1.v]
+
+`rmf_utils` will not break public ABI within a major version number.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_utils` will not break public API or ABI within a released ROS distribution, i.e. no major releases into the same ROS distribution once that ROS distribution is released.
+
+## Change Control Process [2]
+
+`rmf_utils` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_utils` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_utils` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_core/actions?query=workflow%3Abuild+branch%3Amaster).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_utils` does not provide documentation.
+
+### Public API Documentation [3.ii]
+
+`rmf_utils` has some embedded API documentation, but it is not hosted.
+
+### License [3.iii]
+
+The license for `rmf_utils` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_utils`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_utils` contains partial tests for some of its features.
+The tests are not run automatically.
+
+### Public API Testing [4.ii]
+
+`rmf_utils` contains partial tests for some of its public API.
+The tests are not run automatically.
+The API is not completely covered by tests.
+
+### Coverage [4.iii]
+
+`rmf_utils` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rmf_utils` does not test performance.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_utils` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_utils` has no required runtime dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_utils` has no optional runtime dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_utils` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+### Target platforms [6.i]
+
+`rmf_utils` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_utils` supports ROS Eloquent.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_utils/README.md
+++ b/rmf_utils/README.md
@@ -1,0 +1,7 @@
+# rmf_utils
+
+`rmf_utils` provides simple C++ programming utilities used by Robotics Middleware Framework packages
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.

--- a/rmf_workcell_msgs/QUALITY_DECLARATION.md
+++ b/rmf_workcell_msgs/QUALITY_DECLARATION.md
@@ -1,0 +1,131 @@
+This document is a declaration of software quality for the `rmf_workcell_msgs` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_workcell_msgs` Quality Declaration
+
+The package `rmf_workcell_msgs` claims to be in the **Quality Level 3** category.
+
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_workcell_msgs` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_workcell_msgs` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+All message definition files located the `msg` directory are considered part of the public API.
+
+### API Stability Within a Released ROS Distribution [1.iv]/[1.vi]
+
+`rmf_workcell_msgs` will not break public API within a released ROS distribution, i.e. no major releases once the ROS distribution is released.
+
+### ABI Stability Within a Released ROS Distribution [1.v]/[1.vi]
+
+`rmf_workcell_msgs` does not contain any C or C++ code and therefore will not affect ABI stability.
+
+## Change Control Process [2]
+
+`rmf_workcell_msgs` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_workcell_msgs` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_workcell_msgs` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_workcell_msgs` has basic comments in the message definition files, but no list of messages or usage guide is provided.
+New messages require their own documentation in order to be added.
+
+### Public API Documentation [3.ii]
+
+`rmf_workcell_msgs` has embedded API documentation, but it is not currently hosted.
+
+### License [3.iii]
+
+The license for `rmf_workcell_msgs` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_workcell_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_workcell_msgs` is a package providing strictly message definitions and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_workcell_msgs` is a package providing strictly message definitions and therefore has no coverage requirements.
+
+### Performance [4.iv]
+
+`rmf_workcell_msgs` is a package providing strictly message definitions and therefore has no performance requirements.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_workcell_msgs` does not use the standard linters and static analysis tools for its generated C++ and Python code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_workcell_msgs` has the following runtime ROS dependencies, which are at or above Quality Level 3:
+* `builtin_interfaces`: [QL 3](https://github.com/ros2/rcl_interfaces/tree/master/builtin_interfaces/QUALITY_DECLARATION.md)
+* `rosidl_default_runtime` [QL 3](https://github.com/ros2/rosidl_defaults/tree/master/rosidl_default_runtime/QUALITY_DECLARATION.md)
+
+It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_workcell_msgs` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_workcell_msgs` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message definitions package, `rmf_workcell_msgs` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_workcell_msgs/README.md
+++ b/rmf_workcell_msgs/README.md
@@ -1,0 +1,9 @@
+# rmf_workcell_msgs
+
+`rmf_workcell_msgs` provides message types for interacting with workcells.
+
+For more information about ROS 2 interfaces, see [index.ros2.org](https://index.ros.org/doc/ros2/Concepts/About-ROS-Interfaces/)
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category. See the [Quality Declaration](QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
This PR adds [quality declaration documents](https://www.ros.org/reps/rep-2004.html) and (where necessary) basic README files too all packages in `rmf_core`.

The message packages meet the requirements to be Quality Level 3. The pure CMake packages likewise are QL3. All source-code-containing packages are currently QL4.

We need to go over each declaration and discuss it, making sure we all agree on the arguments being made.

Once this PR goes in, we can make a list of tasks that need to be done to move the packages up to higher quality levels.