### PR TITLE
Fix debug build error due to incorrect call to make_segment_num_error

### DIFF
--- a/rmf_traffic/src/rmf_traffic/DetectConflict.cpp
+++ b/rmf_traffic/src/rmf_traffic/DetectConflict.cpp
@@ -796,7 +796,7 @@ bool detect_conflicts(
               << "that should never happen. Please alert the RMF developers."
               << std::endl;
     throw invalid_trajectory_error::Implementation
-          ::make_segment_num_error(trajectory.size());
+          ::make_segment_num_error(trajectory.size(), __LINE__, __FUNCTION__);
   }
 #endif // NDEBUG
 


### PR DESCRIPTION
Ensures correct arguments are passed to `make_segment_num_error`, so that debug builds work.