### PR TITLE
Fix/finish duration

### DIFF
--- a/rmf_tasks/include/rmf_tasks/Estimate.hpp
+++ b/rmf_tasks/include/rmf_tasks/Estimate.hpp
@@ -29,14 +29,25 @@ class Estimate
 {
 public:
 
+  /// Constructor of an estimate of a task request.
+  ///
+  /// \param[in] finish_state
+  ///   Finish state of the robot once it completes the task request.
+  ///
+  /// \param[in] wait_until
+  ///   The ideal time the robot starts executing this task.
   Estimate(agv::State finish_state, rmf_traffic::Time wait_until);
 
+  /// Finish state of the robot once it completes the task request.
   agv::State finish_state() const;
 
+  /// Sets a new finish state for the robot.
   Estimate& finish_state(agv::State new_finish_state);
 
+  /// The ideal time the robot starts executing this task.
   rmf_traffic::Time wait_until() const;
 
+  /// Sets a new starting time for the robot to execute the task request.
   Estimate& wait_until(rmf_traffic::Time new_wait_until);
 
   class Implementation;

--- a/rmf_tasks/include/rmf_tasks/Request.hpp
+++ b/rmf_tasks/include/rmf_tasks/Request.hpp
@@ -42,7 +42,6 @@ public:
   /// Estimate the state of the robot when the task is finished along with the
   /// time the robot has to wait before commencing the task
   virtual rmf_utils::optional<Estimate> estimate_finish(
-    rmf_traffic::Time time_now,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const = 0;
 

--- a/rmf_tasks/include/rmf_tasks/Request.hpp
+++ b/rmf_tasks/include/rmf_tasks/Request.hpp
@@ -42,6 +42,7 @@ public:
   /// Estimate the state of the robot when the task is finished along with the
   /// time the robot has to wait before commencing the task
   virtual rmf_utils::optional<Estimate> estimate_finish(
+    rmf_traffic::Time relative_start_time,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const = 0;
 

--- a/rmf_tasks/include/rmf_tasks/Request.hpp
+++ b/rmf_tasks/include/rmf_tasks/Request.hpp
@@ -42,7 +42,7 @@ public:
   /// Estimate the state of the robot when the task is finished along with the
   /// time the robot has to wait before commencing the task
   virtual rmf_utils::optional<Estimate> estimate_finish(
-    rmf_traffic::Time relative_start_time,
+    rmf_traffic::Time time_now,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const = 0;
 

--- a/rmf_tasks/include/rmf_tasks/Request.hpp
+++ b/rmf_tasks/include/rmf_tasks/Request.hpp
@@ -29,26 +29,26 @@
 
 namespace rmf_tasks {
 
-/// Implement this for new tasks
+/// Implement this for new type of requests.
 class Request
 {
 public:
 
   using SharedPtr = std::shared_ptr<Request>;
 
-  // Get the id of the task
+  /// Get the id of the task
   virtual std::size_t id() const = 0;
 
-  // Estimate the state of the robot when the task is finished along with the
-  // time the robot has to wait before commencing the task
+  /// Estimate the state of the robot when the task is finished along with the
+  /// time the robot has to wait before commencing the task
   virtual rmf_utils::optional<Estimate> estimate_finish(
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const = 0;
 
-  // Estimate the invariant component of the task's duration
+  /// Estimate the invariant component of the task's duration
   virtual rmf_traffic::Duration invariant_duration() const = 0;
 
-  // Get the earliest start time that this task may begin
+  /// Get the earliest start time that this task may begin
   virtual rmf_traffic::Time earliest_start_time() const = 0;
 };
 

--- a/rmf_tasks/include/rmf_tasks/agv/State.hpp
+++ b/rmf_tasks/include/rmf_tasks/agv/State.hpp
@@ -24,6 +24,7 @@
 #include <rmf_utils/optional.hpp>
 
 #include <rmf_traffic/Time.hpp>
+#include <rmf_traffic/agv/Planner.hpp>
 
 namespace rmf_tasks {
 namespace agv {
@@ -35,43 +36,33 @@ public:
 
   /// Constructor
   ///
-  /// \param[in] waypoint
-  ///   Current state's location waypoint index.
+  /// \param[in] plan_start
+  ///   Current state's next start for new plans, includes the time which
+  ///   the plan can feasibly start, according to the finishing time of any
+  ///   tasks that the robot is currently performing.
   ///
   /// \param[in] charging_waypoint
   ///   The charging waypoint index of this robot.
-  ///
-  /// \param[in] finish_duration
-  ///   Time left until the robot finishes it's current task, or until the
-  ///   agent is ready to take on another task.
   ///
   /// \param[in] battery_soc
   ///   Current battery state of charge of the robot. This value needs to be
   ///   between 0.0 to 1.0.
   State(
-    std::size_t waypoint, 
+    rmf_traffic::agv::Plan::Start plan_start,
     std::size_t charging_waypoint,
-    rmf_traffic::Duration finish_duration,
     double battery_soc);
   
-  /// The current location waypoint index.
-  std::size_t waypoint() const;
+  /// The next plan start based on the current state.
+  rmf_traffic::agv::Plan::Start plan_start() const;
 
-  /// Sets the current location waypoint index.
-  State& waypoint(std::size_t new_waypoint);
+  /// Sets the next plan start.
+  State& plan_start(rmf_traffic::agv::Plan::Start new_plan_start);
 
   /// Robot's charging waypoint index.
   std::size_t charging_waypoint() const;
 
   /// Sets the charging waypoint index.
   State& charging_waypoint(std::size_t new_charging_waypoint);
-
-  /// The duration until the robot finishes it's current task or when it is
-  /// ready for a new task.
-  rmf_traffic::Duration finish_duration() const;
-
-  /// Sets the finish duration for the robot.
-  State& finish_duration(rmf_traffic::Duration new_finish_duration);
 
   /// The current battery state of charge of the robot. This value is between
   /// 0.0 and 1.0.
@@ -80,6 +71,19 @@ public:
   /// Sets a new battery state of charge value. This value needs to be between
   /// 0.0 and 1.0.
   State& battery_soc(double new_battery_soc);
+
+  /// The current location waypoint index.
+  std::size_t waypoint() const;
+
+  /// Sets the current location waypoint index.
+  State& waypoint(std::size_t new_waypoint);
+
+  /// The time which the robot finishes its current task or when it is ready for
+  /// a new task.
+  rmf_traffic::Time finish_time() const;
+
+  /// Sets the finish time for the robot.
+  State& finish_time(rmf_traffic::Time new_finish_time);
 
   class Implementation;
 private:

--- a/rmf_tasks/include/rmf_tasks/agv/State.hpp
+++ b/rmf_tasks/include/rmf_tasks/agv/State.hpp
@@ -28,6 +28,7 @@
 namespace rmf_tasks {
 namespace agv {
 
+/// This state representation is used for task planning.
 class State
 {
 public:
@@ -35,32 +36,49 @@ public:
   /// Constructor
   ///
   /// \param[in] waypoint
+  ///   Current state's location waypoint index.
+  ///
   /// \param[in] charging_waypoint
-  /// \param[in] finish_time
+  ///   The charging waypoint index of this robot.
+  ///
+  /// \param[in] finish_duration
+  ///   Time left until the robot finishes it's current task, or until the
+  ///   agent is ready to take on another task.
+  ///
   /// \param[in] battery_soc
-  /// \param[in] threshold_soc
+  ///   Current battery state of charge of the robot. This value needs to be
+  ///   between 0.0 to 1.0.
   State(
     std::size_t waypoint, 
     std::size_t charging_waypoint,
-    rmf_traffic::Time finish_time = std::chrono::steady_clock::now(),
-    double battery_soc = 1.0);
-
-  State();
+    rmf_traffic::Duration finish_duration,
+    double battery_soc);
   
+  /// The current location waypoint index.
   std::size_t waypoint() const;
 
+  /// Sets the current location waypoint index.
   State& waypoint(std::size_t new_waypoint);
 
+  /// Robot's charging waypoint index.
   std::size_t charging_waypoint() const;
 
+  /// Sets the charging waypoint index.
   State& charging_waypoint(std::size_t new_charging_waypoint);
 
-  rmf_traffic::Time finish_time() const;
+  /// The duration until the robot finishes it's current task or when it is
+  /// ready for a new task.
+  rmf_traffic::Duration finish_duration() const;
 
-  State& finish_time(rmf_traffic::Time new_finish_time);
+  /// Sets the finish duration for the robot.
+  State& finish_time(rmf_traffic::Duration new_finish_duration);
 
+  /// The current battery state of charge of the robot. This value is between
+  /// 0.0 and 1.0.
   double battery_soc() const;
 
+  /// Sets a new battery state of charge value. This value needs to be between
+  /// 0.0 and 1.0.
   State& battery_soc(double new_battery_soc);
 
   class Implementation;

--- a/rmf_tasks/include/rmf_tasks/agv/State.hpp
+++ b/rmf_tasks/include/rmf_tasks/agv/State.hpp
@@ -71,7 +71,7 @@ public:
   rmf_traffic::Duration finish_duration() const;
 
   /// Sets the finish duration for the robot.
-  State& finish_time(rmf_traffic::Duration new_finish_duration);
+  State& finish_duration(rmf_traffic::Duration new_finish_duration);
 
   /// The current battery state of charge of the robot. This value is between
   /// 0.0 and 1.0.

--- a/rmf_tasks/include/rmf_tasks/agv/StateConfig.hpp
+++ b/rmf_tasks/include/rmf_tasks/agv/StateConfig.hpp
@@ -30,10 +30,15 @@ public:
   /// Constructor
   ///
   /// \param[in] threshold_soc
+  ///   Minimum charge level the battery is allowed to deplete to. This
+  ///   value needs to be between 0.0 and 1.0.
   StateConfig(double threshold_soc);
 
+  /// Gets the battery state of charge threshold value.
   double threshold_soc() const;
 
+  /// Sets a new battery state of charge threshold value. This value needs to be
+  /// between 0.0 and 1.0.
   StateConfig& threshold_soc(double threshold_soc);
 
   class Implementation;

--- a/rmf_tasks/include/rmf_tasks/agv/TaskPlanner.hpp
+++ b/rmf_tasks/include/rmf_tasks/agv/TaskPlanner.hpp
@@ -127,6 +127,7 @@ public:
   /// Get the greedy planner based assignments for a set of initial states and 
   /// requests
   Assignments greedy_plan(
+    rmf_traffic::Time relative_start_time,
     std::vector<State> initial_states,
     std::vector<StateConfig> state_configs,
     std::vector<Request::SharedPtr> requests);
@@ -138,12 +139,15 @@ public:
   /// recommended to call plan() method and use the greedy solution for bidding.
   /// If a bid is awarded, the optimal solution may be used for assignments.
   Assignments optimal_plan(
+    rmf_traffic::Time relative_start_time,
     std::vector<State> initial_states,
     std::vector<StateConfig> state_configs,
     std::vector<Request::SharedPtr> requests,
     std::function<bool()> interrupter);
 
-  double compute_cost(const Assignments& assignments);
+  double compute_cost(
+    const Assignments& assignments,
+    rmf_traffic::Time relative_start_time);
 
   class Implementation;
 

--- a/rmf_tasks/include/rmf_tasks/agv/TaskPlanner.hpp
+++ b/rmf_tasks/include/rmf_tasks/agv/TaskPlanner.hpp
@@ -145,9 +145,7 @@ public:
     std::vector<Request::SharedPtr> requests,
     std::function<bool()> interrupter);
 
-  double compute_cost(
-    const Assignments& assignments,
-    rmf_traffic::Time relative_start_time);
+  double compute_cost(const Assignments& assignments);
 
   class Implementation;
 

--- a/rmf_tasks/include/rmf_tasks/requests/ChargeBattery.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/ChargeBattery.hpp
@@ -48,6 +48,7 @@ public:
   std::size_t id() const final;
 
   rmf_utils::optional<rmf_tasks::Estimate> estimate_finish(
+    rmf_traffic::Time relative_start_time,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const final;
 

--- a/rmf_tasks/include/rmf_tasks/requests/ChargeBattery.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/ChargeBattery.hpp
@@ -48,7 +48,7 @@ public:
   std::size_t id() const final;
 
   rmf_utils::optional<rmf_tasks::Estimate> estimate_finish(
-    rmf_traffic::Time relative_start_time,
+    rmf_traffic::Time time_now,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const final;
 

--- a/rmf_tasks/include/rmf_tasks/requests/ChargeBattery.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/ChargeBattery.hpp
@@ -48,7 +48,6 @@ public:
   std::size_t id() const final;
 
   rmf_utils::optional<rmf_tasks::Estimate> estimate_finish(
-    rmf_traffic::Time time_now,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const final;
 

--- a/rmf_tasks/include/rmf_tasks/requests/Clean.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/Clean.hpp
@@ -49,8 +49,8 @@ public:
     std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
     std::shared_ptr<rmf_battery::DevicePowerSink> cleaning_sink,
     std::shared_ptr<rmf_traffic::agv::Planner> planner,
-    bool drain_battery = true,
-    rmf_traffic::Time start_time = std::chrono::steady_clock::now());
+    rmf_traffic::Time start_time,
+    bool drain_battery = true);
 
   std::size_t id() const final;
 

--- a/rmf_tasks/include/rmf_tasks/requests/Clean.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/Clean.hpp
@@ -55,7 +55,6 @@ public:
   std::size_t id() const final;
 
   rmf_utils::optional<rmf_tasks::Estimate> estimate_finish(
-    rmf_traffic::Time relative_start_time,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const final;
 

--- a/rmf_tasks/include/rmf_tasks/requests/Clean.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/Clean.hpp
@@ -55,6 +55,7 @@ public:
   std::size_t id() const final;
 
   rmf_utils::optional<rmf_tasks::Estimate> estimate_finish(
+    rmf_traffic::Time relative_start_time,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const final;
 

--- a/rmf_tasks/include/rmf_tasks/requests/Delivery.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/Delivery.hpp
@@ -52,7 +52,6 @@ public:
   std::size_t id() const final;
 
   rmf_utils::optional<rmf_tasks::Estimate> estimate_finish(
-    rmf_traffic::Time relative_start_time,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const final;
 

--- a/rmf_tasks/include/rmf_tasks/requests/Delivery.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/Delivery.hpp
@@ -52,6 +52,7 @@ public:
   std::size_t id() const final;
 
   rmf_utils::optional<rmf_tasks::Estimate> estimate_finish(
+    rmf_traffic::Time relative_start_time,
     const agv::State& initial_state,
     const agv::StateConfig& state_config) const final;
 

--- a/rmf_tasks/include/rmf_tasks/requests/Delivery.hpp
+++ b/rmf_tasks/include/rmf_tasks/requests/Delivery.hpp
@@ -46,8 +46,8 @@ public:
     std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
     std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
     std::shared_ptr<rmf_traffic::agv::Planner> planner,
-    bool drain_battery = true,
-    rmf_traffic::Time start_time = std::chrono::steady_clock::now());
+    rmf_traffic::Time start_time,
+    bool drain_battery = true);
 
   std::size_t id() const final;
 

--- a/rmf_tasks/src/agv/State.cpp
+++ b/rmf_tasks/src/agv/State.cpp
@@ -15,6 +15,8 @@
  *
 */
 
+#include <stdexcept>
+
 #include <rmf_tasks/agv/State.hpp>
 
 namespace rmf_tasks {
@@ -28,17 +30,21 @@ public:
   Implementation(
     std::size_t waypoint, 
     std::size_t charging_waypoint,
-    rmf_traffic::Time finish_time,
+    rmf_traffic::Duration finish_duration,
     double battery_soc)
   : _waypoint(waypoint),
     _charging_waypoint(charging_waypoint),
-    _finish_time(finish_time),
+    _finish_duration(finish_duration),
     _battery_soc(battery_soc)
-  {}
+  {
+    if (_battery_soc < 0.0 || _battery_soc > 1.0)
+      throw std::invalid_argument(
+        "Battery State of Charge needs be between 0.0 and 1.0.");
+  }
 
   std::size_t _waypoint;
   std::size_t _charging_waypoint;
-  rmf_traffic::Time _finish_time;
+  rmf_traffic::Duration _finish_duration;
   double _battery_soc;
 };
 
@@ -46,17 +52,11 @@ public:
 State::State(
   std::size_t waypoint, 
   std::size_t charging_waypoint,
-  rmf_traffic::Time finish_time,
+  rmf_traffic::Duration finish_duration,
   double battery_soc)
 : _pimpl(rmf_utils::make_impl<Implementation>(
     Implementation(
-      waypoint, charging_waypoint, finish_time, battery_soc)))
-{}
-
-//==============================================================================
-State::State()
-: _pimpl(rmf_utils::make_impl<Implementation>(
-    Implementation(0, 0, std::chrono::steady_clock::now(), 0.0)))
+      waypoint, charging_waypoint, finish_duration, battery_soc)))
 {}
 
 //==============================================================================
@@ -86,15 +86,15 @@ State& State::charging_waypoint(std::size_t new_charging_waypoint)
 }
 
 //==============================================================================
-rmf_traffic::Time State::finish_time() const
+rmf_traffic::Duration State::finish_duration() const
 {
-  return _pimpl->_finish_time;
+  return _pimpl->_finish_duration;
 }
 
 //==============================================================================
-State& State::finish_time(rmf_traffic::Time new_finish_time)
+State& State::finish_time(rmf_traffic::Duration new_finish_duration)
 {
-  _pimpl->_finish_time = new_finish_time;
+  _pimpl->_finish_duration = new_finish_duration;
   return *this;
 }
 

--- a/rmf_tasks/src/agv/State.cpp
+++ b/rmf_tasks/src/agv/State.cpp
@@ -92,7 +92,7 @@ rmf_traffic::Duration State::finish_duration() const
 }
 
 //==============================================================================
-State& State::finish_time(rmf_traffic::Duration new_finish_duration)
+State& State::finish_duration(rmf_traffic::Duration new_finish_duration)
 {
   _pimpl->_finish_duration = new_finish_duration;
   return *this;

--- a/rmf_tasks/src/agv/State.cpp
+++ b/rmf_tasks/src/agv/State.cpp
@@ -28,13 +28,11 @@ class State::Implementation
 public:
 
   Implementation(
-    std::size_t waypoint, 
+    rmf_traffic::agv::Plan::Start plan_start,
     std::size_t charging_waypoint,
-    rmf_traffic::Duration finish_duration,
     double battery_soc)
-  : _waypoint(waypoint),
+  : _plan_start(std::move(plan_start)),
     _charging_waypoint(charging_waypoint),
-    _finish_duration(finish_duration),
     _battery_soc(battery_soc)
   {
     if (_battery_soc < 0.0 || _battery_soc > 1.0)
@@ -42,33 +40,30 @@ public:
         "Battery State of Charge needs be between 0.0 and 1.0.");
   }
 
-  std::size_t _waypoint;
+  rmf_traffic::agv::Plan::Start _plan_start;
   std::size_t _charging_waypoint;
-  rmf_traffic::Duration _finish_duration;
   double _battery_soc;
 };
 
 //==============================================================================
 State::State(
-  std::size_t waypoint, 
+  rmf_traffic::agv::Plan::Start plan_start,
   std::size_t charging_waypoint,
-  rmf_traffic::Duration finish_duration,
   double battery_soc)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-    Implementation(
-      waypoint, charging_waypoint, finish_duration, battery_soc)))
+    Implementation(std::move(plan_start), charging_waypoint, battery_soc)))
 {}
 
 //==============================================================================
-std::size_t State::waypoint() const
+rmf_traffic::agv::Plan::Start State::plan_start() const
 {
-  return _pimpl->_waypoint;
+  return _pimpl->_plan_start;
 }
 
 //==============================================================================
-State& State::waypoint(std::size_t new_waypoint)
+State& State::plan_start(rmf_traffic::agv::Plan::Start new_plan_start)
 {
-  _pimpl->_waypoint = new_waypoint;
+  _pimpl->_plan_start = std::move(new_plan_start);
   return *this;
 }
 
@@ -82,19 +77,6 @@ std::size_t State::charging_waypoint() const
 State& State::charging_waypoint(std::size_t new_charging_waypoint)
 {
   _pimpl->_charging_waypoint = new_charging_waypoint;
-  return *this;
-}
-
-//==============================================================================
-rmf_traffic::Duration State::finish_duration() const
-{
-  return _pimpl->_finish_duration;
-}
-
-//==============================================================================
-State& State::finish_duration(rmf_traffic::Duration new_finish_duration)
-{
-  _pimpl->_finish_duration = new_finish_duration;
   return *this;
 }
 
@@ -115,5 +97,32 @@ State& State::battery_soc(double new_battery_soc)
   return *this;
 }
 
+//==============================================================================
+std::size_t State::waypoint() const
+{
+  return _pimpl->_plan_start.waypoint();
+}
+
+//==============================================================================
+State& State::waypoint(std::size_t new_waypoint)
+{
+  _pimpl->_plan_start.waypoint(new_waypoint);
+  return *this;
+}
+
+//==============================================================================
+rmf_traffic::Time State::finish_time() const
+{
+  return _pimpl->_plan_start.time();
+}
+
+//==============================================================================
+State& State::finish_time(rmf_traffic::Time new_finish_time)
+{
+  _pimpl->_plan_start.time(new_finish_time);
+  return *this;
+}
+
+//==============================================================================
 } // namespace agv
 } // namespace rmf_tasks

--- a/rmf_tasks/src/agv/State.cpp
+++ b/rmf_tasks/src/agv/State.cpp
@@ -107,6 +107,10 @@ double State::battery_soc() const
 //==============================================================================
 State& State::battery_soc(double new_battery_soc)
 {
+  if (new_battery_soc < 0.0 || new_battery_soc > 1.0)
+    throw std::invalid_argument(
+      "Battery State of Charge needs be between 0.0 and 1.0.");
+
   _pimpl->_battery_soc = new_battery_soc;
   return *this;
 }

--- a/rmf_tasks/src/agv/StateConfig.cpp
+++ b/rmf_tasks/src/agv/StateConfig.cpp
@@ -15,6 +15,8 @@
  *
 */
 
+#include <stdexcept>
+
 #include <rmf_tasks/agv/StateConfig.hpp>
 
 namespace rmf_tasks {
@@ -34,7 +36,9 @@ StateConfig::StateConfig(double threshold_soc)
       threshold_soc
     }))
 {
-  // Do nothing
+  if (threshold_soc < 0.0 || threshold_soc > 1.0)
+    throw std::invalid_argument(
+      "Battery State of Charge threshold needs be between 0.0 and 1.0.");
 }
 
 double StateConfig::threshold_soc() const
@@ -44,6 +48,10 @@ double StateConfig::threshold_soc() const
 
 auto StateConfig::threshold_soc(double threshold_soc) -> StateConfig&
 {
+  if (threshold_soc < 0.0 || threshold_soc > 1.0)
+    throw std::invalid_argument(
+      "Battery State of Charge threshold needs be between 0.0 and 1.0.");
+
   _pimpl->threshold_soc = threshold_soc;
   return *this;
 }

--- a/rmf_tasks/src/requests/ChargeBattery.cpp
+++ b/rmf_tasks/src/requests/ChargeBattery.cpp
@@ -86,14 +86,14 @@ rmf_utils::optional<rmf_tasks::Estimate> ChargeBattery::estimate_finish(
     return rmf_utils::nullopt;
 
   // Compute time taken to reach charging waypoint from current location
-  rmf_traffic::agv::Plan::Start final_plan_start(
+  rmf_traffic::agv::Plan::Start final_plan_start{
     initial_state.finish_time(),
     initial_state.charging_waypoint(),
-    initial_state.plan_start().orientation());
-  agv::State state(
+    initial_state.plan_start().orientation()};
+  agv::State state{
     std::move(final_plan_start),
     initial_state.charging_waypoint(),
-    initial_state.battery_soc());
+    initial_state.battery_soc()};
 
   const auto start_time = initial_state.finish_time();
 

--- a/rmf_tasks/src/requests/ChargeBattery.cpp
+++ b/rmf_tasks/src/requests/ChargeBattery.cpp
@@ -79,7 +79,6 @@ std::size_t ChargeBattery::id() const
 
 //==============================================================================
 rmf_utils::optional<rmf_tasks::Estimate> ChargeBattery::estimate_finish(
-  rmf_traffic::Time relative_start_time,
   const agv::State& initial_state,
   const agv::StateConfig& state_config) const
 {
@@ -87,13 +86,16 @@ rmf_utils::optional<rmf_tasks::Estimate> ChargeBattery::estimate_finish(
     return rmf_utils::nullopt;
 
   // Compute time taken to reach charging waypoint from current location
+  rmf_traffic::agv::Plan::Start final_plan_start(
+    initial_state.finish_time(),
+    initial_state.charging_waypoint(),
+    initial_state.plan_start().orientation());
   agv::State state(
+    std::move(final_plan_start),
     initial_state.charging_waypoint(),
-    initial_state.charging_waypoint(),
-    initial_state.finish_duration(),
     initial_state.battery_soc());
 
-  const auto start_time = relative_start_time + initial_state.finish_duration();
+  const auto start_time = initial_state.finish_time();
 
   double battery_soc = initial_state.battery_soc();
   rmf_traffic::Duration variant_duration(0);
@@ -134,15 +136,12 @@ rmf_utils::optional<rmf_tasks::Estimate> ChargeBattery::estimate_finish(
     (3600 * delta_soc * _pimpl->_battery_system->nominal_capacity()) /
     _pimpl->_battery_system->charging_current();
 
-  const rmf_traffic::Time wait_until =
-    relative_start_time + initial_state.finish_duration();
+  const rmf_traffic::Time wait_until = initial_state.finish_time();
 
   const rmf_traffic::Time new_finish_time =
     wait_until + variant_duration +
     rmf_traffic::time::from_seconds(time_to_charge);
-  const rmf_traffic::Duration new_finish_duration =
-    new_finish_time - relative_start_time;
-  state.finish_duration(new_finish_duration);
+  state.finish_time(new_finish_time);
   state.battery_soc(_pimpl->_charge_soc);
 
   return Estimate(state, wait_until);

--- a/rmf_tasks/src/requests/Clean.cpp
+++ b/rmf_tasks/src/requests/Clean.cpp
@@ -55,8 +55,8 @@ rmf_tasks::Request::SharedPtr Clean::make(
   std::shared_ptr<rmf_battery::DevicePowerSink> ambient_sink,
   std::shared_ptr<rmf_battery::DevicePowerSink> cleaning_sink,
   std::shared_ptr<rmf_traffic::agv::Planner> planner,
-  bool drain_battery,
-  rmf_traffic::Time start_time)
+  rmf_traffic::Time start_time,
+  bool drain_battery)
 {
   std::shared_ptr<Clean> clean(new Clean());
   clean->_pimpl->id = id;

--- a/rmf_tasks/src/requests/Clean.cpp
+++ b/rmf_tasks/src/requests/Clean.cpp
@@ -112,14 +112,14 @@ rmf_utils::optional<rmf_tasks::Estimate> Clean::estimate_finish(
   const agv::State& initial_state,
   const agv::StateConfig& state_config) const
 {
-  rmf_traffic::agv::Plan::Start final_plan_start(
+  rmf_traffic::agv::Plan::Start final_plan_start{
     initial_state.finish_time(),
     _pimpl->end_waypoint,
-    initial_state.plan_start().orientation());
-  agv::State state(
+    initial_state.plan_start().orientation()};
+  agv::State state{
     std::move(final_plan_start),
     initial_state.charging_waypoint(),
-    initial_state.battery_soc());
+    initial_state.battery_soc()};
 
   rmf_traffic::Duration variant_duration(0);
 

--- a/rmf_tasks/src/requests/Delivery.cpp
+++ b/rmf_tasks/src/requests/Delivery.cpp
@@ -108,18 +108,21 @@ std::size_t Delivery::id() const
 
 //==============================================================================
 rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
+  rmf_traffic::Time relative_start_time,
   const agv::State& initial_state,
   const agv::StateConfig& state_config) const
 {
   agv::State state(
     _pimpl->_dropoff_waypoint, 
     initial_state.charging_waypoint(),
-    initial_state.finish_time(),
+    initial_state.finish_duration(),
     initial_state.battery_soc());
 
   rmf_traffic::Duration variant_duration(0);
 
-  const rmf_traffic::Time start_time = initial_state.finish_time();
+  const rmf_traffic::Time start_time =
+    relative_start_time + initial_state.finish_duration();
+
   double battery_soc = initial_state.battery_soc();
   double dSOC_motion = 0.0;
   double dSOC_device = 0.0;
@@ -159,13 +162,15 @@ rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
   }
 
   const rmf_traffic::Time ideal_start = _pimpl->_start_time - variant_duration;
-  const rmf_traffic::Time wait_until =
-    initial_state.finish_time() > ideal_start ?
-    initial_state.finish_time() : ideal_start;
+  const rmf_traffic::Time state_finish_time =
+    relative_start_time + initial_state.finish_duration();
+  const rmf_traffic::Time wait_until = state_finish_time > ideal_start ?
+    state_finish_time : ideal_start;
 
   // Factor in invariants
-  state.finish_time(
-    wait_until + variant_duration + _pimpl->_invariant_duration);
+  const rmf_traffic::Time new_finish_time =
+    wait_until + variant_duration + _pimpl->_invariant_duration;
+  state.finish_duration(new_finish_time - relative_start_time);
 
   if (_pimpl->_drain_battery)
   {
@@ -181,7 +186,7 @@ rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
     if ( _pimpl->_dropoff_waypoint != state.charging_waypoint())
     {
       rmf_traffic::agv::Planner::Start start{
-        state.finish_time(),
+        relative_start_time + state.finish_duration(),
         _pimpl->_dropoff_waypoint,
         0.0};
 
@@ -193,7 +198,7 @@ rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
           result_to_charger->get_itinerary().back().trajectory();
       const auto& finish_time = *trajectory.finish_time();
       const rmf_traffic::Duration retreat_duration =
-        finish_time - state.finish_time();
+        finish_time - (relative_start_time + state.finish_duration());
       
       dSOC_motion = _pimpl->_motion_sink->compute_change_in_charge(trajectory);
       dSOC_device = _pimpl->_device_sink->compute_change_in_charge(

--- a/rmf_tasks/src/requests/Delivery.cpp
+++ b/rmf_tasks/src/requests/Delivery.cpp
@@ -37,8 +37,8 @@ public:
   std::shared_ptr<rmf_battery::MotionPowerSink> _motion_sink;
   std::shared_ptr<rmf_battery::DevicePowerSink> _device_sink;
   std::shared_ptr<rmf_traffic::agv::Planner> _planner;
-  bool _drain_battery;
   rmf_traffic::Time _start_time;
+  bool _drain_battery;
 
   rmf_traffic::Duration _invariant_duration;
   double _invariant_battery_drain;
@@ -52,8 +52,8 @@ rmf_tasks::Request::SharedPtr Delivery::make(
   std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
   std::shared_ptr<rmf_battery::DevicePowerSink> device_sink,
   std::shared_ptr<rmf_traffic::agv::Planner> planner,
-  bool drain_battery,
-  rmf_traffic::Time start_time)
+  rmf_traffic::Time start_time,
+  bool drain_battery)
 {
   std::shared_ptr<Delivery> delivery(new Delivery());
   delivery->_pimpl->_id = id;
@@ -62,8 +62,8 @@ rmf_tasks::Request::SharedPtr Delivery::make(
   delivery->_pimpl->_motion_sink = std::move(motion_sink);
   delivery->_pimpl->_device_sink = std::move(device_sink);
   delivery->_pimpl->_planner = std::move(planner);
-  delivery->_pimpl->_drain_battery = drain_battery;
   delivery->_pimpl->_start_time = start_time;
+  delivery->_pimpl->_drain_battery = drain_battery;
 
   // Calculate duration of invariant component of task
   const auto plan_start_time = std::chrono::steady_clock::now();

--- a/rmf_tasks/src/requests/Delivery.cpp
+++ b/rmf_tasks/src/requests/Delivery.cpp
@@ -107,18 +107,17 @@ std::size_t Delivery::id() const
 
 //==============================================================================
 rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
-  // rmf_traffic::Time relative_start_time,
   const agv::State& initial_state,
   const agv::StateConfig& state_config) const
 {
-  rmf_traffic::agv::Plan::Start final_plan_start(
+  rmf_traffic::agv::Plan::Start final_plan_start{
     initial_state.finish_time(),
     _pimpl->_dropoff_waypoint,
-    initial_state.plan_start().orientation());
-  agv::State state(
+    initial_state.plan_start().orientation()};
+  agv::State state{
     std::move(final_plan_start),
     initial_state.charging_waypoint(),
-    initial_state.battery_soc());
+    initial_state.battery_soc()};
 
   rmf_traffic::Duration variant_duration(0);
 

--- a/rmf_tasks/src/requests/Delivery.cpp
+++ b/rmf_tasks/src/requests/Delivery.cpp
@@ -107,20 +107,22 @@ std::size_t Delivery::id() const
 
 //==============================================================================
 rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
-  rmf_traffic::Time relative_start_time,
+  // rmf_traffic::Time relative_start_time,
   const agv::State& initial_state,
   const agv::StateConfig& state_config) const
 {
+  rmf_traffic::agv::Plan::Start final_plan_start(
+    initial_state.finish_time(),
+    _pimpl->_dropoff_waypoint,
+    initial_state.plan_start().orientation());
   agv::State state(
-    _pimpl->_dropoff_waypoint, 
+    std::move(final_plan_start),
     initial_state.charging_waypoint(),
-    initial_state.finish_duration(),
     initial_state.battery_soc());
 
   rmf_traffic::Duration variant_duration(0);
 
-  const rmf_traffic::Time start_time =
-    relative_start_time + initial_state.finish_duration();
+  const rmf_traffic::Time start_time = initial_state.finish_time();
 
   double battery_soc = initial_state.battery_soc();
   double dSOC_motion = 0.0;
@@ -158,15 +160,14 @@ rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
   }
 
   const rmf_traffic::Time ideal_start = _pimpl->_start_time - variant_duration;
-  const rmf_traffic::Time state_finish_time =
-    relative_start_time + initial_state.finish_duration();
+  const rmf_traffic::Time state_finish_time = initial_state.finish_time();
   const rmf_traffic::Time wait_until = state_finish_time > ideal_start ?
     state_finish_time : ideal_start;
 
   // Factor in invariants
   const rmf_traffic::Time new_finish_time =
     wait_until + variant_duration + _pimpl->_invariant_duration;
-  state.finish_duration(new_finish_time - relative_start_time);
+  state.finish_time(new_finish_time);
 
   if (_pimpl->_drain_battery)
   {
@@ -179,7 +180,7 @@ rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
     if ( _pimpl->_dropoff_waypoint != state.charging_waypoint())
     {
       rmf_traffic::agv::Planner::Start start{
-        relative_start_time + state.finish_duration(),
+        state.finish_time(),
         _pimpl->_dropoff_waypoint,
         0.0};
 
@@ -191,7 +192,7 @@ rmf_utils::optional<rmf_tasks::Estimate> Delivery::estimate_finish(
           result_to_charger->get_itinerary().back().trajectory();
       const auto& finish_time = *trajectory.finish_time();
       const rmf_traffic::Duration retreat_duration =
-        finish_time - (relative_start_time + state.finish_duration());
+        finish_time - state.finish_time();
       
       dSOC_motion = _pimpl->_motion_sink->compute_change_in_charge(trajectory);
       dSOC_device = _pimpl->_device_sink->compute_change_in_charge(

--- a/rmf_tasks/test/unit/agv/test_TaskPlanner.cpp
+++ b/rmf_tasks/test/unit/agv/test_TaskPlanner.cpp
@@ -44,8 +44,7 @@
 inline void display_solution(
   std::string parent,
   const rmf_tasks::agv::TaskPlanner::Assignments& assignments,
-  const double cost,
-  rmf_traffic::Time relative_start_time)
+  const double cost)
 {
   std::cout << parent << " cost: " << cost << std::endl;
   std::cout << parent << " assignments:" << std::endl;
@@ -56,7 +55,7 @@ inline void display_solution(
     {
       const auto& s = a.state();
       const double start_seconds = a.earliest_start_time().time_since_epoch().count()/1e9;
-      const rmf_traffic::Time finish_time = relative_start_time + s.finish_duration();
+      const rmf_traffic::Time finish_time = s.finish_time();
       const double finish_seconds = finish_time.time_since_epoch().count()/1e9;
       std::cout << "    <" << a.task_id() << ": " << start_seconds 
                 << ", "<< finish_seconds << ", " << 100* s.battery_soc() 
@@ -138,11 +137,15 @@ SCENARIO("Grid World")
   WHEN("Planning for 3 requests and 2 agents")
   {
     const auto now = std::chrono::steady_clock::now();
+    const double default_orientation = 0.0;
+
+    rmf_traffic::agv::Plan::Start first_start(now, 13, default_orientation);
+    rmf_traffic::agv::Plan::Start second_start(now, 2, default_orientation);
 
     std::vector<rmf_tasks::agv::State> initial_states =
     {
-      rmf_tasks::agv::State{13, 13, rmf_traffic::Duration(0), 1.0},
-      rmf_tasks::agv::State{2, 2, rmf_traffic::Duration(0), 1.0}
+      rmf_tasks::agv::State{std::move(first_start), 13, 1.0},
+      rmf_tasks::agv::State{std::move(second_start), 2, 1.0}
     };
 
     std::vector<rmf_tasks::agv::StateConfig> state_configs =
@@ -196,8 +199,8 @@ SCENARIO("Grid World")
       now, initial_states, state_configs, requests, nullptr);
     const double optimal_cost = task_planner.compute_cost(optimal_assignments, now);
     
-    display_solution("Greedy", greedy_assignments, greedy_cost, now);
-    display_solution("Optimal", optimal_assignments, optimal_cost, now);
+    display_solution("Greedy", greedy_assignments, greedy_cost);
+    display_solution("Optimal", optimal_assignments, optimal_cost);
 
     REQUIRE(optimal_cost <= greedy_cost);
   }
@@ -205,11 +208,15 @@ SCENARIO("Grid World")
   WHEN("Planning for 11 requests and 2 agents")
   {
     const auto now = std::chrono::steady_clock::now();
+    const double default_orientation = 0.0;
+
+    rmf_traffic::agv::Plan::Start first_start(now, 13, default_orientation);
+    rmf_traffic::agv::Plan::Start second_start(now, 2, default_orientation);
 
     std::vector<rmf_tasks::agv::State> initial_states =
     {
-      rmf_tasks::agv::State{13, 13, std::chrono::seconds(0), 1.0},
-      rmf_tasks::agv::State{2, 2, std::chrono::seconds(0), 1.0}
+      rmf_tasks::agv::State{std::move(first_start), 13, 1.0},
+      rmf_tasks::agv::State{std::move(second_start), 2, 1.0}
     };
 
     std::vector<rmf_tasks::agv::StateConfig> state_configs =
@@ -353,8 +360,8 @@ SCENARIO("Grid World")
       now, initial_states, state_configs, requests, nullptr);
     const double optimal_cost = task_planner.compute_cost(optimal_assignments, now);
   
-    display_solution("Greedy", greedy_assignments, greedy_cost, now);
-    display_solution("Optimal", optimal_assignments, optimal_cost, now);
+    display_solution("Greedy", greedy_assignments, greedy_cost);
+    display_solution("Optimal", optimal_assignments, optimal_cost);
 
     REQUIRE(optimal_cost <= greedy_cost);
   }

--- a/rmf_tasks/test/unit/agv/test_TaskPlanner.cpp
+++ b/rmf_tasks/test/unit/agv/test_TaskPlanner.cpp
@@ -139,13 +139,13 @@ SCENARIO("Grid World")
     const auto now = std::chrono::steady_clock::now();
     const double default_orientation = 0.0;
 
-    rmf_traffic::agv::Plan::Start first_start(now, 13, default_orientation);
-    rmf_traffic::agv::Plan::Start second_start(now, 2, default_orientation);
+    rmf_traffic::agv::Plan::Start first_start{now, 13, default_orientation};
+    rmf_traffic::agv::Plan::Start second_start{now, 2, default_orientation};
 
     std::vector<rmf_tasks::agv::State> initial_states =
     {
-      rmf_tasks::agv::State{std::move(first_start), 13, 1.0},
-      rmf_tasks::agv::State{std::move(second_start), 2, 1.0}
+      rmf_tasks::agv::State{first_start, 13, 1.0},
+      rmf_tasks::agv::State{second_start, 2, 1.0}
     };
 
     std::vector<rmf_tasks::agv::StateConfig> state_configs =
@@ -193,11 +193,11 @@ SCENARIO("Grid World")
 
     const auto greedy_assignments = task_planner.greedy_plan(
       now, initial_states, state_configs, requests);
-    const double greedy_cost = task_planner.compute_cost(greedy_assignments, now);
+    const double greedy_cost = task_planner.compute_cost(greedy_assignments);
 
     const auto optimal_assignments = task_planner.optimal_plan(
       now, initial_states, state_configs, requests, nullptr);
-    const double optimal_cost = task_planner.compute_cost(optimal_assignments, now);
+    const double optimal_cost = task_planner.compute_cost(optimal_assignments);
     
     display_solution("Greedy", greedy_assignments, greedy_cost);
     display_solution("Optimal", optimal_assignments, optimal_cost);
@@ -210,13 +210,13 @@ SCENARIO("Grid World")
     const auto now = std::chrono::steady_clock::now();
     const double default_orientation = 0.0;
 
-    rmf_traffic::agv::Plan::Start first_start(now, 13, default_orientation);
-    rmf_traffic::agv::Plan::Start second_start(now, 2, default_orientation);
+    rmf_traffic::agv::Plan::Start first_start{now, 13, default_orientation};
+    rmf_traffic::agv::Plan::Start second_start{now, 2, default_orientation};
 
     std::vector<rmf_tasks::agv::State> initial_states =
     {
-      rmf_tasks::agv::State{std::move(first_start), 13, 1.0},
-      rmf_tasks::agv::State{std::move(second_start), 2, 1.0}
+      rmf_tasks::agv::State{first_start, 13, 1.0},
+      rmf_tasks::agv::State{second_start, 2, 1.0}
     };
 
     std::vector<rmf_tasks::agv::StateConfig> state_configs =
@@ -354,11 +354,11 @@ SCENARIO("Grid World")
 
     const auto greedy_assignments = task_planner.greedy_plan(
       now, initial_states, state_configs, requests);
-    const double greedy_cost = task_planner.compute_cost(greedy_assignments, now);
+    const double greedy_cost = task_planner.compute_cost(greedy_assignments);
 
     const auto optimal_assignments = task_planner.optimal_plan(
       now, initial_states, state_configs, requests, nullptr);
-    const double optimal_cost = task_planner.compute_cost(optimal_assignments, now);
+    const double optimal_cost = task_planner.compute_cost(optimal_assignments);
   
     display_solution("Greedy", greedy_assignments, greedy_cost);
     display_solution("Optimal", optimal_assignments, optimal_cost);


### PR DESCRIPTION
* Removed all time related default arguments, especially those using `std::chrono::steady_clock::now()`
* Changed to using `finish_duration` instead of `finish_time`, so that everything is handled relatively to the planning start time
* Added arguments for relative start time to all relevant methods and objects
* Removed default constructor for `agv::State`
* Modified tests to work as before
* Throws exception when invalid battery state of charge values are passed.
* Some documentation