### PR TITLE
Fix lifetime of variant_duration variable

### DIFF
--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -116,7 +116,7 @@ rmf_utils::optional<rmf_task::Estimate> ChargeBattery::estimate_finish(
     const auto result = _pimpl->_planner->plan(start, goal);
     const auto& trajectory = result->get_itinerary().back().trajectory();
     const auto& finish_time = *trajectory.finish_time();
-    const rmf_traffic::Duration variant_duration = finish_time - start_time;
+    variant_duration = finish_time - start_time;
 
     if (_pimpl->_drain_battery)
     {


### PR DESCRIPTION
Minor fix to prevent redeclaration of `variant_duration` inside the if-block scope. Opening a separate PR for this so that it doesn't get lost with other changes to task planning, or in case the other changes do not get merged. 