### PR TITLE
Added export dependencies to rmf_fleet_adapter

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -296,7 +296,14 @@ target_include_directories(task_aggregator
 # -----------------------------------------------------------------------------
 
 ament_export_targets(rmf_fleet_adapter HAS_LIBRARY_TARGET)
-ament_export_dependencies(rmf_traffic_ros2)
+ament_export_dependencies(
+  rmf_traffic_ros2
+  rmf_fleet_msgs
+  rmf_door_msgs
+  rmf_lift_msgs
+  rmf_ingestor_msgs
+  rmf_dispenser_msgs
+)
 
 install(
   TARGETS


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

* Additions to export dependencies to use the `rmf_fleet_adapter` library externally