### PR TITLE
Change id field of Request to string and modify TaskPlanner to use internal ids instead

### DIFF
--- a/rmf_task/include/rmf_task/Request.hpp
+++ b/rmf_task/include/rmf_task/Request.hpp
@@ -37,7 +37,7 @@ public:
   using SharedPtr = std::shared_ptr<Request>;
 
   /// Get the id of the task
-  virtual std::size_t id() const = 0;
+  virtual std::string id() const = 0;
 
   /// Estimate the state of the robot when the task is finished along with the
   /// time the robot has to wait before commencing the task

--- a/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
+++ b/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
@@ -113,9 +113,6 @@ public:
 
     /// Constructor
     ///
-    /// \param[in] id
-    ///   The id for the request this assignment contains
-    ///
     /// \param[in] request
     ///   The task request for this assignment
     ///
@@ -125,14 +122,10 @@ public:
     /// \param[in] earliest_start_time
     ///   The earliest time the agent will begin exececuting this task
     Assignment(
-      size_t request_id,
       rmf_task::RequestPtr request,
       State state,
       rmf_traffic::Time deployment_time);
 
-    // Get the id of the request this task contains
-    size_t request_id() const;
-      
     // Get the request of this task
     rmf_task::RequestPtr request() const;
 

--- a/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
+++ b/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
@@ -113,6 +113,9 @@ public:
 
     /// Constructor
     ///
+    /// \param[in] id
+    ///   The id for the request this assignment contains
+    ///
     /// \param[in] request
     ///   The task request for this assignment
     ///
@@ -122,10 +125,13 @@ public:
     /// \param[in] earliest_start_time
     ///   The earliest time the agent will begin exececuting this task
     Assignment(
+      size_t request_id,
       rmf_task::RequestPtr request,
       State state,
       rmf_traffic::Time deployment_time);
 
+    // Get the id of the request this task contains
+    size_t request_id() const;
       
     // Get the request of this task
     rmf_task::RequestPtr request() const;

--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -18,6 +18,8 @@
 #ifndef INCLUDE__RMF_TASK__REQUESTS__CHARGEBATTERY_HPP
 #define INCLUDE__RMF_TASK__REQUESTS__CHARGEBATTERY_HPP
 
+#include <string>
+
 #include <rmf_traffic/Time.hpp>
 #include <rmf_traffic/agv/Planner.hpp>
 
@@ -46,7 +48,7 @@ public:
     rmf_traffic::Time start_time,
     bool drain_battery = true);
 
-  std::size_t id() const final;
+  std::string id() const final;
 
   rmf_utils::optional<rmf_task::Estimate> estimate_finish(
     const agv::State& initial_state,

--- a/rmf_task/include/rmf_task/requests/Clean.hpp
+++ b/rmf_task/include/rmf_task/requests/Clean.hpp
@@ -19,6 +19,7 @@
 #define INCLUDE__RMF_TASK__REQUESTS__CLEAN_HPP
 
 #include <chrono>
+#include <string>
 
 #include <rmf_traffic/Time.hpp>
 #include <rmf_traffic/Trajectory.hpp>
@@ -41,7 +42,7 @@ class Clean : public rmf_task::Request
 public:
 
   static rmf_task::Request::SharedPtr make(
-    std::size_t id,
+    std::string id,
     std::size_t start_waypoint,
     std::size_t end_waypoint,
     rmf_traffic::Trajectory& cleaning_path,
@@ -52,7 +53,7 @@ public:
     rmf_traffic::Time start_time,
     bool drain_battery = true);
 
-  std::size_t id() const final;
+  std::string id() const final;
 
   rmf_utils::optional<rmf_task::Estimate> estimate_finish(
     const agv::State& initial_state,

--- a/rmf_task/include/rmf_task/requests/Delivery.hpp
+++ b/rmf_task/include/rmf_task/requests/Delivery.hpp
@@ -19,6 +19,7 @@
 #define INCLUDE__RMF_TASK__REQUESTS__DELIVERY_HPP
 
 #include <chrono>
+#include <string>
 
 #include <rmf_traffic/Time.hpp>
 #include <rmf_traffic/agv/Planner.hpp>
@@ -40,7 +41,7 @@ class Delivery : public rmf_task::Request
 public:
 
   static rmf_task::Request::SharedPtr make(
-    std::size_t id,
+    std::string id,
     std::size_t pickup_waypoint,
     std::size_t dropoff_waypoint,
     std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
@@ -49,7 +50,7 @@ public:
     rmf_traffic::Time start_time,
     bool drain_battery = true);
 
-  std::size_t id() const final;
+  std::string id() const final;
 
   rmf_utils::optional<rmf_task::Estimate> estimate_finish(
     const agv::State& initial_state,

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -15,6 +15,7 @@
  *
 */
 
+#include <string>
 #include <rmf_task/requests/ChargeBattery.hpp>
 
 namespace rmf_task {
@@ -29,7 +30,7 @@ public:
   {}
 
   // fixed id for now
-  std::size_t _id = 1001;
+  std::string _id = "Charge";
   rmf_battery::agv::BatterySystemPtr _battery_system;
   std::shared_ptr<rmf_battery::MotionPowerSink> _motion_sink;
   std::shared_ptr<rmf_battery::DevicePowerSink> _device_sink;
@@ -75,7 +76,7 @@ ChargeBattery::ChargeBattery()
 {}
 
 //==============================================================================
-std::size_t ChargeBattery::id() const
+std::string ChargeBattery::id() const
 {
   return _pimpl->_id;
 }

--- a/rmf_task/src/rmf_task/requests/Clean.cpp
+++ b/rmf_task/src/rmf_task/requests/Clean.cpp
@@ -30,7 +30,7 @@ public:
   Implementation()
   {}
 
-  std::size_t id;
+  std::string id;
   std::size_t start_waypoint;
   std::size_t end_waypoint;
   rmf_traffic::Trajectory cleaning_path;
@@ -47,7 +47,7 @@ public:
 
 //==============================================================================
 rmf_task::Request::SharedPtr Clean::make(
-  std::size_t id,
+  std::string id,
   std::size_t start_waypoint,
   std::size_t end_waypoint,
   rmf_traffic::Trajectory& cleaning_path,
@@ -102,7 +102,7 @@ Clean::Clean()
 {}
 
 //==============================================================================
-std::size_t Clean::id() const
+std::string Clean::id() const
 {
   return _pimpl->id;
 }

--- a/rmf_task/src/rmf_task/requests/Delivery.cpp
+++ b/rmf_task/src/rmf_task/requests/Delivery.cpp
@@ -30,7 +30,7 @@ public:
   Implementation()
   {}
 
-  std::size_t _id;
+  std::string _id;
   std::size_t _pickup_waypoint;
   std::size_t _dropoff_waypoint;
   std::shared_ptr<rmf_battery::MotionPowerSink> _motion_sink;
@@ -45,7 +45,7 @@ public:
 
 //==============================================================================
 rmf_task::Request::SharedPtr Delivery::make(
-  std::size_t id,
+  std::string id,
   std::size_t pickup_waypoint,
   std::size_t dropoff_waypoint,
   std::shared_ptr<rmf_battery::MotionPowerSink> motion_sink,
@@ -100,7 +100,7 @@ Delivery::Delivery()
 {}
 
 //==============================================================================
-std::size_t Delivery::id() const
+std::string Delivery::id() const
 {
   return _pimpl->_id;
 }

--- a/rmf_task/test/unit/agv/test_TaskPlanner.cpp
+++ b/rmf_task/test/unit/agv/test_TaskPlanner.cpp
@@ -153,7 +153,7 @@ SCENARIO("Grid World")
     std::vector<rmf_task::Request::SharedPtr> requests =
     {
       rmf_task::requests::Delivery::make(
-        1,
+        "1",
         0,
         3,
         motion_sink,
@@ -163,7 +163,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        2,
+        "2",
         15,
         2,
         motion_sink,
@@ -173,7 +173,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        3,
+        "3",
         7,
         9,
         motion_sink,
@@ -228,7 +228,7 @@ SCENARIO("Grid World")
     std::vector<rmf_task::Request::SharedPtr> requests =
     {
       rmf_task::requests::Delivery::make(
-        1,
+        "1",
         0,
         3,
         motion_sink,
@@ -238,7 +238,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        2,
+        "2",
         15,
         2,
         motion_sink,
@@ -248,7 +248,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        3,
+        "3",
         7,
         9,
         motion_sink,
@@ -258,7 +258,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        4,
+        "4",
         8,
         11,
         motion_sink,
@@ -268,7 +268,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        5,
+        "5",
         10,
         0,
         motion_sink,
@@ -278,7 +278,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        6,
+        "6",
         4,
         8,
         motion_sink,
@@ -288,7 +288,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        7,
+        "7",
         8,
         14,
         motion_sink,
@@ -298,7 +298,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        8,
+        "8",
         5,
         11,
         motion_sink,
@@ -308,7 +308,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        9,
+        "9",
         9,
         0,
         motion_sink,
@@ -318,7 +318,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        10,
+        "10",
         1,
         3,
         motion_sink,
@@ -328,7 +328,7 @@ SCENARIO("Grid World")
         drain_battery),
 
       rmf_task::requests::Delivery::make(
-        11,
+        "11",
         0,
         12,
         motion_sink,


### PR DESCRIPTION
Modifies `request` to use string based id instead of size_t. `Node` generates its own custom ids for any requests that are added to it, for use by the `TaskPlanner`, instead of relying on the `request`'s `id` field.