### PR TITLE
Reduce heuristic overestimation and ignore charging task costs in TaskPlanner

### DIFF
--- a/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
+++ b/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
@@ -121,14 +121,10 @@ public:
     ///
     /// \param[in] earliest_start_time
     ///   The earliest time the agent will begin exececuting this task
-    ///
-    /// \param[in] include_in_cost
-    ///   Whether or not to include the cost of this Assignment in the total
     Assignment(
       rmf_task::RequestPtr request,
       State state,
-      rmf_traffic::Time deployment_time,
-      bool include_in_cost = true);
+      rmf_traffic::Time deployment_time);
       
     // Get the request of this task
     rmf_task::RequestPtr request() const;
@@ -139,9 +135,6 @@ public:
     // Get a const reference to the time when the robot begins executing
     // this assignment
     const rmf_traffic::Time& deployment_time() const;
-
-    // Get a value indicating whether to include the cost of this Assigment in the overall cost
-    bool include_in_cost() const;
 
     class Implementation;
   

--- a/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
+++ b/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
@@ -121,11 +121,14 @@ public:
     ///
     /// \param[in] earliest_start_time
     ///   The earliest time the agent will begin exececuting this task
+    ///
+    /// \param[in] include_in_cost
+    ///   Whether or not to include the cost of this Assignment in the total
     Assignment(
       rmf_task::RequestPtr request,
       State state,
-      rmf_traffic::Time deployment_time);
-
+      rmf_traffic::Time deployment_time,
+      bool include_in_cost = true);
       
     // Get the request of this task
     rmf_task::RequestPtr request() const;
@@ -136,6 +139,9 @@ public:
     // Get a const reference to the time when the robot begins executing
     // this assignment
     const rmf_traffic::Time& deployment_time() const;
+
+    // Get a value indicating whether to include the cost of this Assigment in the overall cost
+    bool include_in_cost() const;
 
     class Implementation;
   

--- a/rmf_task/test/unit/agv/test_TaskPlanner.cpp
+++ b/rmf_task/test/unit/agv/test_TaskPlanner.cpp
@@ -359,4 +359,160 @@ SCENARIO("Grid World")
 
     REQUIRE(optimal_cost <= greedy_cost);
   }
+
+  WHEN("Planning for 11 requests and 2 agents no.2")
+  {
+    const auto now = std::chrono::steady_clock::now();
+    const double default_orientation = 0.0;
+
+    rmf_traffic::agv::Plan::Start first_location{now, 13, default_orientation};
+    rmf_traffic::agv::Plan::Start second_location{now, 2, default_orientation};
+
+    std::vector<rmf_task::agv::State> initial_states =
+    {
+      rmf_task::agv::State{first_location, 9, 1.0},
+      rmf_task::agv::State{second_location, 2, 1.0}
+    };
+
+    std::vector<rmf_task::agv::StateConfig> state_configs =
+    {
+      rmf_task::agv::StateConfig{0.2},
+      rmf_task::agv::StateConfig{0.2}
+    };
+
+    std::vector<rmf_task::Request::SharedPtr> requests =
+    {
+      rmf_task::requests::Delivery::make(
+        1,
+        6,
+        3,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(0),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        2,
+        10,
+        7,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(0),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        3,
+        2,
+        12,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(0),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        4,
+        8,
+        11,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(50000),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        5,
+        10,
+        6,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(50000),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        6,
+        2,
+        9,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(70000),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        7,
+        3,
+        4,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(70000),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        8,
+        5,
+        11,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(70000),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        9,
+        9,
+        1,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(70000),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        10,
+        1,
+        5,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(70000),
+        drain_battery),
+
+      rmf_task::requests::Delivery::make(
+        11,
+        13,
+        10,
+        motion_sink,
+        device_sink,
+        planner,
+        now + rmf_traffic::time::from_seconds(70000),
+        drain_battery)
+    };
+
+    std::shared_ptr<rmf_task::agv::TaskPlanner::Configuration>  task_config =
+      std::make_shared<rmf_task::agv::TaskPlanner::Configuration>(
+        battery_system,
+        motion_sink,
+        device_sink,
+        planner);
+    rmf_task::agv::TaskPlanner task_planner(task_config);
+
+    const auto greedy_assignments = task_planner.greedy_plan(
+      now, initial_states, state_configs, requests);
+    const double greedy_cost = task_planner.compute_cost(greedy_assignments);
+
+    const auto optimal_assignments = task_planner.optimal_plan(
+      now, initial_states, state_configs, requests, nullptr);
+    const double optimal_cost = task_planner.compute_cost(optimal_assignments);
+
+    display_solution("Greedy", greedy_assignments, greedy_cost);
+    display_solution("Optimal", optimal_assignments, optimal_cost);
+
+    REQUIRE(optimal_cost <= greedy_cost);
+  }
+
 }


### PR DESCRIPTION
`g(n)` computes the cost of each task based on its `earliest_start_time`, whereas `h(n)`earlier did not. This meant that costs were overestimated, making A* less likely to pick the optimal solution. This PR modifies `h(n)` to take this into account. The heuristic should now underestimate the costs when the earliest start times for each task are similar/same (enforced by the segmentation_threshold), and should still perform well even if they are not, in all but some rare cases.

In addition, it modifies `g(n)` to ignore the cost of any charging tasks inserted into the plan, since the cost of charging is indirectly included in the tasks that follow. Right now it adds an additional field to `Assignment`. I'm not sure if there is a better way - any suggestions are welcome. (Edit: Actually I could look at the request field and specifically ignore it if it is a charging request using `dynamic_cast`)

Based on some [testing](https://github.com/mrushyendra/rmf_core/blob/task_planner_new/rmf_task/test/unit/agv/test_TaskPlanner.cpp) (not included in this PR), costs with both `greedy_solve` and `optimal_solve` decreased by about 2-30% in almost all cases, even after controlling for the decrease in costs from not considering charging tasks.