### PR TITLE
Cache estimated values to speed up TaskPlanner

### DIFF
--- a/rmf_task/include/rmf_task/Estimate.hpp
+++ b/rmf_task/include/rmf_task/Estimate.hpp
@@ -18,6 +18,9 @@
 #ifndef INCLUDE__RMF_TASK__ESTIMATE_HPP
 #define INCLUDE__RMF_TASK__ESTIMATE_HPP
 
+#include <optional>
+#include <utility>
+
 #include <rmf_task/agv/State.hpp>
 #include <rmf_traffic/Time.hpp>
 #include <rmf_utils/impl_ptr.hpp>
@@ -49,6 +52,34 @@ public:
 
   /// Sets a new starting time for the robot to execute the task request.
   Estimate& wait_until(rmf_traffic::Time new_wait_until);
+
+  class Implementation;
+private:
+  rmf_utils::impl_ptr<Implementation> _pimpl;
+};
+
+/// Stores computed estimates between pairs of waypoints
+class EstimateCache
+{
+public:
+  /// Constructs an empty EstimateCache
+  EstimateCache();
+
+  /// Struct containing the estimated duration and charge required to travel between
+  /// a waypoint pair.
+  struct CacheElem
+  {
+    rmf_traffic::Duration duration;
+    double dsoc; // Positive if charge is consumed
+  };
+
+  /// Returns the saved estimate values for the path between the supplied waypoints,
+  /// if present.
+  std::optional<CacheElem> get(std::pair<size_t, size_t> waypoints) const;
+
+  /// Saves the estimated duration and change in charge between the supplied waypoints.
+  void set(std::pair<size_t, size_t> waypoints,
+    rmf_traffic::Duration duration, double dsoc);
 
   class Implementation;
 private:

--- a/rmf_task/include/rmf_task/Estimate.hpp
+++ b/rmf_task/include/rmf_task/Estimate.hpp
@@ -67,7 +67,7 @@ public:
 
   /// Struct containing the estimated duration and charge required to travel between
   /// a waypoint pair.
-  struct CacheElem
+  struct CacheElement
   {
     rmf_traffic::Duration duration;
     double dsoc; // Positive if charge is consumed
@@ -75,7 +75,7 @@ public:
 
   /// Returns the saved estimate values for the path between the supplied waypoints,
   /// if present.
-  std::optional<CacheElem> get(std::pair<size_t, size_t> waypoints) const;
+  std::optional<CacheElement> get(std::pair<size_t, size_t> waypoints) const;
 
   /// Saves the estimated duration and change in charge between the supplied waypoints.
   void set(std::pair<size_t, size_t> waypoints,

--- a/rmf_task/include/rmf_task/Request.hpp
+++ b/rmf_task/include/rmf_task/Request.hpp
@@ -43,7 +43,8 @@ public:
   /// time the robot has to wait before commencing the task
   virtual rmf_utils::optional<Estimate> estimate_finish(
     const agv::State& initial_state,
-    const agv::StateConfig& state_config) const = 0;
+    const agv::StateConfig& state_config,
+    const std::shared_ptr<EstimateCache> estimate_cache) const = 0;
 
   /// Estimate the invariant component of the task's duration
   virtual rmf_traffic::Duration invariant_duration() const = 0;

--- a/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
+++ b/rmf_task/include/rmf_task/agv/TaskPlanner.hpp
@@ -174,6 +174,8 @@ public:
 
   double compute_cost(const Assignments& assignments);
 
+  const std::shared_ptr<EstimateCache> estimate_cache() const;
+
   class Implementation;
 
 private:

--- a/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
+++ b/rmf_task/include/rmf_task/requests/ChargeBattery.hpp
@@ -52,7 +52,8 @@ public:
 
   rmf_utils::optional<rmf_task::Estimate> estimate_finish(
     const agv::State& initial_state,
-    const agv::StateConfig& state_config) const final;
+    const agv::StateConfig& state_config,
+    const std::shared_ptr<EstimateCache> estimate_cache) const final;
 
   rmf_traffic::Duration invariant_duration() const final;
 

--- a/rmf_task/include/rmf_task/requests/Clean.hpp
+++ b/rmf_task/include/rmf_task/requests/Clean.hpp
@@ -57,7 +57,8 @@ public:
 
   rmf_utils::optional<rmf_task::Estimate> estimate_finish(
     const agv::State& initial_state,
-    const agv::StateConfig& state_config) const final;
+    const agv::StateConfig& state_config,
+    const std::shared_ptr<EstimateCache> estimate_cache) const final;
 
   rmf_traffic::Duration invariant_duration() const final;
 

--- a/rmf_task/include/rmf_task/requests/Delivery.hpp
+++ b/rmf_task/include/rmf_task/requests/Delivery.hpp
@@ -62,7 +62,8 @@ public:
 
   rmf_utils::optional<rmf_task::Estimate> estimate_finish(
     const agv::State& initial_state,
-    const agv::StateConfig& state_config) const final;
+    const agv::StateConfig& state_config,
+    const std::shared_ptr<EstimateCache> estimate_cache) const final;
 
   rmf_traffic::Duration invariant_duration() const final;
 

--- a/rmf_task/include/rmf_task/requests/Loop.hpp
+++ b/rmf_task/include/rmf_task/requests/Loop.hpp
@@ -19,6 +19,7 @@
 #define INCLUDE__RMF_TASK__REQUESTS__LOOP_HPP
 
 #include <chrono>
+#include <string>
 
 #include <rmf_traffic/Time.hpp>
 #include <rmf_traffic/agv/Planner.hpp>

--- a/rmf_task/include/rmf_task/requests/Loop.hpp
+++ b/rmf_task/include/rmf_task/requests/Loop.hpp
@@ -58,7 +58,8 @@ public:
 
   rmf_utils::optional<rmf_task::Estimate> estimate_finish(
     const agv::State& initial_state,
-    const agv::StateConfig& state_config) const final;
+    const agv::StateConfig& state_config,
+    const std::shared_ptr<EstimateCache> estimate_cache) const final;
 
   rmf_traffic::Duration invariant_duration() const final;
 

--- a/rmf_task/src/rmf_task/Estimate.cpp
+++ b/rmf_task/src/rmf_task/Estimate.cpp
@@ -70,14 +70,16 @@ Estimate& Estimate::wait_until(rmf_traffic::Time new_wait_until)
 class EstimateCache::Implementation
 {
   public:
-    struct PairHash {
-      size_t operator()(const std::pair<size_t,size_t>& p) const {
+    struct PairHash
+    {
+      size_t operator()(const std::pair<size_t,size_t>& p) const
+      {
         return std::hash<size_t>()(p.first) ^ std::hash<size_t>()(p.second);
       }
     };
 
     using Cache = std::unordered_map<std::pair<size_t,size_t>,
-      CacheElem, PairHash>;
+      CacheElement, PairHash>;
     Cache _cache;
 };
 
@@ -87,7 +89,7 @@ EstimateCache::EstimateCache()
 {}
 
 //==============================================================================
-std::optional<EstimateCache::CacheElem> EstimateCache::get(
+std::optional<EstimateCache::CacheElement> EstimateCache::get(
   std::pair<size_t, size_t> waypoints) const
 {
   auto it = _pimpl->_cache.find(waypoints);
@@ -102,7 +104,7 @@ std::optional<EstimateCache::CacheElem> EstimateCache::get(
 void EstimateCache::set(std::pair<size_t, size_t> waypoints,
   rmf_traffic::Duration duration, double dsoc)
 {
-  _pimpl->_cache[waypoints] = CacheElem {duration, dsoc};
+  _pimpl->_cache[waypoints] = CacheElement{duration, dsoc};
 }
 
 } // namespace rmf_task

--- a/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
+++ b/rmf_task/src/rmf_task/requests/ChargeBattery.cpp
@@ -121,14 +121,9 @@ rmf_utils::optional<rmf_task::Estimate> ChargeBattery::estimate_finish(
     else
     {
       // Compute plan to charging waypoint along with battery drain
-      rmf_traffic::agv::Planner::Start start{
-        start_time,
-        initial_state.waypoint(),
-        0.0};
-
-      rmf_traffic::agv::Planner::Goal goal{initial_state.charging_waypoint()};
-
-      const auto result = _pimpl->_planner->plan(start, goal);
+      rmf_traffic::agv::Planner::Goal goal{endpoints.second};
+      const auto result = _pimpl->_planner->plan(
+        initial_state.location(), goal);
       const auto& trajectory = result->get_itinerary().back().trajectory();
       const auto& finish_time = *trajectory.finish_time();
       variant_duration = finish_time - start_time;

--- a/rmf_task/src/rmf_task/requests/Delivery.cpp
+++ b/rmf_task/src/rmf_task/requests/Delivery.cpp
@@ -155,14 +155,9 @@ rmf_utils::optional<rmf_task::Estimate> Delivery::estimate_finish(
     else
     {
       // Compute plan to pickup waypoint along with battery drain
-      rmf_traffic::agv::Planner::Start start{
-        start_time,
-        endpoints.first,
-        0.0};
-
       rmf_traffic::agv::Planner::Goal goal{endpoints.second};
-
-      const auto result_to_pickup = _pimpl->_planner->plan(start, goal);
+      const auto result_to_pickup = _pimpl->_planner->plan(
+        initial_state.location(), goal);
       // We assume we can always compute a plan
       const auto& trajectory =
         result_to_pickup->get_itinerary().back().trajectory();

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -120,7 +120,8 @@ std::string Loop::id() const
 //==============================================================================
 rmf_utils::optional<rmf_task::Estimate> Loop::estimate_finish(
   const agv::State& initial_state,
-  const agv::StateConfig& state_config) const
+  const agv::StateConfig& state_config,
+  const std::shared_ptr<EstimateCache> estimate_cache) const
 {
 
   rmf_traffic::Duration variant_duration(0);
@@ -133,27 +134,42 @@ rmf_utils::optional<rmf_task::Estimate> Loop::estimate_finish(
   // Check if a plan has to be generated from finish location to start_waypoint
   if (initial_state.waypoint() != _pimpl->start_waypoint)
   {
-    // Compute plan to start_waypoint along with battery drain
-    rmf_traffic::agv::Planner::Start init_start{
-      start_time,
-      initial_state.waypoint(),
-      0.0};
-
-    rmf_traffic::agv::Planner::Goal loop_start_goal{_pimpl->start_waypoint};
-    const auto plan_to_start = _pimpl->planner->plan(init_start, loop_start_goal);
-    // We assume we can always compute a plan
-    const auto& trajectory = plan_to_start->get_itinerary().back().trajectory();
-    const auto& finish_time = *trajectory.finish_time();
-    variant_duration = finish_time - start_time;
-
-    if (_pimpl->drain_battery)
+    auto endpoints = std::make_pair(initial_state.waypoint(),
+      _pimpl->start_waypoint);
+    const auto& cache_result = estimate_cache->get(endpoints);
+    // Use previously memoized values if possible
+    if (cache_result)
     {
-      // Compute battery drain
-      dSOC_motion = _pimpl->motion_sink->compute_change_in_charge(trajectory);
-      dSOC_device =
-        _pimpl->ambient_sink->compute_change_in_charge(
-          rmf_traffic::time::to_seconds(variant_duration));
-      battery_soc = battery_soc - dSOC_motion - dSOC_device;
+      variant_duration = cache_result->duration;
+      battery_soc = battery_soc - cache_result->dsoc;
+    }
+    else
+    {
+      // Compute plan to start_waypoint along with battery drain
+      rmf_traffic::agv::Planner::Start init_start{
+        start_time,
+        endpoints.first,
+        0.0};
+
+      rmf_traffic::agv::Planner::Goal loop_start_goal{endpoints.second};
+      const auto plan_to_start = _pimpl->planner->plan(init_start, loop_start_goal);
+      // We assume we can always compute a plan
+      const auto& trajectory = plan_to_start->get_itinerary().back().trajectory();
+      const auto& finish_time = *trajectory.finish_time();
+      variant_duration = finish_time - start_time;
+
+      if (_pimpl->drain_battery)
+      {
+        // Compute battery drain
+        dSOC_motion = _pimpl->motion_sink->compute_change_in_charge(trajectory);
+        dSOC_device =
+          _pimpl->ambient_sink->compute_change_in_charge(
+            rmf_traffic::time::to_seconds(variant_duration));
+        battery_soc = battery_soc - dSOC_motion - dSOC_device;
+      }
+
+      estimate_cache->set(endpoints, variant_duration,
+        dSOC_motion + dSOC_device);
     }
 
     if (battery_soc <= state_config.threshold_soc())
@@ -171,6 +187,7 @@ rmf_utils::optional<rmf_task::Estimate> Loop::estimate_finish(
     wait_until + variant_duration  + _pimpl->invariant_duration;
 
   // Subtract invariant battery drain and check if robot can return to its charger
+  double retreat_battery_drain = 0.0;
   if (_pimpl->drain_battery)
   {
     battery_soc -= _pimpl->invariant_battery_drain;
@@ -179,27 +196,39 @@ rmf_utils::optional<rmf_task::Estimate> Loop::estimate_finish(
 
     if ( _pimpl->finish_waypoint != initial_state.charging_waypoint())
     {
-      rmf_traffic::agv::Planner::Start retreat_start{
-        state_finish_time,
-        _pimpl->finish_waypoint,
-        0.0};
+      const auto endpoints = std::make_pair(_pimpl->finish_waypoint,
+        initial_state.charging_waypoint());
+      const auto& cache_result = estimate_cache->get(endpoints);
+      if (cache_result)
+      {
+        retreat_battery_drain = cache_result->dsoc;
+      }
+      else
+      {
+        rmf_traffic::agv::Planner::Start retreat_start{
+          state_finish_time,
+          endpoints.first,
+          0.0};
 
-      rmf_traffic::agv::Planner::Goal charger_goal{
-        initial_state.charging_waypoint()};
+        rmf_traffic::agv::Planner::Goal charger_goal{
+          endpoints.second};
 
-      const auto result_to_charger = _pimpl->planner->plan(
-        retreat_start, charger_goal);
-      // We assume we can always compute a plan
-      const auto& trajectory =
-          result_to_charger->get_itinerary().back().trajectory();
-      const auto& finish_time = *trajectory.finish_time();
-      const rmf_traffic::Duration retreat_duration =
-        finish_time - state_finish_time;
-      
-      dSOC_motion = _pimpl->motion_sink->compute_change_in_charge(trajectory);
-      dSOC_device = _pimpl->ambient_sink->compute_change_in_charge(
-          rmf_traffic::time::to_seconds(retreat_duration));
-      const double retreat_battery_drain = dSOC_motion + dSOC_device;
+        const auto result_to_charger = _pimpl->planner->plan(
+          retreat_start, charger_goal);
+        // We assume we can always compute a plan
+        const auto& trajectory =
+            result_to_charger->get_itinerary().back().trajectory();
+        const auto& finish_time = *trajectory.finish_time();
+        const rmf_traffic::Duration retreat_duration =
+          finish_time - state_finish_time;
+
+        dSOC_motion = _pimpl->motion_sink->compute_change_in_charge(trajectory);
+        dSOC_device = _pimpl->ambient_sink->compute_change_in_charge(
+            rmf_traffic::time::to_seconds(retreat_duration));
+        retreat_battery_drain = dSOC_motion + dSOC_device;
+        estimate_cache->set(endpoints, retreat_duration,
+          retreat_battery_drain);
+      }
 
       if (battery_soc - retreat_battery_drain <= state_config.threshold_soc())
         return rmf_utils::nullopt;

--- a/rmf_task/src/rmf_task/requests/Loop.cpp
+++ b/rmf_task/src/rmf_task/requests/Loop.cpp
@@ -146,13 +146,9 @@ rmf_utils::optional<rmf_task::Estimate> Loop::estimate_finish(
     else
     {
       // Compute plan to start_waypoint along with battery drain
-      rmf_traffic::agv::Planner::Start init_start{
-        start_time,
-        endpoints.first,
-        0.0};
-
       rmf_traffic::agv::Planner::Goal loop_start_goal{endpoints.second};
-      const auto plan_to_start = _pimpl->planner->plan(init_start, loop_start_goal);
+      const auto plan_to_start = _pimpl->planner->plan(
+        initial_state.location(), loop_start_goal);
       // We assume we can always compute a plan
       const auto& trajectory = plan_to_start->get_itinerary().back().trajectory();
       const auto& finish_time = *trajectory.finish_time();

--- a/rmf_task/test/unit/agv/test_TaskPlanner.cpp
+++ b/rmf_task/test/unit/agv/test_TaskPlanner.cpp
@@ -241,6 +241,9 @@ SCENARIO("Grid World")
               << (finish_time - start_time).count() / 1e9 << std::endl;
     display_solution("Greedy", greedy_assignments, greedy_cost);
 
+    // Create new TaskPlanner to reset cache so that measured run times
+    // remain independent of one another
+    task_planner = rmf_task::agv::TaskPlanner(task_config);
     start_time = std::chrono::steady_clock::now();
     const auto optimal_assignments = task_planner.optimal_plan(
       now, initial_states, state_configs, requests, nullptr);
@@ -436,6 +439,7 @@ SCENARIO("Grid World")
               << (finish_time - start_time).count() / 1e9 << std::endl;
     display_solution("Greedy", greedy_assignments, greedy_cost);
 
+    task_planner = rmf_task::agv::TaskPlanner(task_config);
     start_time = std::chrono::steady_clock::now();
     const auto optimal_assignments = task_planner.optimal_plan(
       now, initial_states, state_configs, requests, nullptr);
@@ -541,6 +545,7 @@ SCENARIO("Grid World")
               << (finish_time - start_time).count() / 1e9 << std::endl;
     display_solution("Greedy", greedy_assignments, greedy_cost);
 
+    task_planner = rmf_task::agv::TaskPlanner(task_config);
     start_time = std::chrono::steady_clock::now();
     const auto optimal_assignments = task_planner.optimal_plan(
       now, initial_states, state_configs, requests, nullptr);
@@ -747,6 +752,7 @@ SCENARIO("Grid World")
               << (finish_time - start_time).count() / 1e9 << std::endl;
     display_solution("Greedy", greedy_assignments, greedy_cost);
 
+    task_planner = rmf_task::agv::TaskPlanner(task_config);
     start_time = std::chrono::steady_clock::now();
     const auto optimal_assignments = task_planner.optimal_plan(
       now, initial_states, state_configs, requests, nullptr);


### PR DESCRIPTION
Memoizes the computation of `variant_duration` and change in charge estimates between pairs of waypoints on the graph. Shortens run times for computing plans with the `TaskPlanner` by up to a couple of orders of magnitude, since it reduces the number of calls made to the `rmf_traffic::planner`, which formed the bulk of the run time previously.