### PR TITLE
few liners to populate start and estimated finish time

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -175,6 +175,12 @@ void TaskManager::set_queue(
       msg.task_profile.task_id = _queue.back()->id();
       msg.state = msg.STATE_QUEUED;
       msg.robot_name = _context->name();
+      msg.task_profile.task_type.type = 
+        msg.task_profile.task_type.TYPE_CLEAN;
+      msg.start_time = rmf_traffic_ros2::convert(
+        task->deployment_time());
+      msg.start_time = rmf_traffic_ros2::convert(
+        task->finish_state().finish_time());
       this->_context->node()->task_summary()->publish(msg);
     }
 
@@ -198,8 +204,13 @@ void TaskManager::set_queue(
       msg.task_profile.task_id = _queue.back()->id();
       msg.state = msg.STATE_QUEUED;
       msg.robot_name = _context->name();
+      msg.task_profile.task_type.type = 
+        msg.task_profile.task_type.TYPE_CHARGE_BATTERY;
+      msg.start_time = rmf_traffic_ros2::convert(
+        task->deployment_time());
+      msg.start_time = rmf_traffic_ros2::convert(
+        task->finish_state().finish_time());
       this->_context->node()->task_summary()->publish(msg);
-
     }
 
     else if (const auto request =
@@ -261,11 +272,8 @@ const std::vector<rmf_task::ConstRequestPtr> TaskManager::requests() const
     if (std::dynamic_pointer_cast<const rmf_task::requests::ChargeBattery>(
       task->request()))
       continue;
-
     requests.push_back(task->request());
-
   }
-  
   return requests;
 }
 
@@ -315,6 +323,10 @@ void TaskManager::_begin_next_task()
       msg.task_id = id;
       msg.task_profile.task_id = id;
       msg.robot_name = _context->name();
+      msg.start_time = rmf_traffic_ros2::convert(
+        _active_task->deployment_time());
+      msg.end_time = rmf_traffic_ros2::convert(
+        _active_task->finish_state().finish_time());
       _context->node()->task_summary()->publish(msg);
     },
           [this, id = _active_task->id()](std::exception_ptr e)
@@ -332,6 +344,10 @@ void TaskManager::_begin_next_task()
       msg.task_id = id;
       msg.task_profile.task_id = id;
       msg.robot_name = _context->name();
+      msg.start_time = rmf_traffic_ros2::convert(
+        _active_task->deployment_time());
+      msg.end_time = rmf_traffic_ros2::convert(
+        _active_task->finish_state().finish_time());
       _context->node()->task_summary()->publish(msg);
       // _begin_next_task();
     },
@@ -342,6 +358,10 @@ void TaskManager::_begin_next_task()
       msg.task_profile.task_id = id;
       msg.state = msg.STATE_COMPLETED;
       msg.robot_name = _context->name();
+      msg.start_time = rmf_traffic_ros2::convert(
+        _active_task->deployment_time());
+      msg.end_time = rmf_traffic_ros2::convert(
+        _active_task->finish_state().finish_time());
       this->_context->node()->task_summary()->publish(msg);
 
       _active_task = nullptr;


### PR DESCRIPTION
Populate start_time and estimated end_time in `task_summary` msg. Will soon need to address the issue of updating the estimated end_time when the task is delayed.