### PR TITLE
removing fcl as its not a rosdep key

### DIFF
--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -13,6 +13,8 @@
 
   <build_depend>libccd-dev</build_depend>
   <build_depend>libfcl-dev</build_depend>
+  <!-- Uncomment the line below for fcl-0.6 -->
+  <!-- <build_depend>fcl</build_depend> -->
 
   <test_depend>ament_cmake_catch2</test_depend>
   <test_depend>rmf_cmake_uncrustify</test_depend>

--- a/rmf_traffic/package.xml
+++ b/rmf_traffic/package.xml
@@ -13,7 +13,6 @@
 
   <build_depend>libccd-dev</build_depend>
   <build_depend>libfcl-dev</build_depend>
-  <build_depend>fcl</build_depend>
 
   <test_depend>ament_cmake_catch2</test_depend>
   <test_depend>rmf_cmake_uncrustify</test_depend>


### PR DESCRIPTION
`fcl` is currently not a rosdep key therefore it does not resolve to any package. I assume it's trying to install `libfcl0.5` but this is already a dependency on `libfcl-dev` so I would suggest leaving this out of the `package.xml` for now.

Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>