### PR TITLE
fix rmf_fleet_adapter cmake to be used by packages downstream

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -320,6 +320,7 @@ install(
   RUNTIME DESTINATION lib/rmf_fleet_adapter
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
+  INCLUDES DESTINATION include
 )
 
 # -----------------------------------------------------------------------------
@@ -333,5 +334,8 @@ install(
   DIRECTORY include/
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+ament_export_include_directories(include)
+ament_export_libraries(rmf_fleet_adapter)
 
 ament_package()


### PR DESCRIPTION
allows `rmf_fleet_adapter::rmf_fleet_adapter` to be used in cmake's `target_include_directories` and `target_link_libraries`