### PR TITLE
Address bug with task queue

### DIFF
--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -160,97 +160,103 @@ agv::ConstRobotContextPtr TaskManager::context() const
 void TaskManager::set_queue(
   const std::vector<TaskManager::Assignment>& assignments)
 {
-  std::lock_guard<std::mutex> guard(_mutex);
-  _queue.clear();
-
-  // We use dynamic cast to determine the type of request and then call the
-  // appropriate make(~) function to convert the request into a task
-  for (std::size_t i = 0; i < assignments.size(); ++i)
+  // We indent this block as _mutex is also locked in the _begin_next_task()
+  // function that is called at the end of this function.
   {
-    const auto& a = assignments[i];
-    auto start = _context->current_task_end_state().location();
-    if (i != 0)
-      start = assignments[i-1].state().location();
-    start.time(a.deployment_time());
-    rmf_task_msgs::msg::TaskType task_type_msg;
+    std::lock_guard<std::mutex> guard(_mutex);
+    _queue.clear();
 
-    if (const auto request =
-      std::dynamic_pointer_cast<const rmf_task::requests::Clean>(a.request()))
+    // We use dynamic cast to determine the type of request and then call the
+    // appropriate make(~) function to convert the request into a task
+    for (std::size_t i = 0; i < assignments.size(); ++i)
     {
-      task_type_msg.type = task_type_msg.TYPE_CLEAN;
-      auto task = rmf_fleet_adapter::tasks::make_clean(
-        request,
-        _context,
-        start,
-        a.deployment_time(),
-        a.state());
-      
-      _queue.push_back(task);
+      const auto& a = assignments[i];
+      auto start = _context->current_task_end_state().location();
+      if (i != 0)
+        start = assignments[i-1].state().location();
+      start.time(a.deployment_time());
+      rmf_task_msgs::msg::TaskType task_type_msg;
+
+      if (const auto request =
+        std::dynamic_pointer_cast<const rmf_task::requests::Clean>(a.request()))
+      {
+        task_type_msg.type = task_type_msg.TYPE_CLEAN;
+        auto task = rmf_fleet_adapter::tasks::make_clean(
+          request,
+          _context,
+          start,
+          a.deployment_time(),
+          a.state());
+        
+        _queue.push_back(task);
+      }
+
+      else if (const auto request =
+        std::dynamic_pointer_cast<const rmf_task::requests::ChargeBattery>(
+          a.request()))
+      {
+        task_type_msg.type = task_type_msg.TYPE_CHARGE_BATTERY;
+        const auto task = tasks::make_charge_battery(
+          request,
+          _context,
+          start,
+          a.deployment_time(),
+          a.state());
+
+        _queue.push_back(task);
+      }
+
+      else if (const auto request =
+        std::dynamic_pointer_cast<const rmf_task::requests::Delivery>(
+          a.request()))
+      {
+        task_type_msg.type = task_type_msg.TYPE_DELIVERY;
+        const auto task = tasks::make_delivery(
+          request,
+          _context,
+          start,
+          a.deployment_time(),
+          a.state());
+
+        _queue.push_back(task);
+      }
+
+      else if (const auto request =
+        std::dynamic_pointer_cast<const rmf_task::requests::Loop>(a.request()))
+      {
+        task_type_msg.type = task_type_msg.TYPE_LOOP;
+        const auto task = tasks::make_loop(
+          request,
+          _context,
+          start,
+          a.deployment_time(),
+          a.state());
+
+        _queue.push_back(task);
+      }
+
+      else
+      {
+        continue;
+      }
+
+      // publish queued task
+      rmf_task_msgs::msg::TaskSummary msg;
+      msg.task_id = _queue.back()->id();
+      msg.task_profile.task_id = _queue.back()->id();
+      msg.state = msg.STATE_QUEUED;
+      msg.robot_name = _context->name();
+      msg.fleet_name = _context->description().owner();
+      msg.task_profile.description.task_type = task_type_msg;
+      msg.start_time = rmf_traffic_ros2::convert(
+        _queue.back()->deployment_time());
+      msg.start_time = rmf_traffic_ros2::convert(
+        _queue.back()->finish_state().finish_time());
+      this->_context->node()->task_summary()->publish(msg);
     }
-
-    else if (const auto request =
-      std::dynamic_pointer_cast<const rmf_task::requests::ChargeBattery>(
-        a.request()))
-    {
-      task_type_msg.type = task_type_msg.TYPE_CHARGE_BATTERY;
-      const auto task = tasks::make_charge_battery(
-        request,
-        _context,
-        start,
-        a.deployment_time(),
-        a.state());
-
-      _queue.push_back(task);
-    }
-
-    else if (const auto request =
-      std::dynamic_pointer_cast<const rmf_task::requests::Delivery>(
-        a.request()))
-    {
-      task_type_msg.type = task_type_msg.TYPE_DELIVERY;
-      const auto task = tasks::make_delivery(
-        request,
-        _context,
-        start,
-        a.deployment_time(),
-        a.state());
-
-      _queue.push_back(task);
-    }
-
-    else if (const auto request =
-      std::dynamic_pointer_cast<const rmf_task::requests::Loop>(a.request()))
-    {
-      task_type_msg.type = task_type_msg.TYPE_LOOP;
-      const auto task = tasks::make_loop(
-        request,
-        _context,
-        start,
-        a.deployment_time(),
-        a.state());
-
-      _queue.push_back(task);
-    }
-
-    else
-    {
-      continue;
-    }
-
-    // publish queued task
-    rmf_task_msgs::msg::TaskSummary msg;
-    msg.task_id = _queue.back()->id();
-    msg.task_profile.task_id = _queue.back()->id();
-    msg.state = msg.STATE_QUEUED;
-    msg.robot_name = _context->name();
-    msg.fleet_name = _context->description().owner();
-    msg.task_profile.description.task_type = task_type_msg;
-    msg.start_time = rmf_traffic_ros2::convert(
-      _queue.back()->deployment_time());
-    msg.start_time = rmf_traffic_ros2::convert(
-      _queue.back()->finish_state().finish_time());
-    this->_context->node()->task_summary()->publish(msg);
   }
+
+  _begin_next_task();
 }
 
 //==============================================================================

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -502,7 +502,10 @@ const std::vector<std::string>& TaskManager::get_executed_tasks() const
 //==============================================================================
 void TaskManager::_register_executed_task(const std::string& id)
 {
-  if (_executed_task_registry.size() == 100)
+  // Currently the choice of storing 100 executed tasks is arbitrary.
+  // TODO: Save a time stamp for when tasks are completed and cull entries after
+  // a certain time window instead.
+  if (_executed_task_registry.size() >= 100)
     _executed_task_registry.erase(_executed_task_registry.begin());
   
   _executed_task_registry.push_back(id);

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -237,6 +237,13 @@ void TaskManager::set_queue(
 
       else
       {
+        RCLCPP_WARN(
+          _context->node()->get_logger(),
+          "[TaskManager] Un-supported request type in assignment list. "
+          "Please update the implementation of TaskManager::set_queue() to "
+          "support request with task_id:[%s]",
+          a.request()->id().c_str());
+
         continue;
       }
 
@@ -368,6 +375,7 @@ void TaskManager::_begin_next_task()
     });
 
     _active_task->begin();
+    _register_executed_task(_active_task->id());
   }
 }
 
@@ -484,5 +492,21 @@ void TaskManager::retreat_to_charger()
       _context->name().c_str());
   }
 }
+
+//==============================================================================
+const std::vector<std::string>& TaskManager::get_executed_tasks() const
+{
+  return _executed_task_registry;
+}
+
+//==============================================================================
+void TaskManager::_register_executed_task(const std::string& id)
+{
+  if (_executed_task_registry.size() == 100)
+    _executed_task_registry.erase(_executed_task_registry.begin());
+  
+  _executed_task_registry.push_back(id);
+}
+
 
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -73,6 +73,10 @@ public:
   /// when robot is idle and battery level drops below a retreat threshold.
   void retreat_to_charger();
 
+  /// Get the list of task ids for tasks that have started execution. 
+  /// The list will contain upto 100 latest task ids only.
+  const std::vector<std::string>& get_executed_tasks() const;  
+
 private:
 
   TaskManager(agv::RobotContextPtr context);
@@ -91,8 +95,17 @@ private:
   rclcpp::TimerBase::SharedPtr _task_timer;
   rclcpp::TimerBase::SharedPtr _retreat_timer;
 
+  // Container to keep track of tasks that have been started by this TaskManager
+  // Use the _register_executed_task() to populate this container.
+  std::vector<std::string> _executed_task_registry;
+
   /// Callback for task timer which begins next task if its deployment time has passed
   void _begin_next_task();
+
+  /// Function to register the task id of a task that has begun execution
+  /// The input task id will be inserted into the registry such that the max
+  /// size of the registry is 100.
+  void _register_executed_task(const std::string& id);
 };
 
 using TaskManagerPtr = std::shared_ptr<TaskManager>;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -560,8 +560,8 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
   bid_proposal_pub->publish(bid_proposal);
   RCLCPP_INFO(
     node->get_logger(),
-    "Submitted BidProposal to accommodate task [%s] with new cost [%f]",
-    id.c_str(), cost);
+    "Submitted BidProposal to accommodate task [%s] by robot [%s] with new cost [%f]",
+    id.c_str(), bid_proposal.robot_name.c_str(), cost);
 
   // Store assignments in internal map
   bid_notice_assignments.insert({id, assignments});

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -554,6 +554,7 @@ void FleetUpdateHandle::Implementation::dispatch_request_cb(
           RCLCPP_WARN(
             node->get_logger(),
             "Unable to replan assignments for task_id:[%s]", id.c_str());
+          return;
         }
         assignments = replan_results.value();
         // We re-check the assignments as a task could have started while replanning

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -430,7 +430,7 @@ void FleetUpdateHandle::Implementation::bid_notice_cb(
 
   const auto allocation_result = allocate_tasks(new_request);
 
-  if (!allocation_result)
+  if (!allocation_result.has_value())
     return;
   
   const auto& assignments = allocation_result.value();
@@ -548,6 +548,9 @@ void FleetUpdateHandle::Implementation::dispatch_request_cb(
         const auto request_it = generated_requests.find(id);
         if (request_it == generated_requests.end())
           return;
+        // TODO: This replanning is blocking the main thread. Instead, the
+        // replanning should run on a separate worker and then deliver the
+        // result back to the main worker.
         const auto replan_results = allocate_tasks(request_it->second);
         if (!replan_results)
         {
@@ -557,8 +560,9 @@ void FleetUpdateHandle::Implementation::dispatch_request_cb(
           return;
         }
         assignments = replan_results.value();
-        // We re-check the assignments as a task could have started while replanning
-        valid_assignments = is_valid_assignments(assignments);
+        // We do not need to re-check if assignments are valid as this function
+        // is being called by the ROS2 executor and is running on the main
+        // rxcpp worker. Hence, no new tasks would have started during this replanning.
       }
     }
 
@@ -579,11 +583,20 @@ void FleetUpdateHandle::Implementation::dispatch_request_cb(
 
   else if (msg->method == DispatchRequest::CANCEL)
   {
-    // TODO(YV)
+    RCLCPP_WARN(
+      node->get_logger(),
+      "Cancellation of a task has not been implemented yet. Ignoring "
+      "DispatchRequest for task_id:[%s].",
+      id.c_str());
   }
 
   else
   {
+    RCLCPP_WARN(
+      node->get_logger(),
+      "Received DispatchRequest for task_id:[%s] with invalid method. Only "
+      "ADD and CANCEL methods are supported. The request will be ignored.",
+      id.c_str());
     return;
   }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/FleetUpdateHandle.cpp
@@ -738,6 +738,12 @@ void FleetUpdateHandle::Implementation::publish_fleet_state() const
   fleet_state_pub->publish(std::move(fleet_state));
 }
 
+std::optional<Assignments> FleetUpdateHandle::Implementation:: allocate_tasks(
+  rmf_task::ConstRequestPtr request) const
+{
+  return std::nulllopt;
+}
+
 //==============================================================================
 void FleetUpdateHandle::add_robot(
     std::shared_ptr<RobotCommandHandle> command,

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -174,6 +174,7 @@ public:
   // Map to store task id with assignments for BidNotice
   std::unordered_map<std::string, Assignments> bid_notice_assignments = {};
 
+  std::unordered_map<std::string, rmf_task::ConstRequestPtr> generated_requests;
   AcceptTaskRequest accept_task = nullptr;
 
   using BidNotice = rmf_task_msgs::msg::BidNotice;
@@ -268,6 +269,8 @@ public:
 
   std::optional<Assignments> allocate_tasks(
     rmf_task::ConstRequestPtr request = nullptr) const;
+
+  bool is_valid_assignments(Assignments& assignments) const;
 
   static Implementation& get(FleetUpdateHandle& fleet)
   {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/internal_FleetUpdateHandle.hpp
@@ -47,6 +47,7 @@
 
 #include <iostream>
 #include <unordered_set>
+#include <optional>
 
 namespace rmf_fleet_adapter {
 namespace agv {
@@ -264,6 +265,9 @@ public:
   std::size_t get_nearest_charger(
     const rmf_traffic::agv::Planner::Start& start,
     const std::unordered_set<std::size_t>& charging_waypoints);
+
+  std::optional<Assignments> allocate_tasks(
+    rmf_task::ConstRequestPtr request = nullptr) const;
 
   static Implementation& get(FleetUpdateHandle& fleet)
   {


### PR DESCRIPTION
The current `TaskManager` implementation has a timer which periodically (every 1 second) calls `_begin_next_task()`. This function checks whether the `deployment time` for the front element of the task queue has passed and if so begins execution of the same (and then pops it from the queue).

However when a list of tasks with `start_time` of "now" is submitted, a potential race condition may arise:
Consider a fleet with two robots RobotA & RobotB.
A `BidProposal` for `TaskA` is received and is eventually queued in the `TaskManager` of `RobotA`. The task should technically begin execution but does not as the timer callback has not been called yet. (Still within 1s window)
A second `BidProposal` for `TaskB` is received. Here the task assignments will be replanned for a list comprising of the new task, `TaskB`, and any tasks still in the task queues for each robot in the fleet. So in this case the set of tasks `{TaskA, TaskB}` will be planned for. Assume the assignment returns such that `[{RobotB: {TaskB, TaskA}}, {RobotA:{}}]`, ie, RobotB is assigned to perform TaskB followed by TaskA and RobotA is not assigned any of the tasks. 
Now before the task queues of each robot are overwritten with the new assignments (ie, while waiting for the `DispatchResult` message from the Dispatcher node), the timer for RobotA executes (it has been 1s since "now") and so RobotA begins TaskA. (which has now technically been reassigned to RobotB). Then when the `DispatchResult` message arrives, the tasks queues are finally overwritten (too late). As a result `TaskA` will be performed twice: Once by `RobotA` right now, and again by `RobotB` after it finishes `TaskB`.

This PR introduces a stopgap fix for the problem described above.