### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,56 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+This form is strictly for reporting bugs.
+For technical help or general questions, please use the Discussions tab on https://github.com/osrf/rmf_core
+-->
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Workspace information:**
+ - Operating system and version:
+ - ROS distribution:
+ - ROS installation method: [from binary packages or from source]
+ - RMF installation method: [from binary packages or from source]
+ - RMF binaries version, if installed from binaries:
+ - RMF source versions, if installed from source:
+   - `rmf_demos` branch or commit hash: 
+   - `rmf_core` branch or commit hash: 
+   - `rmf_schedule_visualizaer` branch or commit hash: 
+   - `traffic_editor` branch or commit hash: 
+
+**Steps to Reproduce**
+
+1. 
+2. 
+3. ```
+
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A description of what actually happens.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,15 +2,6 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
-assignees: ''
-
----
-
----
-name: Bug report
-about: Create a report to help us improve
-title: ''
 labels: ''
 assignees: ''
 
@@ -37,7 +28,6 @@ A clear and concise description of what the bug is.
    - `traffic_editor` branch or commit hash: 
 
 **Steps to Reproduce**
-
 1. 
 2. 
 3. ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 <!--
 This form is strictly for reporting bugs.
-For technical help or general questions, please use the Discussions tab on https://github.com/osrf/rmf_core
+For technical help or general questions, please use the Discussions tab at https://github.com/osrf/rmf_core/discussions
 -->
 
 **Describe the bug**


### PR DESCRIPTION
Introducing a template to gather information when users report bugs. The form also directs users to ask general questions on `Discussions` instead. 