### PR TITLE
experimental argument for launching fleet adapter in gdb

### DIFF
--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -36,7 +36,9 @@
   <arg name="tool_power_drain" description="The power rating(W) of special tools (vaccuum, cleaning systems, etc.) of the vehicles in this fleet"/>
   <arg name="drain_battery" default="false" description="Whether battery drain should be considered while assigning tasks to vechiles in this fleet"/>
   <arg name="recharge_threshold" default="0.2" description="The fraction of total battery capacity below which the robot must return to its charger"/>
+  <arg name="launch_in_gdb_xterm" default="false" description="Should launch inside gdb in an xterm?"/>
 
+  <let name="launch-prefix" value="xterm -e gdb -ex run --args" if="$(var launch_in_gdb_xterm)"/>
 
   <node pkg="rmf_fleet_adapter"
         exec="$(var control_type)"


### PR DESCRIPTION
When debugging segfaults in the fleet adapters, it can be tricky to launch it inside `gdb` when inside deeply nested launch files with many arguments. This PR attempts to add an argument to the launch file which will pop up the fleet adapter in a new `xterm` inside `gdb`. It is not yet tested though, so it probably needs some iteration.

Signed-off-by: Morgan Quigley <morgan@osrfoundation.org>