### PR TITLE
Adding an experimental feature for confirming lift clearance before entering

### DIFF
--- a/rmf_fleet_adapter/CMakeLists.txt
+++ b/rmf_fleet_adapter/CMakeLists.txt
@@ -211,6 +211,23 @@ target_include_directories(lift_supervisor
     ${std_msgs_INCLUDE_DIRS}
 )
 
+# -----------------------------------------------------------------------------
+
+add_executable(experimental_lift_watchdog
+  src/experimental_lift_watchdog/main.cpp
+)
+
+target_link_libraries(experimental_lift_watchdog
+  PRIVATE
+    ${rclcpp_LIBRARIES}
+    ${rmf_fleet_msgs_LIBRARIES}
+)
+
+target_include_directories(experimental_lift_watchdog
+  PRIVATE
+    ${rclcpp_INCLUDE_DIRS}
+    ${rmf_fleet_msgs_INCLUDE_DIRS}
+)
 
 # -----------------------------------------------------------------------------
 
@@ -320,6 +337,7 @@ install(
     mock_traffic_light
     full_control
     lift_supervisor
+    experimental_lift_watchdog
     door_supervisor
     robot_state_aggregator
     test_read_only_adapter

--- a/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
+++ b/rmf_fleet_adapter/include/rmf_fleet_adapter/agv/RobotUpdateHandle.hpp
@@ -120,6 +120,28 @@ public:
     /// Get the schedule participant of this robot
     rmf_traffic::schedule::Participant* get_participant();
 
+    enum class Decision
+    {
+      Undefined = 0,
+      Clear = 1,
+      Crowded = 2
+    };
+
+    /// A callback with this signature will be given to the watchdog when the
+    /// robot is ready to enter a lift. If the watchdog passes in a true, then
+    /// the robot will proceed to enter the lift. If the watchdog passes in a
+    /// false, then the fleet adapter will release its session with the lift and
+    /// resume later.
+    using Decide = std::function<void(Decision)>;
+
+    using Watchdog = std::function<void(const std::string&, Decide)>;
+
+    /// Set a callback that can be used to check whether the robot is clear to
+    /// enter the lift.
+    void set_lift_entry_watchdog(
+      Watchdog watchdog,
+      rmf_traffic::Duration wait_duration = std::chrono::seconds(10));
+
   private:
     friend Implementation;
     Implementation* _pimpl;

--- a/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
+++ b/rmf_fleet_adapter/launch/fleet_adapter.launch.xml
@@ -36,6 +36,7 @@
   <arg name="tool_power_drain" description="The power rating(W) of special tools (vaccuum, cleaning systems, etc.) of the vehicles in this fleet"/>
   <arg name="drain_battery" default="false" description="Whether battery drain should be considered while assigning tasks to vechiles in this fleet"/>
   <arg name="recharge_threshold" default="0.2" description="The fraction of total battery capacity below which the robot must return to its charger"/>
+  <arg name="experimental_lift_watchdog_service" default="" description="(Experimental) The name of a service to check whether a robot can enter a lift"/>
 
 
   <node pkg="rmf_fleet_adapter"
@@ -76,6 +77,8 @@
     <param name="tool_power_drain" value="$(var tool_power_drain)"/>
     <param name="drain_battery" value="$(var drain_battery)"/>
     <param name="recharge_threshold" value="$(var recharge_threshold)"/> 
+
+    <param name="experimental_lift_watchdog_service" value="$(var experimental_lift_watchdog_service)"/>
 
     <param name="use_sim_time" value="$(var use_sim_time)"/>
   </node>

--- a/rmf_fleet_adapter/src/experimental_lift_watchdog/main.cpp
+++ b/rmf_fleet_adapter/src/experimental_lift_watchdog/main.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/executors.hpp>
+
+#include <rmf_fleet_msgs/srv/lift_clearance.hpp>
+#include <std_msgs/msg/bool.hpp>
+
+class ExperimentalLiftWatchdogNode : public rclcpp::Node
+{
+public:
+
+  using Service = rmf_fleet_msgs::srv::LiftClearance;
+  using Request = Service::Request;
+  using Response = Service::Response;
+
+  ExperimentalLiftWatchdogNode()
+    : rclcpp::Node("experimental_lift_watchdog")
+  {
+    service = create_service<rmf_fleet_msgs::srv::LiftClearance>(
+      "experimental_lift_watchdog",
+      [=](
+        const std::shared_ptr<rmw_request_id_t> header,
+        const std::shared_ptr<Request> request,
+        const std::shared_ptr<Response> response)
+    {
+      service_callback(header, request, response);
+    });
+
+    permission_subscription = create_subscription<std_msgs::msg::Bool>(
+      "experimental_lift_permission", rclcpp::SystemDefaultsQoS(),
+      [=](std::shared_ptr<std_msgs::msg::Bool> msg)
+    {
+      permission_callback(msg);
+    });
+  }
+
+  void service_callback(
+    const std::shared_ptr<rmw_request_id_t>& /*header*/,
+    const std::shared_ptr<Request>& request,
+    const std::shared_ptr<Response>& response)
+  {
+    if (permission)
+    {
+      response->decision =
+          rmf_fleet_msgs::srv::LiftClearance::Response::DECISION_CLEAR;
+
+      RCLCPP_INFO(
+        get_logger(),
+        "Robot [%s] is clear to enter lift [%s]",
+        request->robot_name.c_str(), request->lift_name.c_str());
+    }
+    else
+    {
+      response->decision =
+          rmf_fleet_msgs::srv::LiftClearance::Response::DECISION_CROWDED;
+
+      RCLCPP_INFO(
+        get_logger(),
+        "Robot [%s] cannot enter lift [%s]",
+        request->robot_name.c_str(), request->lift_name.c_str());
+    }
+  }
+
+  void permission_callback(
+    const std::shared_ptr<std_msgs::msg::Bool>& msg)
+  {
+    permission = msg->data;
+  }
+
+  rclcpp::Service<Service>::SharedPtr service;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr permission_subscription;
+  bool permission = true;
+
+};
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<ExperimentalLiftWatchdogNode>());
+  rclcpp::shutdown();
+}

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.cpp
@@ -261,6 +261,28 @@ RobotContext::task_planner() const
 }
 
 //==============================================================================
+void RobotContext::set_lift_entry_watchdog(
+    RobotUpdateHandle::Unstable::Watchdog watchdog,
+    rmf_traffic::Duration wait_duration)
+{
+  _lift_watchdog = std::move(watchdog);
+  _lift_rewait_duration = wait_duration;
+}
+
+//==============================================================================
+const RobotUpdateHandle::Unstable::Watchdog&
+RobotContext::get_lift_watchdog() const
+{
+  return _lift_watchdog;
+}
+
+//==============================================================================
+rmf_traffic::Duration RobotContext::get_lift_rewait_duration() const
+{
+  return _lift_rewait_duration;
+}
+
+//==============================================================================
 void RobotContext::respond(
     const TableViewerPtr& table_viewer,
     const ResponderPtr& responder)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -139,6 +139,13 @@ public:
   /// Get a mutable reference to the task planner for this robot
   const std::shared_ptr<const rmf_task::agv::TaskPlanner>& task_planner() const;
 
+  void set_lift_entry_watchdog(
+    RobotUpdateHandle::Unstable::Watchdog watchdog,
+    rmf_traffic::Duration wait_duration);
+
+  const RobotUpdateHandle::Unstable::Watchdog& get_lift_watchdog() const;
+
+  rmf_traffic::Duration get_lift_rewait_duration() const;
 
 private:
   friend class FleetUpdateHandle;
@@ -183,6 +190,9 @@ private:
   rmf_task::agv::State _current_task_end_state;
   rmf_task::agv::Constraints _task_planning_constraints;
   std::shared_ptr<const rmf_task::agv::TaskPlanner> _task_planner;
+
+  RobotUpdateHandle::Unstable::Watchdog _lift_watchdog;
+  rmf_traffic::Duration _lift_rewait_duration = std::chrono::seconds(0);
 };
 
 using RobotContextPtr = std::shared_ptr<RobotContext>;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotUpdateHandle.cpp
@@ -252,6 +252,20 @@ RobotUpdateHandle::Unstable::get_participant()
   return nullptr;
 }
 
+//==============================================================================
+void RobotUpdateHandle::Unstable::set_lift_entry_watchdog(
+  Watchdog watchdog,
+  rmf_traffic::Duration wait_duration)
+{
+  if (const auto context = _pimpl->get_context())
+  {
+    context->worker().schedule(
+      [context, watchdog = std::move(watchdog), wait_duration](const auto&)
+    {
+      context->set_lift_entry_watchdog(watchdog, wait_duration);
+    });
+  }
+}
 
 } // namespace agv
 } // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.cpp
@@ -188,14 +188,96 @@ Task::StatusMsg RequestLift::ActivePhase::_get_status(
   using rmf_lift_msgs::msg::LiftRequest;
   Task::StatusMsg status{};
   status.state = Task::StatusMsg::STATE_ACTIVE;
-  if (lift_state->lift_name == _lift_name &&
+  if (!_rewaiting &&
+      lift_state->lift_name == _lift_name &&
       lift_state->current_floor == _destination &&
       lift_state->door_state == LiftState::DOOR_OPEN &&
       lift_state->session_id == _context->requester_id())
   {
-    status.state = Task::StatusMsg::STATE_COMPLETED;
-    status.status = "success";
-    _timer.reset();
+    bool completed = false;
+    const auto& watchdog = _context->get_lift_watchdog();
+
+    if (_watchdog_info)
+    {
+      std::lock_guard<std::mutex> lock(_watchdog_info->mutex);
+      if (_watchdog_info->decision.has_value())
+      {
+        switch (*_watchdog_info->decision)
+        {
+          case agv::RobotUpdateHandle::Unstable::Decision::Clear:
+          {
+            completed = true;
+            break;
+          }
+          case agv::RobotUpdateHandle::Unstable::Decision::Undefined:
+          {
+            RCLCPP_ERROR(
+              _context->node()->get_logger(),
+              "Received undefined decision for lift watchdog of [%s]. "
+              "Defaulting to a Crowded decision.",
+              _context->name().c_str());
+            // Intentionally drop to the next case
+            [[fallthrough]];
+          }
+          case agv::RobotUpdateHandle::Unstable::Decision::Crowded:
+          {
+            _rewaiting = true;
+
+            _lift_end_phase = EndLiftSession::Active::make(
+              _context, _lift_name, _destination);
+            _reset_session_subscription = _lift_end_phase->observe()
+                .subscribe([](const auto&)
+            {
+              // Do nothing
+            });
+
+            _rewait_timer = _context->node()->create_wall_timer(
+              _context->get_lift_rewait_duration(),
+              [w = weak_from_this()]()
+            {
+              if (const auto& me = w.lock())
+              {
+                me->_rewaiting = false;
+                me->_rewait_timer.reset();
+                me->_reset_session_subscription =
+                    rmf_rxcpp::subscription_guard();
+              }
+            });
+            break;
+          }
+        }
+
+        _watchdog_info.reset();
+      }
+    }
+    else if (_located == Located::Outside && watchdog)
+    {
+      _watchdog_info = std::make_shared<WatchdogInfo>();
+      watchdog(
+        _lift_name,
+        [info = _watchdog_info](
+          agv::RobotUpdateHandle::Unstable::Decision decision)
+      {
+        std::lock_guard<std::mutex> lock(info->mutex);
+        info->decision = decision;
+      });
+    }
+    else
+    {
+      completed = true;
+    }
+
+    if (completed)
+    {
+      status.state = Task::StatusMsg::STATE_COMPLETED;
+      status.status = "success";
+      _timer.reset();
+    }
+  }
+  else if (_rewaiting)
+  {
+    status.status = "[" + _context->name() + "] is waiting for lift ["
+        + _lift_name + "] to clear out";
   }
   else if (lift_state->lift_name == _lift_name)
   {
@@ -214,6 +296,9 @@ Task::StatusMsg RequestLift::ActivePhase::_get_status(
 //==============================================================================
 void RequestLift::ActivePhase::_do_publish()
 {
+  if (_rewaiting)
+    return;
+
   rmf_lift_msgs::msg::LiftRequest msg{};
   msg.lift_name = _lift_name;
   msg.destination_floor = _destination;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/RequestLift.hpp
@@ -67,6 +67,17 @@ struct RequestLift
     rclcpp::TimerBase::SharedPtr _timer;
     std::shared_ptr<EndLiftSession::Active> _lift_end_phase;
     Located _located;
+    rmf_rxcpp::subscription_guard _reset_session_subscription;
+
+    struct WatchdogInfo
+    {
+      std::mutex mutex;
+      std::optional<agv::RobotUpdateHandle::Unstable::Decision> decision;
+    };
+
+    std::shared_ptr<WatchdogInfo> _watchdog_info;
+    rclcpp::TimerBase::SharedPtr _rewait_timer;
+    bool _rewaiting = false;
 
     ActivePhase(
       agv::RobotContextPtr context,

--- a/rmf_fleet_msgs/CMakeLists.txt
+++ b/rmf_fleet_msgs/CMakeLists.txt
@@ -31,6 +31,10 @@ set(msg_files
   "msg/DockSummary.msg"
 )
 
+set(srv_files
+  "srv/LiftClearance.srv"
+)
+
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}

--- a/rmf_fleet_msgs/srv/LiftClearance.srv
+++ b/rmf_fleet_msgs/srv/LiftClearance.srv
@@ -1,0 +1,12 @@
+
+# Name of the robot that wants to enter a lift
+string robot_name
+
+# Name of the lift that the robot wants to enter
+string lift_name
+
+---
+
+uint32 decision
+uint32 DECISION_CLEAR = 1
+uint32 DECISION_CROWDED = 2


### PR DESCRIPTION
This experimental feature provides an optional hook for an external "watchdog" to judge whether a lift is sufficiently clear before the robot enters.

If a lift is judged to be too crowded, the robot will end its lift session and then initiate a new session some number of seconds later (10 is the default, but this can be changed). This will repeat until the watchdog gives a confirmation that the lift is clear.

This is an experimental feature, meaning we do not officially support it and we make no guarantee that its API will remain available in future releases. Since the feature is experimental and does not impact any supported features or behaviors, I'll be merging it without review.