### PR TITLE
Alternative StubbornNegotiator that shares ownership of participant

### DIFF
--- a/rmf_traffic/include/rmf_traffic/schedule/StubbornNegotiator.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/StubbornNegotiator.hpp
@@ -45,6 +45,17 @@ public:
   ///   The Participant who wants to be stubborn.
   StubbornNegotiator(const Participant& participant);
 
+  /// Owning Constructor
+  ///
+  /// The StubbornNegotiator instance will now hold a shared reference to the
+  /// participant to ensure it maintains its lifetime. This constructor should
+  /// be used in cases where the StubbornNegotiator instance has a prolonged
+  /// lifecycle.
+  ///
+  /// \param[in] participant
+  ///   The Participant who wants to be stubborn.
+  StubbornNegotiator(std::shared_ptr<const Participant> participant);
+
   void respond(
       const schedule::Negotiation::Table::ViewerPtr& table_viewer,
       const ResponderPtr& responder) final;

--- a/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
+++ b/rmf_traffic/src/rmf_traffic/schedule/StubbornNegotiator.cpp
@@ -27,12 +27,23 @@ class StubbornNegotiator::Implementation
 public:
 
   const Participant* participant;
+  std::shared_ptr<const Participant> shared_ref;
 
 };
 
 //==============================================================================
 StubbornNegotiator::StubbornNegotiator(const Participant& participant)
-  : _pimpl(rmf_utils::make_impl<Implementation>(Implementation{&participant}))
+  : _pimpl(rmf_utils::make_impl<Implementation>(
+             Implementation{&participant, nullptr}))
+{
+  // Do nothing
+}
+
+//==============================================================================
+StubbornNegotiator::StubbornNegotiator(
+    std::shared_ptr<const Participant> participant)
+  : _pimpl(rmf_utils::make_impl<Implementation>(
+             Implementation{participant.get(), participant}))
 {
   // Do nothing
 }


### PR DESCRIPTION
The requirement that the `StubbornNegotiator` will always have a very short lifecycle may be too confusing and restrictive for some users, so this adds an alternative constructor that accepts a shared reference to the participant. This will help in situations where the `StubbornNegotiator` has a long lifecycle and needs to be tied to a participant which may move around between different owners.