### PR TITLE
Allow users to specify a minimum finishing time for planning

### DIFF
--- a/rmf_traffic/CHANGELOG.rst
+++ b/rmf_traffic/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog for package rmf_traffic
 1.3.0 (2021-XX-XX)
 ------------------
 * Add persistence to Traffic Schedule Participant IDs: [#242](https://github.com/osrf/rmf_core/pull/242)
+* Allow a minimum plan finish time to be specified: [#307](https://github.com/osrf/rmf_core/pull/307)
 
 1.2.0 (2021-01-05)
 ------------------

--- a/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
+++ b/rmf_traffic/include/rmf_traffic/agv/Planner.hpp
@@ -323,6 +323,23 @@ public:
     ///   The orientation that the AGV needs to end with.
     Goal(std::size_t goal_waypoint, double goal_orientation);
 
+    /// Constructor
+    ///
+    /// \param[in] goal_waypoint
+    ///   The waypoint that the AGV needs to reach.
+    ///
+    /// \param[in] minimum_time
+    ///   The AGV must be on the goal waypoint at or after this time for the
+    ///   plan to be successful. This is useful if a robot needs to wait at a
+    ///   location, but you want it to give way for other robots.
+    ///
+    /// \param[in] goal_orientation
+    ///   An optional goal orientation that the AGV needs to end with.
+    Goal(
+      std::size_t goal_waypoint,
+      std::optional<rmf_traffic::Time> minimum_time,
+      std::optional<double> goal_orientation = std::nullopt);
+
     /// Set the goal waypoint.
     Goal& waypoint(std::size_t goal_waypoint);
 
@@ -338,6 +355,14 @@ public:
     /// Get a reference to the goal orientation (or a nullptr if any orientation
     /// is acceptable).
     const double* orientation() const;
+
+    /// Set the minimum time for the goal. Pass in a nullopt to remove the
+    /// minimum time.
+    Goal& minimum_time(std::optional<rmf_traffic::Time> value);
+
+    /// Get the minimum time for the goal (or a nullopt is there is no minimum
+    /// time).
+    std::optional<rmf_traffic::Time> minimum_time() const;
 
     class Implementation;
   private:

--- a/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/Planner.cpp
@@ -365,8 +365,8 @@ class Planner::Goal::Implementation
 public:
 
   std::size_t waypoint;
-
-  rmf_utils::optional<double> orientation;
+  std::optional<double> orientation;
+  std::optional<rmf_traffic::Time> minimum_time;
 
 };
 
@@ -375,7 +375,8 @@ Planner::Goal::Goal(const std::size_t waypoint)
 : _pimpl(rmf_utils::make_impl<Implementation>(
       Implementation{
         waypoint,
-        rmf_utils::nullopt
+        std::nullopt,
+        std::nullopt
       }))
 {
   // Do nothing
@@ -386,10 +387,26 @@ Planner::Goal::Goal(
   const std::size_t waypoint,
   const double goal_orientation)
 : _pimpl(rmf_utils::make_impl<Implementation>(
-      Implementation{
-        waypoint,
-        goal_orientation
-      }))
+    Implementation{
+      waypoint,
+      goal_orientation,
+      std::nullopt
+    }))
+{
+  // Do nothing
+}
+
+//==============================================================================
+Planner::Goal::Goal(
+  const std::size_t goal_waypoint,
+  const std::optional<rmf_traffic::Time> minimum_time,
+  const std::optional<double> goal_orientation)
+: _pimpl(rmf_utils::make_impl<Implementation>(
+    Implementation{
+      goal_waypoint,
+      goal_orientation,
+      minimum_time
+    }))
 {
   // Do nothing
 }
@@ -428,6 +445,20 @@ const double* Planner::Goal::orientation() const
     return &(*_pimpl->orientation);
 
   return nullptr;
+}
+
+//==============================================================================
+auto Planner::Goal::minimum_time(std::optional<rmf_traffic::Time> value)
+-> Goal&
+{
+  _pimpl->minimum_time = value;
+  return *this;
+}
+
+//==============================================================================
+std::optional<rmf_traffic::Time> Planner::Goal::minimum_time() const
+{
+  return _pimpl->minimum_time;
 }
 
 //==============================================================================

--- a/rmf_traffic/test/unit/agv/planning/test_ShortestPathHeuristic.cpp
+++ b/rmf_traffic/test/unit/agv/planning/test_ShortestPathHeuristic.cpp
@@ -58,11 +58,6 @@ SCENARIO("Shortest Path Heuristic -- Single Floor")
           rmf_traffic::agv::planning::ShortestPathHeuristicFactory>(
             supergraph));
 
-  const Eigen::Vector2d p0 = graph.get_waypoint(0).get_location();
-  const Eigen::Vector2d p1 = graph.get_waypoint(1).get_location();
-  const Eigen::Vector2d p2 = graph.get_waypoint(2).get_location();
-  const Eigen::Vector2d p3 = graph.get_waypoint(3).get_location();
-
   using CacheOpt = std::optional<rmf_traffic::agv::planning::Cache<
     rmf_traffic::agv::planning::ShortestPathHeuristic>>;
   CacheOpt cache = cache_map.get(2)->get();
@@ -160,14 +155,6 @@ SCENARIO("Shortest Path Heuristic -- Easy Multifloor")
         std::make_shared<
           rmf_traffic::agv::planning::ShortestPathHeuristicFactory>(
             supergraph));
-
-  const Eigen::Vector2d p0 = graph.get_waypoint(0).get_location();
-  const Eigen::Vector2d p1 = graph.get_waypoint(1).get_location();
-  const Eigen::Vector2d p2 = graph.get_waypoint(2).get_location();
-  const Eigen::Vector2d p3 = graph.get_waypoint(3).get_location();
-  const Eigen::Vector2d p7 = graph.get_waypoint(7).get_location();
-  const Eigen::Vector2d p8 = graph.get_waypoint(8).get_location();
-  const Eigen::Vector2d p11 = graph.get_waypoint(11).get_location();
 
   const std::size_t goal = 8;
 
@@ -305,13 +292,6 @@ SCENARIO("Shortest Path Heuristic -- Complex Multifloor")
           rmf_traffic::agv::planning::ShortestPathHeuristicFactory>(
             supergraph));
 
-  const Eigen::Vector2d p0 = graph.get_waypoint(0).get_location();
-  const Eigen::Vector2d p1 = graph.get_waypoint(1).get_location();
-  const Eigen::Vector2d p2 = graph.get_waypoint(2).get_location();
-  const Eigen::Vector2d p3 = graph.get_waypoint(3).get_location();
-  const Eigen::Vector2d p12 = graph.get_waypoint(12).get_location();
-  const Eigen::Vector2d p14 = graph.get_waypoint(14).get_location();
-
   const std::size_t goal = 8;
 
   using CacheOpt = std::optional<rmf_traffic::agv::planning::Cache<
@@ -328,7 +308,7 @@ SCENARIO("Shortest Path Heuristic -- Complex Multifloor")
   REQUIRE(value.has_value());
   CHECK(value.value() == Approx(expected_cost(1)).margin(1e-12));
 
-  /*auto */value = cache->get(0);
+  value = cache->get(0);
   REQUIRE(value.has_value());
   CHECK(value.value() == Approx(expected_cost(1)).margin(1e-12));
 

--- a/rmf_traffic/test/unit/agv/test_Planner.cpp
+++ b/rmf_traffic/test/unit/agv/test_Planner.cpp
@@ -3059,7 +3059,7 @@ SCENARIO("Close start", "[close_start]")
   auto p1 = rmf_traffic::schedule::make_participant(
     rmf_traffic::schedule::ParticipantDescription{
       "participant 1",
-      "test_Negotiator",
+      "test_Planner",
       rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
       profile
     },
@@ -3068,7 +3068,7 @@ SCENARIO("Close start", "[close_start]")
   auto p2 = rmf_traffic::schedule::make_participant(
     rmf_traffic::schedule::ParticipantDescription{
       "participant 2",
-      "test_Negotiator",
+      "test_Planner",
       rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
       profile
     },
@@ -3152,4 +3152,151 @@ SCENARIO("Close start", "[close_start]")
   CHECK(visited_wps.count(3));
   CHECK(visited_wps.count(5));
   CHECK(visited_wps.count(4));
+}
+
+SCENARIO("Minimum time", "[minimum_time]")
+{
+
+  using namespace std::chrono_literals;
+
+  auto database = std::make_shared<rmf_traffic::schedule::Database>();
+
+  rmf_traffic::Profile profile{
+    rmf_traffic::geometry::make_final_convex<
+      rmf_traffic::geometry::Circle>(0.1),
+    rmf_traffic::geometry::make_final_convex<
+      rmf_traffic::geometry::Circle>(1.0)
+  };
+
+  auto p1 = rmf_traffic::schedule::make_participant(
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 1",
+      "test_Planner",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
+
+  auto p2 = rmf_traffic::schedule::make_participant(
+    rmf_traffic::schedule::ParticipantDescription{
+      "participant 2",
+      "test_Planner",
+      rmf_traffic::schedule::ParticipantDescription::Rx::Responsive,
+      profile
+    },
+    database);
+
+  const std::string test_map_name = "test_map";
+  rmf_traffic::agv::Graph graph;
+  graph.add_waypoint(test_map_name, { 0.0, -5.0}); // 0
+  graph.add_waypoint(test_map_name, {-5.0, 0.0}); // 1
+  graph.add_waypoint(test_map_name, { 0.0, 0.0}); // 2
+  graph.add_waypoint(test_map_name, { 5.0,  0.0}); // 3
+  graph.add_waypoint(test_map_name, { 0.0, 5.0}); // 4
+  graph.add_waypoint(test_map_name, { 5.0, 5.0}); // 5
+
+  /*
+   *         4-----5
+   *         |     |
+   *         |     |
+   *   1-----2-----3
+   *         |
+   *         |
+   *         0
+   */
+
+  auto add_bidir_lane = [&](const std::size_t w0, const std::size_t w1)
+    {
+      graph.add_lane(w0, w1);
+      graph.add_lane(w1, w0);
+    };
+
+  add_bidir_lane(0, 2);
+  add_bidir_lane(1, 2);
+  add_bidir_lane(3, 2);
+  add_bidir_lane(3, 5);
+  add_bidir_lane(4, 2);
+  add_bidir_lane(4, 5);
+
+  const rmf_traffic::agv::VehicleTraits traits{
+    {0.7, 0.3},
+    {1.0, 0.45},
+    profile
+  };
+
+  const auto time = std::chrono::steady_clock::now();
+  const auto duration = 1min;
+
+  rmf_traffic::Trajectory t_obs;
+  t_obs.insert(time, {0.0, 5.0, 0.0}, {0, 0, 0});
+  t_obs.insert(time + duration, {0.0, -5.0, 0.0}, {0, 0, 0});
+  p2.set({{test_map_name, t_obs}});
+
+  rmf_traffic::agv::Planner::Configuration configuration{graph, traits};
+  rmf_traffic::agv::Plan::Options options(nullptr);
+  rmf_traffic::agv::Plan::Start start(time, 2, 0.0);
+
+  const auto validator = rmf_traffic::agv::ScheduleRouteValidator::make(
+    database, p1.id(), p1.description().profile());
+
+  GIVEN("Start at the goal")
+  {
+    WHEN("No obstacle")
+    {
+      // Do nothing
+    }
+
+    WHEN("An obstacle")
+    {
+      options.validator(validator);
+    }
+  }
+
+  GIVEN("Start off the goal")
+  {
+    start.waypoint(1);
+
+    WHEN("No obstacle")
+    {
+      // Do nothing
+    }
+
+    WHEN("An obstacle")
+    {
+      options.validator(validator);
+    }
+  }
+
+  rmf_traffic::agv::Planner planner{configuration, options};
+
+  const auto result =
+      planner.plan(start, rmf_traffic::agv::Plan::Goal(2, time+duration));
+
+  REQUIRE(result);
+
+  std::unordered_set<std::size_t> visited;
+  for (const auto& wp : result->get_waypoints())
+  {
+    REQUIRE(wp.graph_index().has_value());
+    visited.insert(*wp.graph_index());
+  }
+
+  CHECK(visited.count(2) > 0);
+
+  if (options.validator())
+  {
+    if (start.waypoint() == 2)
+      CHECK(visited.size() == 2);
+    else
+      CHECK(visited.size() == 3);
+  }
+  else
+  {
+    if (start.waypoint() == 2)
+      CHECK(visited.size() == 1);
+    else
+      CHECK(visited.size() == 2);
+  }
+
+  CHECK(time + duration <= result->get_waypoints().back().time());
 }


### PR DESCRIPTION
This feature is useful for allowing the planner to have the robot remain on a single waypoint as much as possible but still move out of the way of other traffic when needed.