### PR TITLE
Introducing ResponsiveWait task phase

### DIFF
--- a/rmf_fleet_adapter/CHANGELOG.rst
+++ b/rmf_fleet_adapter/CHANGELOG.rst
@@ -10,6 +10,10 @@ Changelog for package rmf_fleet_adapter
     * The `rmf_fleet_adapter::agv` component interacts with a dispatcher node over topics with `rmf_task` prefix as specified in `rmf_fleet_adapter/StandardNames.hpp`
     * Support for executing tasks at specified timepoints
     * Support for `Loop`, `Delivery`, `Clean` and `ChargeBattery` tasks
+* Introduce ResponsiveWait: [#308](https://github.com/osrf/rmf_core/pull/308)
+    * The new ResponsiveWait task phase can be used to have idle/waiting robots respond to schedule conflicts
+    * Idle robots (robots that do not have an assigned task) will automatically enter ResponsiveWait mode
+
 
 1.2.0 (2021-01-05)
 ------------------

--- a/rmf_fleet_adapter/src/full_control/main.cpp
+++ b/rmf_fleet_adapter/src/full_control/main.cpp
@@ -238,6 +238,23 @@ public:
   void update_state(const rmf_fleet_msgs::msg::RobotState& state)
   {
     auto lock = _lock();
+
+    // Update battery soc
+    const double battery_soc = state.battery_percent / 100.0;
+    if (battery_soc >= 0.0 && battery_soc <= 1.0)
+    {
+      _travel_info.updater->update_battery_soc(battery_soc);
+    }
+    else
+    {
+      RCLCPP_ERROR(
+        _node->get_logger(),
+        "Battery percentage reported by the robot is outside of the valid "
+        "range [0,100] and hence the battery soc will not be updated. It is "
+        "critical to update the battery soc with a valid battery percentage "
+        "for task allocation planning.");
+    }
+
     if (_travel_info.path_finished_callback)
     {
       // If we have a path_finished_callback, then the robot should be
@@ -353,18 +370,6 @@ public:
       // command
       estimate_state(_node, state.location, _travel_info);
     }
-
-    // Update battery soc
-    const double battery_soc = state.battery_percent / 100.0;
-    if (battery_soc >= 0.0 && battery_soc <= 1.0)
-      _travel_info.updater->update_battery_soc(battery_soc);
-    else
-      RCLCPP_ERROR(
-        _node->get_logger(),
-        "Battery percentage reported by the robot is outside of the valid "
-        "range [0,100] and hence the battery soc will not be updated. It is "
-        "critical to update the battery soc with a valid battery percentage "
-        "for task allocation planning.");
   }
 
   void set_updater(rmf_fleet_adapter::agv::RobotUpdateHandlePtr updater)

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -431,6 +431,14 @@ void TaskManager::_begin_waiting()
         msg.end_time = rmf_traffic_ros2::convert(
           _active_task->finish_state().finish_time());
         _context->node()->task_summary()->publish(msg);
+
+        RCLCPP_WARN(
+          _context->node()->get_logger(),
+          "Robot [%s] encountered an error while doing a ResponsiveWait: %s",
+          _context->requester_id().c_str(), msg.status.c_str());
+
+        // Go back to waiting if an error has occurred
+        _begin_waiting();
       },
       [this]()
       {

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -287,13 +287,8 @@ const std::vector<rmf_task::ConstRequestPtr> TaskManager::requests() const
 //==============================================================================
 void TaskManager::_begin_next_task()
 {
-  std::cout << " >> " << _context->requester_id() << " Beginning next task for "  << std::endl;
   if (_active_task)
-  {
-    std::cout << " >> " << _context->requester_id() << " Already have task: " << _active_task->current_phase()->description()
-              << std::endl;
     return;
-  }
 
   std::lock_guard<std::mutex> guard(_mutex);
 
@@ -302,19 +297,14 @@ void TaskManager::_begin_next_task()
     if (!_waiting)
       _begin_waiting();
 
-    std::cout << " >> " << _context->requester_id() << " queue empty" << std::endl;
     return;
   }
 
   if (_waiting)
   {
-    std::cout << " >> !! Canceling wait for " << _context->requester_id() << std::endl;
     _waiting->cancel();
     return;
   }
-
-  std::cout << " >> Beginning new task from queue of " << _queue.size()
-            << ": " << _queue.front()->id() << std::endl;
 
   const rmf_traffic::Time now = rmf_traffic_ros2::convert(
     _context->node()->now());
@@ -385,7 +375,6 @@ void TaskManager::_begin_next_task()
         _active_task->finish_state().finish_time());
       this->_context->node()->task_summary()->publish(msg);
 
-      std::cout << " >> " << _context->requester_id() << " finished task " << id << std::endl;
       _active_task = nullptr;
     });
 
@@ -394,10 +383,6 @@ void TaskManager::_begin_next_task()
   }
   else
   {
-    std::cout << " >> Not deployment time yet ("
-              << rmf_traffic::time::to_seconds(deployment_time - now) << ")"
-              << std::endl;
-
     if (!_waiting)
       _begin_waiting();
   }
@@ -449,7 +434,6 @@ void TaskManager::_begin_waiting()
       },
       [this]()
       {
-        std::cout << " >> Discarding waiting phase for " << _context->requester_id() << std::endl;
         _waiting = nullptr;
         _begin_next_task();
       });

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.cpp
@@ -133,10 +133,10 @@ auto TaskManager::expected_finish_state() const -> State
   auto location = finish_state.location();
   location.time(rmf_traffic_ros2::convert(_context->node()->now()));
   finish_state.location(location);
-  
+
   const double current_battery_soc = _context->current_battery_soc();
   finish_state.battery_soc(current_battery_soc);
-  
+
   return finish_state;
 }
 
@@ -162,7 +162,6 @@ agv::ConstRobotContextPtr TaskManager::context() const
 void TaskManager::set_queue(
   const std::vector<TaskManager::Assignment>& assignments)
 {
-  std::cout << " == Setting queue for " << _context->requester_id() << std::endl;
   // We indent this block as _mutex is also locked in the _begin_next_task()
   // function that is called at the end of this function.
   {
@@ -175,7 +174,6 @@ void TaskManager::set_queue(
     {
       const auto& a = assignments[i];
       auto start = _context->current_task_end_state().location();
-      std::cout << " == " << i << ") start time: " << rmf_traffic::time::to_seconds(start.time().time_since_epoch()) << std::endl;
       if (i != 0)
         start = assignments[i-1].state().location();
       start.time(a.deployment_time());
@@ -191,7 +189,7 @@ void TaskManager::set_queue(
           start,
           a.deployment_time(),
           a.state());
-        
+
         _queue.push_back(task);
       }
 

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/TaskManager.hpp
@@ -88,6 +88,11 @@ private:
   rxcpp::subscription _task_sub;
   rxcpp::subscription _emergency_sub;
 
+  /// This phase will kick in automatically when no task is being executed. It
+  /// will ensure that the agent continues to respond to traffic negotiations so
+  /// it does not become a blocker for other traffic participants.
+  std::shared_ptr<Task::ActivePhase> _waiting;
+
   // TODO: Eliminate the need for a mutex by redesigning the use of the task
   // manager so that modifications of shared data only happen on designated
   // rxcpp worker
@@ -101,6 +106,9 @@ private:
 
   /// Callback for task timer which begins next task if its deployment time has passed
   void _begin_next_task();
+
+  /// Begin responsively waiting for the next task
+  void _begin_waiting();
 
   /// Function to register the task id of a task that has begun execution
   /// The input task id will be inserted into the registry such that the max

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/RobotContext.hpp
@@ -184,7 +184,7 @@ private:
   rmf_traffic::schedule::Negotiator* _negotiator = nullptr;
 
   /// Always call the current_battery_soc() setter to set a new value
-  double _current_battery_soc;
+  double _current_battery_soc = 1.0;
   rxcpp::subjects::subject<double> _battery_soc_publisher;
   rxcpp::observable<double> _battery_soc_obs;
   rmf_task::agv::State _current_task_end_state;

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/GoToPlace.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/GoToPlace.hpp
@@ -56,7 +56,7 @@ public:
     void cancel() final;
 
     // Documentation inherited from ActivePhase
-    const std::string & description() const final;
+    const std::string& description() const final;
 
     // Documentation inherited from Negotiator
     void respond(

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.cpp
@@ -85,7 +85,6 @@ ResponsiveWait::Active::Active(PhaseInfo info)
 //==============================================================================
 void ResponsiveWait::Active::_begin_movement()
 {
-  std::cout << "Reseting wait for " << _info.context->requester_id() << std::endl;
   const rmf_traffic::Time now = _info.context->now();
   rmf_traffic::agv::Plan::Start start_estimate(now, _info.waiting_point, 0.0);
   rmf_traffic::agv::Plan::Goal goal(_info.waiting_point);
@@ -113,42 +112,34 @@ void ResponsiveWait::Active::_begin_movement()
     .subscribe(
       [w = weak_from_this()](const StatusMsg& msg)
       {
-        std::cout << " !! STATUS UPDATE FROM GoToPlace !! " << std::endl;
         const auto me = w.lock();
         if (!me)
           return;
 
-        std::cout << "Update from GoToPlace of " << me->_info.context->requester_id() << std::endl;
         me->_status_publisher.get_subscriber().on_next(msg);
       },
       [w = weak_from_this()](std::exception_ptr e)
       {
-        std::cout << " !! ERROR FROM GoToPlace !! " << std::endl;
         const auto me = w.lock();
         if (!me)
           return;
 
-        std::cout << "Error from GoToPlace of " << me->_info.context->requester_id() << std::endl;
         me->_status_publisher.get_subscriber().on_error(std::move(e));
       },
       [w = weak_from_this()]()
       {
-        std::cout << " !! FINISHED GoToPlace !!" << std::endl;
         const auto me = w.lock();
         if (!me)
           return;
 
-        std::cout << "Finished GoToPlace of " << me->_info.context->requester_id() << std::endl;
         if (me->_info.period.has_value())
         {
-          std::cout << " -- We have a period" << std::endl;
           // If this is an uncanceled indefinite wait, then we will begin the
           // movement again.
           me->_begin_movement();
           return;
         }
 
-        std::cout << " -- No period??" << std::endl;
         me->_status_publisher.get_subscriber().on_completed();
       });
 }

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.cpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include "ResponsiveWait.hpp"
+
+#include <rmf_traffic_ros2/Time.hpp>
+
+namespace rmf_fleet_adapter {
+namespace phases {
+
+//==============================================================================
+auto ResponsiveWait::Active::observe() const
+-> const rxcpp::observable<StatusMsg>&
+{
+  return _status_obs;
+}
+
+//==============================================================================
+rmf_traffic::Duration ResponsiveWait::Active::estimate_remaining_time() const
+{
+  if (_info.finish_time.has_value())
+  {
+    const auto now = rmf_traffic_ros2::convert(_info.context->node()->now());
+    const auto remaining = *_info.finish_time - now;
+    if (remaining.count() > 0)
+      return remaining;
+  }
+
+  return std::chrono::seconds(0);
+}
+
+//==============================================================================
+void ResponsiveWait::Active::emergency_alarm(bool on)
+{
+  if (!_movement)
+  {
+    throw std::runtime_error(
+      "[rmf_fleet_adapter::phases::ResponsiveWait::Active::emergency_alarm] "
+      "_movement field is null. This is a critical bug in rmf_fleet_adapter. "
+      "Please report this to the maintainers.");
+  }
+
+  _movement->emergency_alarm(on);
+}
+
+//==============================================================================
+void ResponsiveWait::Active::cancel()
+{
+  // We reset the period to ensure that the phase ends the next time GoToPlace
+  // issues that it is finished.
+  _info.period.reset();
+
+  // Now we cancel the movement and wait for the underlying GoToPlace phase to
+  // report that it is finished.
+  _movement->cancel();
+}
+
+//==============================================================================
+const std::string& ResponsiveWait::Active::description() const
+{
+  return _info.description;
+}
+
+//==============================================================================
+ResponsiveWait::Active::Active(PhaseInfo info)
+: _info(std::move(info))
+{
+  _status_obs = _status_publisher.get_observable();
+}
+
+//==============================================================================
+void ResponsiveWait::Active::_begin_movement()
+{
+  std::cout << "Reseting wait for " << _info.context->requester_id() << std::endl;
+  const rmf_traffic::Time now = _info.context->now();
+  rmf_traffic::agv::Plan::Start start_estimate(now, _info.waiting_point, 0.0);
+  rmf_traffic::agv::Plan::Goal goal(_info.waiting_point);
+  if (_info.finish_time.has_value())
+  {
+    goal.minimum_time(*_info.finish_time);
+  }
+  else if (_info.period.has_value())
+  {
+    goal.minimum_time(now + *_info.period);
+  }
+  else
+  {
+    throw std::runtime_error(
+      "[rmf_fleet_adapter::phases::ResponsiveWait::Active::constructor] "
+      "PhaseInfo is missing both finish_time and period. This is a critical "
+      "bug in rmf_fleet_adapter. Please report it to the maintainers.");
+  }
+
+  _movement = GoToPlace::make(_info.context, start_estimate, goal)->begin();
+
+  _movement_subscription =
+    _movement->observe()
+    .observe_on(rxcpp::identity_same_worker(_info.context->worker()))
+    .subscribe(
+      [w = weak_from_this()](const StatusMsg& msg)
+      {
+        std::cout << " !! STATUS UPDATE FROM GoToPlace !! " << std::endl;
+        const auto me = w.lock();
+        if (!me)
+          return;
+
+        std::cout << "Update from GoToPlace of " << me->_info.context->requester_id() << std::endl;
+        me->_status_publisher.get_subscriber().on_next(msg);
+      },
+      [w = weak_from_this()](std::exception_ptr e)
+      {
+        std::cout << " !! ERROR FROM GoToPlace !! " << std::endl;
+        const auto me = w.lock();
+        if (!me)
+          return;
+
+        std::cout << "Error from GoToPlace of " << me->_info.context->requester_id() << std::endl;
+        me->_status_publisher.get_subscriber().on_error(std::move(e));
+      },
+      [w = weak_from_this()]()
+      {
+        std::cout << " !! FINISHED GoToPlace !!" << std::endl;
+        const auto me = w.lock();
+        if (!me)
+          return;
+
+        std::cout << "Finished GoToPlace of " << me->_info.context->requester_id() << std::endl;
+        if (me->_info.period.has_value())
+        {
+          std::cout << " -- We have a period" << std::endl;
+          // If this is an uncanceled indefinite wait, then we will begin the
+          // movement again.
+          me->_begin_movement();
+          return;
+        }
+
+        std::cout << " -- No period??" << std::endl;
+        me->_status_publisher.get_subscriber().on_completed();
+      });
+}
+
+//==============================================================================
+std::shared_ptr<Task::ActivePhase> ResponsiveWait::Pending::begin()
+{
+  auto active = std::shared_ptr<Active>(new Active(_info));
+  active->_begin_movement();
+
+  return active;
+}
+
+//==============================================================================
+rmf_traffic::Duration ResponsiveWait::Pending::estimate_phase_duration() const
+{
+  return std::chrono::seconds(0);
+}
+
+//==============================================================================
+const std::string& ResponsiveWait::Pending::description() const
+{
+  return _info.description;
+}
+
+//==============================================================================
+ResponsiveWait::Pending::Pending(PhaseInfo info)
+: _info(std::move(info))
+{
+  // Do nothing
+}
+
+//==============================================================================
+auto ResponsiveWait::make_until(
+  agv::RobotContextPtr context,
+  std::size_t waiting_point,
+  rmf_traffic::Time finish_time) -> std::unique_ptr<Pending>
+{
+  PhaseInfo info{
+    std::move(context),
+    waiting_point,
+    finish_time,
+    std::nullopt,
+    ""
+  };
+
+  info.description = "[" + info.context->requester_id() + "] waiting at ["
+      + std::to_string(info.waiting_point) + "]";
+
+  return std::unique_ptr<Pending>(new Pending(std::move(info)));
+}
+
+//==============================================================================
+auto ResponsiveWait::make_indefinite(
+  agv::RobotContextPtr context,
+  std::size_t waiting_point,
+  rmf_traffic::Duration update_period) -> std::unique_ptr<Pending>
+{
+  PhaseInfo info{
+    std::move(context),
+    waiting_point,
+    std::nullopt,
+    update_period,
+    ""
+  };
+
+  info.description = "[" + info.context->requester_id() + "] waiting at ["
+      + std::to_string(info.waiting_point) + "]";
+
+  return std::unique_ptr<Pending>(new Pending(std::move(info)));
+}
+
+} // namespace phases
+} // namespace rmf_fleet_adapter

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.hpp
@@ -136,7 +136,7 @@ public:
   static std::unique_ptr<Pending> make_indefinite(
     agv::RobotContextPtr context,
     std::size_t waiting_point,
-    rmf_traffic::Duration update_period = std::chrono::seconds(10));
+    rmf_traffic::Duration update_period = std::chrono::seconds(30));
 };
 
 } // namespace phases

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.hpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#ifndef SRC__RMF_FLEET_ADAPTER__PHASES__RESPONSIVEWAIT_HPP
+#define SRC__RMF_FLEET_ADAPTER__PHASES__RESPONSIVEWAIT_HPP
+
+#include "GoToPlace.hpp"
+
+namespace rmf_fleet_adapter {
+namespace phases {
+
+//==============================================================================
+class ResponsiveWait
+{
+private:
+  struct PhaseInfo
+  {
+    agv::RobotContextPtr context;
+    std::size_t waiting_point;
+    std::optional<rmf_traffic::Time> finish_time;
+    std::optional<rmf_traffic::Duration> period;
+    std::string description;
+  };
+
+public:
+
+  using StatusMsg = Task::StatusMsg;
+  class Pending;
+
+  class Active
+      : public Task::ActivePhase,
+        public std::enable_shared_from_this<Active>
+  {
+  public:
+
+    // Documentation inherited
+    const rxcpp::observable<StatusMsg>& observe() const final;
+
+    // Documentation inherited
+    rmf_traffic::Duration estimate_remaining_time() const final;
+
+    // Documentation inherited
+    void emergency_alarm(bool on) final;
+
+    // Documentation inherited
+    void cancel() final;
+
+    // Documentation inherited
+    const std::string& description() const final;
+
+  private:
+    friend class Pending;
+    Active(PhaseInfo info);
+
+    void _begin_movement();
+
+    PhaseInfo _info;
+    rxcpp::observable<StatusMsg> _status_obs;
+    rxcpp::subjects::subject<StatusMsg> _status_publisher;
+    rmf_rxcpp::subscription_guard _movement_subscription;
+    std::shared_ptr<Task::ActivePhase> _movement;
+  };
+
+  class Pending : public Task::PendingPhase
+  {
+  public:
+
+    // Documentation inherited
+    std::shared_ptr<Task::ActivePhase> begin() final;
+
+    // Documentation inherited
+    rmf_traffic::Duration estimate_phase_duration() const final;
+
+    // Documentation inherited
+    const std::string& description() const final;
+
+  private:
+    friend class ResponsiveWait;
+    Pending(PhaseInfo info);
+    PhaseInfo _info;
+  };
+
+  /// Make an ActiveWait phase that has an explicit deadline. When the ROS time
+  /// reaches or passes finish_time (and the robot is on its goal waypoint),
+  /// the phase will successfully finish.
+  ///
+  /// \param[in] context
+  ///   The context of the robot that needs to wait
+  ///
+  /// \param[in] waiting_point
+  ///   The graph waypoint index that the robot should wait on
+  ///
+  /// \param[in] finish_time
+  ///   The time that the robot can stop waiting
+  static std::unique_ptr<Pending> make_until(
+    agv::RobotContextPtr context,
+    std::size_t waiting_point,
+    rmf_traffic::Time finish_time);
+
+  /// Make an ActiveWait phase that has no deadline. The phase will continue
+  /// until someone explicitly calls cancel() on it.
+  ///
+  /// To avoid slamming the schedule with an unreasonably long waiting
+  /// prediction, the phase will only schedule a wait for the duration of
+  /// the update_period parameter. When that period has passed, the phase will
+  /// restart its scheduling for another duration equal to update_period.
+  ///
+  /// The value of update_period may have a noticeable impact on how other
+  /// traffic participants schedule around or through this robot. A small
+  /// update_period might make other participants more likely to try to schedule
+  /// their paths through this robot. A longer update_period might make that
+  /// less likely.
+  ///
+  /// \param[in] context
+  ///   The context of the robot that needs to wait
+  ///
+  /// \param[in] waiting_point
+  ///   The graph waypoint index that the robot should wait on
+  ///
+  /// \param[in] update_period
+  ///   The scheduling period for the waiting
+  static std::unique_ptr<Pending> make_indefinite(
+    agv::RobotContextPtr context,
+    std::size_t waiting_point,
+    rmf_traffic::Duration update_period = std::chrono::seconds(10));
+};
+
+} // namespace phases
+} // namespace rmf_fleet_adapter
+
+#endif // SRC__RMF_FLEET_ADAPTER__PHASES__RESPONSIVEWAIT_HPP

--- a/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.hpp
+++ b/rmf_fleet_adapter/src/rmf_fleet_adapter/phases/ResponsiveWait.hpp
@@ -94,7 +94,7 @@ public:
     PhaseInfo _info;
   };
 
-  /// Make an ActiveWait phase that has an explicit deadline. When the ROS time
+  /// Make a ResponsiveWait phase that has an explicit deadline. When the ROS time
   /// reaches or passes finish_time (and the robot is on its goal waypoint),
   /// the phase will successfully finish.
   ///

--- a/rmf_traffic/CHANGELOG.rst
+++ b/rmf_traffic/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog for package rmf_traffic
 ------------------
 * Add persistence to Traffic Schedule Participant IDs: [#242](https://github.com/osrf/rmf_core/pull/242)
 * Allow a minimum plan finish time to be specified: [#307](https://github.com/osrf/rmf_core/pull/307)
+* Check itinerary endpoints when negotiating: [#308](https://github.com/osrf/rmf_core/pull/308)
 
 1.2.0 (2021-01-05)
 ------------------

--- a/rmf_traffic/include/rmf_traffic/schedule/Negotiation.hpp
+++ b/rmf_traffic/include/rmf_traffic/schedule/Negotiation.hpp
@@ -158,6 +158,38 @@ public:
           const Query::Spacetime& parameters,
           const VersionedKeySequence& alternatives) const;
 
+      /// View the first or last (depending on context) waypoint in a
+      /// negotiation participant's itinerary or alternative.
+      class Endpoint
+      {
+      public:
+
+        /// The ID of the participant
+        ParticipantId participant() const;
+
+        /// The first or last (depending on context) waypoint
+        const rmf_traffic::Trajectory::Waypoint& waypoint() const;
+
+        /// The map that the endpoint is on
+        const std::string& map() const;
+
+        /// The description of the participant
+        const ParticipantDescription& description() const;
+
+        class Implementation;
+      private:
+        Endpoint();
+        rmf_utils::impl_ptr<Implementation> _pimpl;
+      };
+
+      /// Get the set of initial waypoints for the negotiation participants.
+      std::unordered_map<ParticipantId, Endpoint> initial_endpoints(
+        const VersionedKeySequence& alternatives) const;
+
+      /// Get the set of final waypoints for the negotiation participants.
+      std::unordered_map<ParticipantId, Endpoint> final_endpoints(
+        const VersionedKeySequence& alterantives) const;
+
       using AlternativeMap =
         std::unordered_map<ParticipantId, std::shared_ptr<Alternatives>>;
 

--- a/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
@@ -408,71 +408,75 @@ NegotiatingRouteValidator::find_conflict(const Route& route) const
     }
   }
 
-  const auto initial_endpoints = _pimpl->data->viewer->initial_endpoints(
-    _pimpl->rollouts);
-
-  const auto& initial_wp = route.trajectory().front();
-  for (const auto& other : initial_endpoints)
   {
-    if (route.map() != other.second.map())
-      continue;
+    const auto initial_endpoints = _pimpl->data->viewer->initial_endpoints(
+      _pimpl->rollouts);
 
-    const auto& other_wp = other.second.waypoint();
-    if (other_wp.time() <= initial_wp.time())
-      continue;
-
-    Trajectory other_start;
-    other_start.insert(
-      initial_wp.time() - 1s,
-      other_wp.position(),
-      Eigen::Vector3d::Zero());
-
-    other_start.insert(
-      other_wp.time(),
-      other_wp.position(),
-      Eigen::Vector3d::Zero());
-
-    if (const auto time = rmf_traffic::DetectConflict::between(
-          _pimpl->data->profile,
-          route.trajectory(),
-          other.second.description().profile(),
-          other_start))
+    const auto& initial_wp = route.trajectory().front();
+    for (const auto& other : initial_endpoints)
     {
-      return Conflict{other.first, *time};
+      if (route.map() != other.second.map())
+        continue;
+
+      const auto& other_wp = other.second.waypoint();
+      if (other_wp.time() <= initial_wp.time())
+        continue;
+
+      Trajectory other_start;
+      other_start.insert(
+        initial_wp.time() - 1s,
+        other_wp.position(),
+        Eigen::Vector3d::Zero());
+
+      other_start.insert(
+        other_wp.time(),
+        other_wp.position(),
+        Eigen::Vector3d::Zero());
+
+      if (const auto time = rmf_traffic::DetectConflict::between(
+            _pimpl->data->profile,
+            route.trajectory(),
+            other.second.description().profile(),
+            other_start))
+      {
+        return Conflict{other.first, *time};
+      }
     }
   }
 
-  const auto final_endpoints = _pimpl->data->viewer->final_endpoints(
-    _pimpl->rollouts);
-
-  const auto& final_wp = route.trajectory().back();
-  for (const auto& other : initial_endpoints)
   {
-    if (route.map() != other.second.map())
-      continue;
+    const auto final_endpoints = _pimpl->data->viewer->final_endpoints(
+      _pimpl->rollouts);
 
-    const auto& other_wp = other.second.waypoint();
-    if (final_wp.time() <= other_wp.time())
-      continue;
-
-    Trajectory other_finish;
-    other_finish.insert(
-      other_wp.time(),
-      other_wp.position(),
-      Eigen::Vector3d::Zero());
-
-    other_finish.insert(
-      final_wp.time() + 1s,
-      other_wp.position(),
-      Eigen::Vector3d::Zero());
-
-    if (const auto time = rmf_traffic::DetectConflict::between(
-          _pimpl->data->profile,
-          route.trajectory(),
-          other.second.description().profile(),
-          other_finish))
+    const auto& final_wp = route.trajectory().back();
+    for (const auto& other : final_endpoints)
     {
-      return Conflict{other.first, *time};
+      if (route.map() != other.second.map())
+        continue;
+
+      const auto& other_wp = other.second.waypoint();
+      if (final_wp.time() <= other_wp.time())
+        continue;
+
+      Trajectory other_finish;
+      other_finish.insert(
+        other_wp.time(),
+        other_wp.position(),
+        Eigen::Vector3d::Zero());
+
+      other_finish.insert(
+        final_wp.time() + 1s,
+        other_wp.position(),
+        Eigen::Vector3d::Zero());
+
+      if (const auto time = rmf_traffic::DetectConflict::between(
+            _pimpl->data->profile,
+            route.trajectory(),
+            other.second.description().profile(),
+            other_finish))
+      {
+        return Conflict{other.first, *time};
+      }
     }
   }
 

--- a/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
+++ b/rmf_traffic/src/rmf_traffic/agv/RouteValidator.cpp
@@ -93,6 +93,30 @@ schedule::ParticipantId ScheduleRouteValidator::participant() const
   return _pimpl->participant;
 }
 
+namespace {
+//==============================================================================
+/// The end_cap trajectory represents the last known position of the other
+/// participant's trajectory. This prevents the negotiator from using a
+/// pathological strategy like waiting until the other participant vanishes.
+Trajectory make_endcap(
+  const Route& my_route,
+  const Trajectory::Waypoint& other_end_wp)
+{
+  Trajectory end_cap;
+  end_cap.insert(
+    other_end_wp.time(),
+    other_end_wp.position(),
+    Eigen::Vector3d::Zero());
+
+  end_cap.insert(
+    *my_route.trajectory().finish_time() + std::chrono::seconds(10),
+    other_end_wp.position(),
+    Eigen::Vector3d::Zero());
+
+  return end_cap;
+}
+} // anonymous namespace
+
 //==============================================================================
 rmf_utils::optional<RouteValidator::Conflict>
 ScheduleRouteValidator::find_conflict(const Route& route) const
@@ -385,10 +409,18 @@ NegotiatingRouteValidator::find_conflict(const Route& route) const
   spacetime.query_timespan()
       .all_maps(false)
       .add_map(route.map())
-      .set_lower_time_bound(*route.trajectory().start_time())
-      .set_upper_time_bound(*route.trajectory().finish_time());
+//      .set_lower_time_bound(*route.trajectory().start_time())
+//      .set_upper_time_bound(*route.trajectory().finish_time());
+      .remove_lower_time_bound()
+      .remove_upper_time_bound();
 
   const auto view = _pimpl->data->viewer->query(spacetime, _pimpl->rollouts);
+
+  std::unordered_map<ParticipantId, const rmf_traffic::Trajectory::Waypoint*>
+      all_last_wp;
+
+  std::unordered_map<ParticipantId, const rmf_traffic::Trajectory::Waypoint*>
+      all_first_wp;
 
   for (const auto& v : view)
   {
@@ -405,51 +437,47 @@ NegotiatingRouteValidator::find_conflict(const Route& route) const
     {
       return Conflict{v.participant, *time};
     }
+
+    const auto last_wp_it = all_last_wp.insert({v.participant, nullptr}).first;
+    const auto& check_last = v.route.trajectory().back();
+    if (!last_wp_it->second)
+    {
+      last_wp_it->second = &check_last;
+    }
+    else if (last_wp_it->second->time() < check_last.time())
+    {
+      last_wp_it->second = &check_last;
+    }
+
+//    const auto first_wp_it = all_first_wp.insert({v.participant, nullptr}).first;
+//    const auto& check_first = v.route.trajectory().front();
+//    if (!first_wp_it->second)
+//    {
+//      first_wp_it->second = &check_first;
+//    }
+//    else if (check_first.time() < first_wp_it->second->time())
+//    {
+//      first_wp_it->second = &check_first;
+//    }
   }
 
-  for (const auto& r : _pimpl->rollouts)
+  for (const auto& last_wp : all_last_wp)
   {
-    if (_pimpl->masked && (*_pimpl->masked == r.participant))
+    if (*route.trajectory().finish_time() < last_wp.second->time())
       continue;
 
-    const auto& last_route =
-        _pimpl->data->viewer->alternatives()
-        .at(r.participant)
-        ->at(r.version).back();
-
-    if (route.map() != last_route->map())
-      continue;
-
-    const auto& last_wp = last_route->trajectory().back();
-
-    if (*route.trajectory().finish_time() < last_wp.time())
-      continue;
-
+    const auto participant = last_wp.first;
     const auto& description =
-        _pimpl->data->viewer->get_description(r.participant);
-    assert(description);
+        _pimpl->data->viewer->get_description(participant);
 
-    // The end_cap trajectory represents the last known position of the
-    // rollout's alternative. This prevents the negotiator from using a
-    // pathological strategy like waiting until the other participant vanishes.
-    Trajectory end_cap;
-    end_cap.insert(
-          last_wp.time(),
-          last_wp.position(),
-          Eigen::Vector3d::Zero());
-
-    end_cap.insert(
-          *route.trajectory().finish_time() + std::chrono::seconds(10),
-          last_wp.position(),
-          Eigen::Vector3d::Zero());
-
+    // Project the other participant
     if (const auto time = rmf_traffic::DetectConflict::between(
           _pimpl->data->profile,
           route.trajectory(),
           description->profile(),
-          end_cap))
+          make_endcap(route, *last_wp.second)))
     {
-      return Conflict{r.participant, *time};
+      return Conflict{participant, *time};
     }
   }
 


### PR DESCRIPTION
This PR introduces the `ResponsiveWait` task phase. This task phase can be used any time a robot needs to wait somewhere that it might interfere with the traffic of other schedule participants.

While running the `ResponsiveWait` phase, a robot will try to sit on the designated waypoint, but will automatically move out of the way of other traffic and will participate in traffic negotiations.

In this PR, we also have any idle robots automatically engage in a `ResponsiveWait` phase, which will automatically be canceled when they are assigned a new task.

Note that this change means that if two robots are both idle on locations where they have overlap in their footprints/vicinities, then they will likely enter an endless cycle of negotiating with each other. That problem will be addressed when the parking spot reservation system is completed. In the meantime, users are advised to avoid situations where robots are idle on locations where they conflict with each other.